### PR TITLE
feat: proposal for new sdk api

### DIFF
--- a/src/new-api-proposal/Attestation.ts
+++ b/src/new-api-proposal/Attestation.ts
@@ -1,0 +1,132 @@
+import { SubmittableExtrinsic } from '@polkadot/api'
+import { CodecResult, SubscriptionResult } from '@polkadot/api/promise/types'
+import { Option, Text } from '@polkadot/types'
+import { Codec } from '@polkadot/types/types'
+import { Identity } from 'src'
+import { IDelegationBaseNode } from 'src/delegation/Delegation'
+import { IPublicIdentity } from 'src/identity/PublicIdentity'
+import { IRequestForAttestation } from 'src/requestforattestation/RequestForAttestation'
+import { factory } from '../config/ConfigLog'
+import { BlockchainApi } from './BlockchainApi'
+import { BlockchainApiConnection } from './BlockchainApiConnection'
+import { TxStatus } from './TxStatus'
+
+const log = factory.getLogger('Attestation')
+
+interface IAttestation {
+  claimHash: string
+  cTypeHash: string
+  owner: IPublicIdentity['address']
+  delegationId?: IDelegationBaseNode['id']
+  revoked: boolean
+
+  store(identity: Identity): Promise<TxStatus>
+  revoke(identity: Identity): Promise<TxStatus>
+  verify(): Promise<boolean>
+}
+
+class Attestation implements IAttestation {
+  public static decode(
+    encoded: Codec | null | undefined,
+    claimHash: string
+  ): IAttestation[] {
+    const json = encoded && encoded.encodedLength ? encoded.toJSON() : null
+    return json
+      .map((attestationTuple: any) => {
+        return {
+          claimHash,
+          cTypeHash: attestationTuple[0],
+          owner: attestationTuple[1],
+          delegationId: attestationTuple[2],
+          revoked: attestationTuple[3],
+        } as IAttestation
+      })
+      .map((iAttestation: IAttestation) => {
+        const newAttestation: Attestation = Object.create(Attestation.prototype)
+        return Object.assign(newAttestation, iAttestation)
+      })
+      .find((e: any) => true)
+  }
+
+  public claimHash: string
+  public cTypeHash: string
+  public owner: IPublicIdentity['address']
+  public delegationId?: IDelegationBaseNode['id']
+  public revoked: boolean
+
+  constructor(
+    requestForAttestation: IRequestForAttestation,
+    attester: Identity,
+    revoked: boolean = false
+  ) {
+    this.owner = attester.address
+    this.claimHash = requestForAttestation.hash
+    this.cTypeHash = requestForAttestation.claim.cType
+    this.revoked = revoked
+  }
+
+  public async store(identity: Identity): Promise<TxStatus> {
+    const txParams = {
+      claimHash: this.claimHash,
+      ctypeHash: this.cTypeHash,
+      delegationId: new Option(Text, this.delegationId),
+    }
+    log.debug(() => `Create tx for 'attestation.add'`)
+    const blockchain: BlockchainApi = await BlockchainApiConnection.get()
+    // @ts-ignore
+    const tx: SubmittableExtrinsic<
+      CodecResult,
+      SubscriptionResult
+    > = blockchain.api.tx.attestation.add(
+      txParams.claimHash,
+      txParams.ctypeHash,
+      txParams.delegationId
+    )
+    return blockchain.submitTx(identity, tx)
+  }
+
+  public async revoke(identity: Identity): Promise<TxStatus> {
+    const blockchain: BlockchainApi = await BlockchainApiConnection.get()
+    log.debug(() => `Revoking attestations with claim hash ${this.claimHash}`)
+    const tx: SubmittableExtrinsic<
+      CodecResult,
+      SubscriptionResult
+    > = blockchain.api.tx.attestation.revoke(this.claimHash)
+    return blockchain.submitTx(identity, tx)
+  }
+
+  public async verify(): Promise<boolean> {
+    const blockchain: BlockchainApi = await BlockchainApiConnection.get()
+    const result:
+      | Codec
+      | null
+      | undefined = await blockchain.api.query.attestation.attestations(
+      this.claimHash
+    )
+    const attestations: IAttestation[] = Attestation.decode(
+      result,
+      this.claimHash
+    )
+
+    const verifiedAttestation = attestations.find(
+      (attestation: IAttestation) => {
+        let delegationIdMatches: boolean = true
+        if (this.delegationId) {
+          delegationIdMatches = this.delegationId === attestation.delegationId
+        }
+        return (
+          attestation.owner === this.owner &&
+          !attestation.revoked &&
+          delegationIdMatches
+        )
+      }
+    )
+    const attestationValid: boolean = verifiedAttestation !== undefined
+    if (!attestationValid) {
+      log.debug(() => 'No valid attestation found')
+    }
+    return Promise.resolve(attestationValid)
+  }
+}
+
+export { Attestation, IAttestation }

