### PR TITLE
feat: added date, time and uri formats

### DIFF
--- a/src/ctype/CType.ts
+++ b/src/ctype/CType.ts
@@ -72,10 +72,11 @@ export default class CType implements ICType {
 
     const properties = {}
     for (const p of ctypeInput.properties) {
-      properties[p.$id] = { type: p.type }
-      ctype.metadata.properties[p.$id] = {
+      const { title, $id, ...rest } = p
+      properties[$id] = rest
+      ctype.metadata.properties[$id] = {
         title: {
-          default: p.title,
+          default: title,
         },
       }
     }

--- a/src/ctype/CTypeSchema.ts
+++ b/src/ctype/CTypeSchema.ts
@@ -51,6 +51,11 @@ export const CTypeInputModel = {
             enum: ['string', 'integer', 'number', 'boolean'],
             enumTitles: ['Text', 'Number', 'Decimal', 'Yes/No'],
           },
+          format: {
+            title: 'Format',
+            type: 'string',
+            enum: ['date', 'time', 'uri'],
+          },
         },
         required: ['$id', 'title', 'type'],
       },
@@ -95,6 +100,10 @@ export const CTypeModel = {
             type: {
               type: 'string',
               enum: ['string', 'integer', 'number', 'boolean'],
+            },
+            format: {
+              type: 'string',
+              enum: ['date', 'time', 'uri'],
             },
           },
           required: ['type'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "outDir": "build",
     "module": "none",
-    "target": "esnext",
+    "target": "es2017",
     "lib": ["es6"],
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
fixes #92 

This PR adds date, time and uri formats to the schema.
To use it, the corresponding branch on prototype-client has to be used.

Since I am using spread/rest on objects here, I changed the typescript target to es2017. This makes it more easy usable in the client.