### PR TITLE
fix: decrypted message has to support senderboxpublickey

### DIFF
--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -24,6 +24,7 @@ export interface IMessage {
   createdAt: number
   receiverAddress: IPublicIdentity['address']
   senderAddress: IPublicIdentity['address']
+  senderBoxPublicKey?: IPublicIdentity['boxPublicKeyAsHex']
 
   messageId?: string
   receivedAt?: number

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -24,7 +24,7 @@ export interface IMessage {
   createdAt: number
   receiverAddress: IPublicIdentity['address']
   senderAddress: IPublicIdentity['address']
-  senderBoxPublicKey?: IPublicIdentity['boxPublicKeyAsHex']
+  senderBoxPublicKey: IPublicIdentity['boxPublicKeyAsHex']
 
   messageId?: string
   receivedAt?: number


### PR DESCRIPTION
IMessage now has optional parameter senderboxpublickey. Should resolve the failed build.