--- a/src/new-api-proposal/AttestationModule.ts
+++ b/src/new-api-proposal/AttestationModule.ts
@@ -1,0 +1,58 @@
+import { Codec } from '@polkadot/types/types'
+import { Identity, PublicIdentity } from 'src'
+import { IDelegationBaseNode } from 'src/delegation/Delegation'
+import { IRequestForAttestation } from 'src/requestforattestation/RequestForAttestation'
+import { factory } from '../config/ConfigLog'
+import { Attestation, IAttestation } from './Attestation'
+import { TxStatus } from './TxStatus'
+import { IBlockchainApi } from './BlockchainApi'
+
+const log = factory.getLogger('Attestation')
+
+export class AttestationModule {
+  constructor(private blockchain: IBlockchainApi) {}
+
+  public create(
+    requestForAttestation: IRequestForAttestation,
+    attester: Identity,
+    revoked: boolean = false
+  ): IAttestation {
+    return new Attestation(requestForAttestation, attester)
+  }
+
+  public async query(claimHash: string): Promise<IAttestation[]> {
+    const result:
+      | Codec
+      | null
+      | undefined = await this.blockchain.api.query.attestation.attestations(
+      claimHash
+    )
+    return Attestation.decode(result, claimHash)
+  }
+
+  /**
+   * Checks if there is a non-revoked attestation for `claimHash` attested by `attester` on chain.
+   */
+  public async verify(
+    claimHash: string,
+    attester: PublicIdentity['address']
+  ): Promise<boolean> {
+    const attestations: IAttestation[] = await this.query(claimHash)
+    const verifiedAttestation = attestations.find(
+      (attestation: Attestation) => {
+        return attestation.owner === attester && !attestation.revoked
+      }
+    )
+    const attestationValid: boolean = verifiedAttestation !== undefined
+    if (!attestationValid) {
+      log.debug(() => 'No valid attestation found')
+    }
+    return Promise.resolve(attestationValid)
+  }
+
+  public async revokeAll(
+    delegationId: IDelegationBaseNode['id']
+  ): Promise<TxStatus> {
+    return Promise.resolve({} as TxStatus)
+  }
+}

--- a/src/new-api-proposal/BalanceModule.ts
+++ b/src/new-api-proposal/BalanceModule.ts
@@ -1,0 +1,54 @@
+import { Identity } from 'src'
+import { IPublicIdentity } from 'src/identity/PublicIdentity'
+import { TxStatus } from './TxStatus'
+import { IBlockchainApi } from './BlockchainApi'
+import BN from 'bn.js'
+
+export class BalanceModule {
+  constructor(private blockchain: IBlockchainApi) {}
+
+  public async getBalance(
+    accountAddress: IPublicIdentity['address']
+  ): Promise<number> {
+    // @ts-ignore
+    const balance: BN = await this.blockchain.api.query.balances.freeBalance(
+      accountAddress
+    )
+    return balance.toNumber()
+  }
+
+  public async listenToBalanceChanges(
+    accountAddress: string,
+    listener?: (account: string, balance: number, change: number) => void
+  ) {
+    // @ts-ignore
+    let previous: BN = await this.blockchain.api.query.balances.freeBalance(
+      accountAddress
+    )
+
+    if (listener) {
+      await this.blockchain.api.query.balances.freeBalance(
+        accountAddress,
+        // @ts-ignore
+        (current: BN) => {
+          const change = current.sub(previous)
+          previous = current
+          listener(accountAddress, current.toNumber(), change.toNumber())
+        }
+      )
+    }
+    return previous
+  }
+
+  public async makeTransfer(
+    identity: Identity,
+    accountAddressTo: string,
+    amount: number
+  ): Promise<TxStatus> {
+    const transfer = await this.blockchain.api.tx.balances.transfer(
+      accountAddressTo,
+      amount
+    )
+    return await this.blockchain.submitTx(identity, transfer)
+  }
+}

