### PR TITLE
[WIP] hash-tree (trie)

### DIFF
--- a/src/crypto/CryptoHash.ts
+++ b/src/crypto/CryptoHash.ts
@@ -1,0 +1,53 @@
+import { u8aToHex } from '@polkadot/util'
+import { keccakAsU8a } from '@polkadot/util-crypto'
+
+const object = {
+  claim: {
+    name: 'Timo',
+    age: 31,
+  },
+  legitimations: [
+    {
+      claim: {
+        isCompany: true,
+      },
+      attestation: {
+        attester: '0x12324214a',
+        signature: '0x324234234',
+      },
+    },
+  ],
+}
+
+const hash = hashBranch(object)
+console.log(u8aToHex(hash))
+
+function hashBranch(obj: any): Uint8Array {
+  let result = new Uint8Array([])
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      let val = obj[key]
+      let intermediate = new Uint8Array([])
+
+      if (typeof val === 'object') {
+        intermediate = hashBranch(val)
+      } else {
+        // const hashedKey = keccakAsU8a(key)
+        if (typeof val !== 'string') {
+          val = val.toString()
+        }
+        // const hashedVal = keccakAsU8a(val)
+        // intermediate = new Uint8Array(hashedKey.length + hashedVal.length)
+        // intermediate.set(hashedKey)
+        // intermediate.set(hashedVal, hashedKey.length)
+        intermediate = keccakAsU8a(`${key}:${val}`)
+      }
+      const old = result
+      result = new Uint8Array(old.length + intermediate.length)
+      result.set(old)
+      result.set(intermediate, old.length)
+      result = keccakAsU8a(result)
+    }
+  }
+  return result
+}


### PR DESCRIPTION
I created a first draft, on how we could do our claim hashing.
To run it, first execute
```
npx tsc src/crypto/CryptoHash.ts
```
and then
```
node src/crypto/CryptoHash.js
```

It is reasonably fast with 10ms, but I also tried the `trie-hash` algorithm, which can be a bit faster with 8ms

trie-hash:
```
elapsed_time('start trieRoot')
const claimTrie = trieRoot([
  { k: stringToU8a('name'), v: stringToU8a('Timo') },
  { k: stringToU8a('age'), v: stringToU8a('30') },
])
const legitimationsTrie = trieRoot([
  { k: stringToU8a('isCompany'), v: stringToU8a('true') },
  { k: stringToU8a('attester'), v: stringToU8a('0x12324214a') },
  { k: stringToU8a('signature'), v: stringToU8a('0x324234234') },
])
const resultTrieRoot = trieRoot([
  { k: stringToU8a('claim'), v: claimTrie },
  { k: stringToU8a('legitimations'), v: legitimationsTrie },
])
elapsed_time('start trieRoot')
console.log(u8aToHex(resultTrieRoot))
```

Please note: the place of the file and the filename is not well thought-out. We might want to change that.
Also I am not sure how to call this algorithm. It is definetly not a Trie, but it could be described as a normal (Hash-)Tree, I guess.
