### PR TITLE
refactor: removed ctype utils to the demo client

### DIFF
--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,5 +1,4 @@
 import CType from './CType'
-import * as CTypeUtils from './CTypeUtils'
 import Identity from '../identity/Identity'
 import Crypto from '../crypto'
 import ICType from '../types/CType'
@@ -27,74 +26,6 @@ describe('CType', () => {
       },
     },
   } as ICType
-
-  it('verify model transformations', () => {
-    const ctypeInput = {
-      $id: 'http://example.com/ctype-1',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype-input#',
-      properties: [
-        {
-          title: 'First Property',
-          $id: 'first-property',
-          type: 'integer',
-        },
-        {
-          title: 'Second Property',
-          $id: 'second-property',
-          type: 'string',
-        },
-      ],
-      type: 'object',
-      title: 'CType Title',
-      required: ['first-property', 'second-property'],
-    }
-
-    const claimInput = {
-      $id: 'http://example.com/ctype-1',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      properties: {
-        'first-property': { type: 'integer', title: 'First Property' },
-        'second-property': { type: 'string', title: 'Second Property' },
-      },
-      type: 'object',
-      title: 'CType Title',
-      required: ['first-property', 'second-property'],
-    }
-    const goodClaim = {
-      'first-property': 10,
-      'second-property': '12',
-    }
-    const badClaim = {
-      'first-property': '1',
-      'second-property': '12',
-      'third-property': true,
-    }
-
-    const ctypeFromInput = CTypeUtils.fromInputModel(ctypeInput)
-    const ctypeFromModel = new CType(ctypeModel)
-    expect(JSON.stringify(ctypeFromInput.getModel())).toEqual(
-      JSON.stringify(ctypeFromModel.getModel())
-    )
-    expect(
-      JSON.stringify(CTypeUtils.getClaimInputModel(ctypeFromInput, 'en'))
-    ).toEqual(JSON.stringify(claimInput))
-    expect(
-      JSON.stringify(CTypeUtils.getCTypeInputModel(ctypeFromInput))
-    ).toEqual(JSON.stringify(ctypeInput))
-
-    expect(ctypeFromInput.verifyClaimStructure(goodClaim)).toBeTruthy()
-    expect(ctypeFromInput.verifyClaimStructure(badClaim)).toBeFalsy()
-
-    expect(() => {
-      // @ts-ignore
-      new CType(goodClaim).verifyClaimStructure(goodClaim)
-    }).toThrow(new Error('CType does not correspond to schema'))
-    expect(() => {
-      CTypeUtils.fromInputModel(ctypeModel)
-    }).toThrow(
-      new Error('CType input does not correspond to input model schema')
-    )
-  })
 
   it('stores ctypes', async () => {
     const identityAlice = Identity.buildFromURI('//Alice')

--- a/src/ctype/CTypeUtils.ts
+++ b/src/ctype/CTypeUtils.ts
@@ -2,9 +2,7 @@
  * @module CType
  */
 import Ajv from 'ajv'
-
-import { CTypeModel, CTypeInputModel } from './CTypeSchema'
-import CType from './CType'
+import { CTypeModel } from './CTypeSchema'
 import ICType from '../types/CType'
 import Crypto from '../crypto'
 
@@ -39,104 +37,4 @@ export function verifyClaimStructure(claim: any, schema: any): boolean {
 
 export function getHashForSchema(schema: ICType['schema']): string {
   return Crypto.hashObjectAsStr(schema)
-}
-
-/**
- * Create the CTYPE model from a CTYPE input model (used in CTYPE editing components).
- * This is necessary because component editors rely on editing arrays of properties instead of
- * arbitrary properties of an object. Additionally the default language translations are integrated
- * into the input model and need to be separated for the CTYPE model.
- * This is the reverse function of CType.getCTypeInputModel(...).
- * @returns The CTYPE for the input model.
- */
-export function fromInputModel(ctypeInput: any): CType {
-  if (!verifySchema(ctypeInput, CTypeInputModel)) {
-    throw new Error('CType input does not correspond to input model schema')
-  }
-  const ctype = {
-    schema: {
-      $id: ctypeInput.$id,
-      $schema: CTypeModel.properties.$schema.default,
-      properties: {},
-      type: 'object',
-    },
-    metadata: {
-      title: {
-        default: ctypeInput.title,
-      },
-      description: {
-        default: ctypeInput.description,
-      },
-      properties: {},
-    },
-  }
-
-  const properties = {}
-  ctypeInput.properties.forEach((p: any) => {
-    const { title, $id, ...rest } = p
-    properties[$id] = rest
-    ctype.metadata.properties[$id] = {
-      title: {
-        default: title,
-      },
-    }
-  })
-  ctype.schema.properties = properties
-  return new CType(ctype as ICType)
-}
-
-function getLocalized(o: any, lang?: string): any {
-  if (lang == null || !o[lang]) {
-    return o.default
-  }
-  return o[lang]
-}
-
-/**
- * Create the CTYPE input model for a CTYPE editing component form the CTYPE model.
- * This is necessary because component editors rely on editing arrays of properties instead of
- * arbitrary properties of an object. Additionally the default language translations are integrated
- * into the input model. This is the reverse function of CType.fromInputModel(...).
- * @returns The CTYPE input model.
- */
-export function getCTypeInputModel(ctype: CType): any {
-  // create clone
-  const result = JSON.parse(JSON.stringify(ctype.schema))
-  result.$schema = CTypeInputModel.$id
-  result.title = getLocalized(ctype.metadata.title)
-  result.description = getLocalized(ctype.metadata.description)
-  result.required = []
-  result.properties = []
-
-  Object.entries(ctype.schema.properties as object).forEach(([key, value]) => {
-    result.properties.push({
-      title: getLocalized(ctype.metadata.properties[key].title),
-      $id: key,
-      type: value.type,
-    })
-    result.required.push(key)
-  })
-
-  return result
-}
-
-/**
- * This method creates an input model for a claim from a CTYPE.
- * It selects translations for a specific language from the localized part of the CTYPE meta data.
- * @param {string} lang the language to choose translations for
- * @returns {any} The claim input model
- */
-export function getClaimInputModel(ctype: ICType, lang?: string): any {
-  // create clone
-  const result = JSON.parse(JSON.stringify(ctype.schema))
-  result.title = getLocalized(ctype.metadata.title, lang)
-  result.description = getLocalized(ctype.metadata.description, lang)
-  result.required = []
-  Object.entries(ctype.metadata.properties as object).forEach(
-    ([key, value]) => {
-      result.properties[key].title = getLocalized(value.title, lang)
-      result.required.push(key)
-    }
-  )
-  return result
 }


### PR DESCRIPTION
## fixes #200 

Removed funtions from the CtypeUtils, and placed them into the demo-client. 

## How to test:

yarn test

Test Suites: 1 skipped, 17 passed, 17 of 18 total
Tests:       2 skipped, 49 passed, 51 total


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