--- a/src/new-api-proposal/BlockchainApi.ts
+++ b/src/new-api-proposal/BlockchainApi.ts
@@ -1,0 +1,60 @@
+import {
+  ApiPromise,
+  SubmittableExtrinsic,
+  SubmittableResult,
+} from '@polkadot/api'
+import { CodecResult, SubscriptionResult } from '@polkadot/api/promise/types'
+import { Identity } from 'src'
+import { factory } from '../config/ConfigLog'
+import { TxStatus } from './TxStatus'
+
+const log = factory.getLogger('BlockchainApi')
+
+export interface IBlockchainApi {
+  api: ApiPromise
+
+  submitTx(
+    identity: Identity,
+    tx: SubmittableExtrinsic<CodecResult, SubscriptionResult>
+  ): Promise<TxStatus>
+}
+
+export class BlockchainApi implements IBlockchainApi {
+  constructor(public api: ApiPromise) {}
+
+  public async submitTx(
+    identity: Identity,
+    tx: SubmittableExtrinsic<CodecResult, SubscriptionResult>
+  ): Promise<TxStatus> {
+    const accountAddress = identity.address
+    const nonce = await this.api.query.system.accountNonce(accountAddress)
+    if (!nonce) {
+      throw Error(`Nonce not found for account ${accountAddress}`)
+    }
+    const signed: SubmittableExtrinsic<
+      CodecResult,
+      SubscriptionResult
+    > = identity.signSubmittableExtrinsic(tx, nonce.toHex())
+    log.info(`Submitting ${tx.method}`)
+    return new Promise<TxStatus>((resolve, reject) => {
+      signed
+        .send((result: SubmittableResult) => {
+          log.info(`Got tx status '${result.status.type}'`)
+          const status = result.status
+          if (
+            status.type === 'Finalised' &&
+            status.value &&
+            status.value.encodedLength > 0
+          ) {
+            log.info(() => `Transaction complete. Status: '${status.type}'`)
+            resolve(new TxStatus(status.type))
+          } else if (status.type === 'Invalid' || status.type === 'Dropped') {
+            reject(new TxStatus(status.type))
+          }
+        })
+        .catch(err => {
+          log.error(err)
+        })
+    })
+  }
+}

--- a/src/new-api-proposal/BlockchainApiConnection.ts
+++ b/src/new-api-proposal/BlockchainApiConnection.ts
@@ -1,0 +1,38 @@
+import { ApiPromise, WsProvider } from '@polkadot/api'
+import { BlockchainApi, IBlockchainApi } from './BlockchainApi'
+
+export class BlockchainApiConnection {
+  public static DEFAULT_WS_ADDRESS = 'ws://127.0.0.1:9944'
+
+  public static instance: Promise<IBlockchainApi>
+
+  public static async get(
+    host: string = this.getNodeWebsocketUrl()
+  ): Promise<IBlockchainApi> {
+    if (!BlockchainApiConnection.instance) {
+      BlockchainApiConnection.instance = BlockchainApiConnection.buildConnection(
+        host
+      )
+    }
+    return BlockchainApiConnection.instance
+  }
+
+  private static async buildConnection(
+    host: string = BlockchainApiConnection.DEFAULT_WS_ADDRESS
+  ): Promise<IBlockchainApi> {
+    const provider = new WsProvider(host)
+    const api: ApiPromise = await ApiPromise.create({
+      provider,
+      types: {
+        DelegationNodeId: 'Hash',
+      },
+    })
+    return new BlockchainApi(api)
+  }
+
+  private static getNodeWebsocketUrl() {
+    return `//${process.env.REACT_APP_NODE_HOST}:${
+      process.env.REACT_APP_NODE_WS_PORT
+    }`
+  }
+}

