### PR TITLE
removed deprecated parameter for createFromEncryptedMessage

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -261,7 +261,6 @@ and the Attester (and only she) can also decrypt it:
 ```typescript
 const decrypted = Message.createFromEncryptedMessage(
   encrypted,
-  claimer,
   attester
 )
 ```


### PR DESCRIPTION
removed claimer : sdk.Contact since the method only needs 2 parameters and the encrypted Message contains the claimers Public Key