### PR TITLE
feat: enable multiple cType for requestClaimsForCtypes

### DIFF
--- a/src/messaging/Message.spec.ts
+++ b/src/messaging/Message.spec.ts
@@ -1,13 +1,13 @@
 import Identity from '../identity/Identity'
 import {
-  IRequestClaimsForCtype,
+  IRequestClaimsForCTypes,
   default as Message,
   MessageBodyType,
   IEncryptedMessage,
   IMessage,
   IRequestAttestationForClaim,
   ISubmitAttestationForClaim,
-  ISubmitClaimsForCtype,
+  ISubmitClaimsForCTypes,
 } from './Message'
 import { EncryptedAsymmetricString } from '../crypto/Crypto'
 import Crypto from '../crypto'
@@ -17,9 +17,9 @@ describe('Messaging', () => {
   const identityBob = Identity.buildFromURI('//Bob')
 
   it('verify message encryption and signing', () => {
-    const messageBody: IRequestClaimsForCtype = {
-      content: '0x12345678',
-      type: MessageBodyType.REQUEST_CLAIMS_FOR_CTYPE,
+    const messageBody: IRequestClaimsForCTypes = {
+      content: ['0x12345678'],
+      type: MessageBodyType.REQUEST_CLAIMS_FOR_CTYPES,
     }
     const message: Message = new Message(
       messageBody,
@@ -175,9 +175,9 @@ describe('Messaging', () => {
       )
     )
 
-    const submitClaimsForCTypeBody: ISubmitClaimsForCtype = {
+    const submitClaimsForCTypeBody: ISubmitClaimsForCTypes = {
       content: [submitAttestationBody.content],
-      type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPE,
+      type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES,
     }
 
     Message.ensureOwnerIsSender(

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -58,7 +58,7 @@ export default class Message implements IMessage {
           throw new Error('Sender is not owner of the attestation')
         }
         break
-      case MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPE:
+      case MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES:
         const submitClaimsForCtype = message.body
         submitClaimsForCtype.content.forEach(claim => {
           if (claim.request.claim.owner !== message.senderAddress) {
@@ -176,10 +176,10 @@ export enum MessageBodyType {
   SUBMIT_ATTESTATION_FOR_CLAIM = 'submit-attestation-for-claim',
   REJECT_ATTESTATION_FOR_CLAIM = 'reject-attestation-for-claim',
 
-  REQUEST_CLAIMS_FOR_CTYPE = 'request-claims-for-ctype',
-  SUBMIT_CLAIMS_FOR_CTYPE = 'submit-claims-for-ctype',
-  ACCEPT_CLAIMS_FOR_CTYPE = 'accept-claims-for-ctype',
-  REJECT_CLAIMS_FOR_CTYPE = 'reject-claims-for-ctype',
+  REQUEST_CLAIMS_FOR_CTYPES = 'request-claims-for-ctypes',
+  SUBMIT_CLAIMS_FOR_CTYPES = 'submit-claims-for-ctypes',
+  ACCEPT_CLAIMS_FOR_CTYPES = 'accept-claims-for-ctypes',
+  REJECT_CLAIMS_FOR_CTYPES = 'reject-claims-for-ctypes',
 
   REQUEST_ACCEPT_DELEGATION = 'request-accept-delegation',
   SUBMIT_ACCEPT_DELEGATION = 'submit-accept-delegation',
@@ -226,21 +226,21 @@ export interface IRejectAttestationForClaim extends IMessageBodyBase {
   type: MessageBodyType.REJECT_ATTESTATION_FOR_CLAIM
 }
 
-export interface IRequestClaimsForCtype extends IMessageBodyBase {
-  content: ICType['hash']
-  type: MessageBodyType.REQUEST_CLAIMS_FOR_CTYPE
+export interface IRequestClaimsForCTypes extends IMessageBodyBase {
+  content: Array<ICType['hash']>
+  type: MessageBodyType.REQUEST_CLAIMS_FOR_CTYPES
 }
-export interface ISubmitClaimsForCtype extends IMessageBodyBase {
+export interface ISubmitClaimsForCTypes extends IMessageBodyBase {
   content: IAttestedClaim[]
-  type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPE
+  type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES
 }
-export interface IAcceptClaimsForCtype extends IMessageBodyBase {
+export interface IAcceptClaimsForCTypes extends IMessageBodyBase {
   content: IAttestedClaim[]
-  type: MessageBodyType.ACCEPT_CLAIMS_FOR_CTYPE
+  type: MessageBodyType.ACCEPT_CLAIMS_FOR_CTYPES
 }
-export interface IRejectClaimsForCtype extends IMessageBodyBase {
+export interface IRejectClaimsForCTypes extends IMessageBodyBase {
   content: IAttestedClaim[]
-  type: MessageBodyType.REJECT_CLAIMS_FOR_CTYPE
+  type: MessageBodyType.REJECT_CLAIMS_FOR_CTYPES
 }
 
 export interface IRequestAcceptDelegation extends IMessageBodyBase {
@@ -296,10 +296,10 @@ export type MessageBody =
   | ISubmitAttestationForClaim
   | IRejectAttestationForClaim
   //
-  | IRequestClaimsForCtype
-  | ISubmitClaimsForCtype
-  | IAcceptClaimsForCtype
-  | IRejectClaimsForCtype
+  | IRequestClaimsForCTypes
+  | ISubmitClaimsForCTypes
+  | IAcceptClaimsForCTypes
+  | IRejectClaimsForCTypes
   //
   | IRequestAcceptDelegation
   | ISubmitAcceptDelegation


### PR DESCRIPTION
renames to message body types
enables sending of array of cTypeHashes when requesting claims

works with `origin/feature/mw_166_multiple_cTypes` of client