--- a/src/new-api-proposal/CType.ts
+++ b/src/new-api-proposal/CType.ts
@@ -1,0 +1,124 @@
+import { Codec } from '@polkadot/types/types'
+import { Identity } from 'src'
+import Crypto from 'src/crypto'
+import { CtypeMetadata, CTypeSchema } from 'src/ctype/CType'
+import { CTypeInputModel, CTypeWrapperModel } from 'src/ctype/CTypeSchema'
+import * as CTypeUtils from 'src/ctype/CTypeUtils'
+import { BlockchainApiConnection } from './BlockchainApiConnection'
+import { TxStatus } from './TxStatus'
+import { IBlockchainApi } from './BlockchainApi'
+
+interface ICType {
+  hash?: string
+  schema: CTypeSchema
+  metadata: CtypeMetadata
+
+  verifyClaimStructure(claim: any): boolean
+  getClaimInputModel(lang?: string): any
+  getCTypeInputModel(): any
+
+  store(identity: Identity): Promise<TxStatus>
+  verifyStored(): Promise<boolean>
+}
+
+class CType implements ICType {
+  public hash?: string
+  public schema: CTypeSchema
+  public metadata: CtypeMetadata
+
+  constructor(schema: CTypeSchema, metadata: CtypeMetadata, hash?: string) {
+    this.schema = schema
+    this.metadata = metadata
+
+    this.hash = Crypto.hashStr(JSON.stringify(this.schema))
+
+    if (hash && this.hash !== hash) {
+      throw Error('provided and generated cType hash are not the same')
+    }
+
+    if (!CTypeUtils.verifySchema(this, CTypeWrapperModel)) {
+      throw new Error('CType does not correspond to schema')
+    }
+  }
+
+  public verifyClaimStructure(claim: any): boolean {
+    return CTypeUtils.verifySchema(claim, this.schema)
+  }
+
+  /**
+   * This method creates an input model for a claim from a CTYPE.
+   * It selects translations for a specific language from the localized part of the CTYPE meta data.
+   * @param {string} lang the language to choose translations for
+   * @returns {any} The claim input model
+   */
+  public getClaimInputModel(lang?: string): any {
+    // create clone
+    const result = JSON.parse(JSON.stringify(this.schema))
+    result.title = this.getLocalized(this.metadata.title, lang)
+    result.description = this.getLocalized(this.metadata.description, lang)
+    result.required = []
+    for (const x in this.metadata.properties) {
+      if (this.metadata.properties.hasOwnProperty(x)) {
+        result.properties[x].title = this.getLocalized(
+          this.metadata.properties[x].title,
+          lang
+        )
+        result.required.push(x)
+      }
+    }
+    return result
+  }
+
+  /**
+   * Create the CTYPE input model for a CTYPE editing component form the CTYPE model.
+   * This is necessary because component editors rely on editing arrays of properties instead of
+   * arbitrary properties of an object. Additionally the default language translations are integrated
+   * into the input model. This is the reverse function of CType.fromInputModel(...).
+   * @returns The CTYPE input model.
+   */
+  public getCTypeInputModel(): any {
+    // create clone
+    const result = JSON.parse(JSON.stringify(this.schema))
+    result.$schema = CTypeInputModel.$id
+    result.title = this.getLocalized(this.metadata.title)
+    result.description = this.getLocalized(this.metadata.description)
+    result.required = []
+    result.properties = []
+    for (const x in this.schema.properties) {
+      if (this.schema.properties.hasOwnProperty(x)) {
+        const p = this.schema.properties[x]
+        result.properties.push({
+          title: this.getLocalized(this.metadata.properties[x].title),
+          $id: x,
+          type: p.type,
+        })
+        result.required.push(x)
+      }
+    }
+    return result
+  }
+
+  public async store(identity: Identity): Promise<TxStatus> {
+    const blockchain: IBlockchainApi = await BlockchainApiConnection.get()
+    const tx: any = await blockchain.api.tx.ctype.add(this.hash)
+    return await blockchain.submitTx(identity, tx)
+  }
+
+  public async verifyStored(): Promise<boolean> {
+    const blockchain: IBlockchainApi = await BlockchainApiConnection.get()
+    const encoded:
+      | Codec
+      | null
+      | undefined = await blockchain.api.query.ctype.cTYPEs(this.hash)
+    return (encoded && encoded.encodedLength > 0) || false
+  }
+
+  private getLocalized(o: any, lang?: string): any {
+    if (lang == null || !o[lang]) {
+      return o.default
+    }
+    return o[lang]
+  }
+}
+
+export { ICType, CType }

