### PR TITLE
fix: empty address was decoded to string representation

### DIFF
--- a/src/ctype/CType.chain.ts
+++ b/src/ctype/CType.chain.ts
@@ -35,7 +35,9 @@ export async function store(
 }
 
 function decode(encoded: QueryResult): IPublicIdentity['address'] | null {
-  return encoded && encoded.encodedLength ? encoded.toString() : null
+  return encoded && encoded.encodedLength && !encoded.isEmpty
+    ? encoded.toString()
+    : null
 }
 
 export async function getOwner(


### PR DESCRIPTION
## Description
`getOwner(ctype.hash)` internally was receiving an empty result
```    
encoded Type [Uint8Array] [
      0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0, 0, 0, 0, 0,
      0, 0, 0, 0, 0
    ] 
```
when the CType hash did not exist on chain, but this was converted to a public address by the decoder, which was then returned by `getOwner()`. With this fix, `decode()` returns `null` for an empty result and `getOwner()` returns `null` when the ctype hash is not found on chain. 

## How to test:
`await getOwner('0x22b14646c541790db1e2879c93302c5e6872476cb2212c0665b0ca78e9ca2ee1')`
must return `null`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