--- a/src/new-api-proposal/CTypeModule.ts
+++ b/src/new-api-proposal/CTypeModule.ts
@@ -1,0 +1,59 @@
+import { Codec } from '@polkadot/types/types'
+import { CtypeMetadata, CTypeSchema } from 'src/ctype/CType'
+import { CTypeInputModel, CTypeModel } from 'src/ctype/CTypeSchema'
+import * as CTypeUtils from 'src/ctype/CTypeUtils'
+import { CType, ICType } from './CType'
+import { IBlockchainApi } from './BlockchainApi'
+
+export class CTypeModule {
+  constructor(private blockchain: IBlockchainApi) {}
+
+  public create(
+    schema: CTypeSchema,
+    metadata: CtypeMetadata,
+    hash?: ICType['hash']
+  ): ICType {
+    return new CType(schema, metadata, hash)
+  }
+
+  public createFromInputModel(cTypeInput: any): ICType {
+    if (!CTypeUtils.verifySchema(cTypeInput, CTypeInputModel)) {
+      throw new Error('CType input does not correspond to input model schema')
+    }
+    const schema: CTypeSchema = {
+      $id: cTypeInput.$id,
+      $schema: CTypeModel.properties.$schema.default,
+      properties: {},
+      type: 'object',
+    }
+    const metadata: CtypeMetadata = {
+      title: {
+        default: cTypeInput.title,
+      },
+      description: {
+        default: cTypeInput.description,
+      },
+      properties: {},
+    }
+
+    const properties = {}
+    for (const p of cTypeInput.properties) {
+      properties[p.$id] = { type: p.type }
+      metadata.properties[p.$id] = {
+        title: {
+          default: p.title,
+        },
+      }
+    }
+    schema.properties = properties
+    return this.create(schema, metadata)
+  }
+
+  public async verifyStored(cTypeHash: ICType['hash']): Promise<boolean> {
+    const encoded:
+      | Codec
+      | null
+      | undefined = await this.blockchain.api.query.ctype.cTYPEs(cTypeHash)
+    return (encoded && encoded.encodedLength > 0) || false
+  }
+}

--- a/src/new-api-proposal/Kilt.spec.ts
+++ b/src/new-api-proposal/Kilt.spec.ts
@@ -1,0 +1,105 @@
+import Kilt from './Kilt'
+import { AttestationModule } from './AttestationModule'
+import { IRequestForAttestation } from 'src/requestforattestation/RequestForAttestation'
+import { Identity } from 'src'
+import { IAttestation } from './Attestation'
+import { TxStatus } from './TxStatus'
+import { BalanceModule } from './BalanceModule'
+import { CTypeModule } from './CTypeModule'
+import { ICType } from './CType'
+import { CTypeSchema, CtypeMetadata } from 'src/ctype/CType'
+
+describe('Kilt', async () => {
+  const identity: Identity = {} as Identity
+
+  // connect to Kilt chain
+  const kilt: Kilt = await Kilt.connect()
+
+  it('test attestations', async () => {
+    const requestForAttestation = {} as IRequestForAttestation
+
+    const attestations: AttestationModule = kilt.attestations()
+    // create new attestation
+    const attestation: IAttestation = attestations.create(
+      requestForAttestation,
+      identity
+    )
+    let txStatus: TxStatus = await attestation.store(identity)
+    console.log(txStatus)
+
+    // query existing attestations
+    const allAttestationForClaimHash: IAttestation[] = await attestations.query(
+      'myClaimHash'
+    )
+    console.log('allAttestationsForClaimHash', allAttestationForClaimHash)
+    allAttestationForClaimHash.forEach(async (att: IAttestation) => {
+      console.log(await att.verify())
+    })
+
+    // pick an attestation
+    const anyAttestation: IAttestation = allAttestationForClaimHash[0]
+
+    // verify attestation
+    console.log(await anyAttestation.verify()) // true
+
+    // revoke attestation
+    txStatus = await anyAttestation.revoke(identity)
+    console.log(txStatus)
+
+    // verify again
+    console.log(await anyAttestation.verify()) // false
+
+    // revoke all by delegation node id
+    console.log(await attestations.revokeAll('myDelegationNodeId'))
+  })
+
+  it('test balance', async () => {
+    const balances: BalanceModule = kilt.balances()
+
+    // get balance
+    const balance: number = await balances.getBalance('myAccountAdress')
+    console.log('my balance:', balance)
+
+    // make money transfer
+    const txStatus: TxStatus = await balances.makeTransfer(
+      identity,
+      'receiverAccountAddress',
+      100
+    )
+    console.log(txStatus)
+
+    // listen to balance changes
+    balances.listenToBalanceChanges(
+      'myAccountAddress',
+      (account: string, bal: number, change: number) => {
+        console.log('balances changed to', bal)
+      }
+    )
+  })
+
+  it('test CTYPE', async () => {
+    const cTypes: CTypeModule = kilt.CTYPEs()
+
+    // create CTYPE from input model
+    const anInputModel = {}
+    const cType: ICType = cTypes.createFromInputModel(anInputModel)
+
+    // store the CTYPE on chain
+    const txStatus: TxStatus = await cType.store(identity)
+    console.log('status', txStatus)
+
+    // check if CTYPE is stored on chain
+    const stored: boolean = await cTypes.verifyStored('myCtypeHash')
+    console.log(stored)
+
+    // build CTYPE from existing hash + schema + metadata
+    const schema = {} as CTypeSchema
+    const metadata = {} as CtypeMetadata
+    const hash = 'myCtypeHash'
+    const rebuiltCtype: ICType = cTypes.create(schema, metadata, hash)
+
+    // verify CTYPE is on chain
+    const rebuiltCtypeStored: boolean = await rebuiltCtype.verifyStored()
+    console.log('stored', rebuiltCtypeStored)
+  })
+})

--- a/src/new-api-proposal/Kilt.ts
+++ b/src/new-api-proposal/Kilt.ts
@@ -1,0 +1,26 @@
+import { AttestationModule } from './AttestationModule'
+import { BalanceModule } from './BalanceModule'
+import { IBlockchainApi } from './BlockchainApi'
+import { BlockchainApiConnection } from './BlockchainApiConnection'
+import { CTypeModule } from './CTypeModule'
+
+export default class Kilt {
+  public static async connect(): Promise<Kilt> {
+    const blockchainApi: IBlockchainApi = await BlockchainApiConnection.get()
+    return new Kilt(blockchainApi)
+  }
+
+  private constructor(private blockchainApi: IBlockchainApi) {}
+
+  public attestations(): AttestationModule {
+    return new AttestationModule(this.blockchainApi)
+  }
+
+  public balances(): BalanceModule {
+    return new BalanceModule(this.blockchainApi)
+  }
+
+  public CTYPEs(): CTypeModule {
+    return new CTypeModule(this.blockchainApi)
+  }
+}

--- a/src/new-api-proposal/TxStatus.ts
+++ b/src/new-api-proposal/TxStatus.ts
@@ -1,0 +1,3 @@
+export class TxStatus {
+  constructor(public type: string) {}
+}


### PR DESCRIPTION
Hier mein Vorschlag für die Restrukturierung des SDK.

Wesentliche Punkte sind:

- Blockchain Connection + Low-level API wird durch das SDK gekapselt (Blockchain Instanz muss nicht mehr im Client vorgehalten und als Param mit gegeben werden)
- Einführung von API-Modulen (`Attestations`, `CTYPEs`, `Balance`, etc.) analog Chain Impl.
- API-Module gewährleisten Zugriff auf Typen (ähnlich DAO-Pattern)
- Sprechender SDK-Entrypoint `Kilt.connect()`
- Verbesserung der Wiederverwendbarkeit von Blockchain API Transaktionen (denn es werden weitere transaktionale Operationen hinzukommen), `BlockchainStorable` nicht mehr nötig
- Eigener Typ `TxStatus` für Transaktionen
- Typen werden ausschließlich über das SDK erzeugt
- das SDK exposed nur Interfaces, keine Implementierungs-Details
- Interfaces definieren Properties + Operationen


Offene Punkte
- Promises durch `rx` ersetzen
- Events verwenden

Im Test `Kilt.spec.ts` zeige ich wie man es benutzt.


Feedback welcome!