### PR TITLE
Feat: added signature/verification features to the DID Document methods

### DIFF
--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -116,55 +116,6 @@ describe('DID', () => {
     })
   })
 
-  it('creates signed default did document', () => {
-    const identity = Identity.buildFromURI('//Alice')
-    expect(
-      Did.createDefaultDidDocumentSigned(
-        Did.getIdentifierFromAddress(identity.address),
-        identity.boxPublicKeyAsHex,
-        identity.signPublicKeyAsHex,
-        // @ts-ignore
-        identity.signKeyringPair,
-        'http://myDID.kilt.io/service'
-      )
-    ).toEqual({
-      id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
-      '@context': 'https://w3id.org/did/v1',
-      authentication: {
-        type: 'Ed25519SignatureAuthentication2018',
-        publicKey: [
-          'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-1',
-        ],
-      },
-      publicKey: [
-        {
-          controller:
-            'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
-          id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-1',
-          publicKeyHex:
-            '0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee',
-          type: 'Ed25519VerificationKey2018',
-        },
-        {
-          controller:
-            'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
-          id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-2',
-          publicKeyHex:
-            '0xe54bdd5e4f0929471fb333b17c0d865fc4f2cbc45364602bd1b85550328c3c62',
-          type: 'X25519Salsa20Poly1305Key2018',
-        },
-      ],
-      service: [
-        {
-          serviceEndpoint: 'http://myDID.kilt.io/service',
-          type: 'KiltMessagingService',
-        },
-      ],
-      signature:
-        '0xc1e24605bc58707e220ad760ba4c18a2b45b65c59731ba9ea1a83933afc67feb4f8f7107cf75b3189dd17617df29af26e55f19eb826e794ab3bdc7d375a3df0b',
-    })
-  })
-
   it('creates signed default did document from identity', () => {
     const identity = Identity.buildFromURI('//Alice')
     expect(

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -78,7 +78,9 @@ describe('DID', () => {
       Identity.buildFromURI('//Alice'),
       'http://myDID.kilt.io'
     )
-    expect(did.getDefaultDocument('http://myDID.kilt.io/service')).toEqual({
+    expect(
+      did.createDefaultDidDocument('http://myDID.kilt.io/service')
+    ).toEqual({
       '@context': 'https://w3id.org/did/v1',
       authentication: {
         publicKey: [

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -73,7 +73,7 @@ describe('DID', () => {
     expect(await did.store(alice)).toEqual({ status: 'ok' })
   })
 
-  it('get default did document', async () => {
+  it('creates default did document', async () => {
     const did = Did.fromIdentity(
       Identity.buildFromURI('//Alice'),
       'http://myDID.kilt.io'
@@ -114,6 +114,147 @@ describe('DID', () => {
         },
       ],
     })
+  })
+
+  it('creates signed default did document', () => {
+    const identity = Identity.buildFromURI('//Alice')
+    expect(
+      Did.createDefaultDidDocumentSigned(
+        Did.getIdentifierFromAddress(identity.address),
+        identity.boxPublicKeyAsHex,
+        identity.signPublicKeyAsHex,
+        // @ts-ignore
+        identity.signKeyringPair,
+        'http://myDID.kilt.io/service'
+      )
+    ).toEqual({
+      id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
+      '@context': 'https://w3id.org/did/v1',
+      authentication: {
+        type: 'Ed25519SignatureAuthentication2018',
+        publicKey: [
+          'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-1',
+        ],
+      },
+      publicKey: [
+        {
+          controller:
+            'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
+          id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-1',
+          publicKeyHex:
+            '0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee',
+          type: 'Ed25519VerificationKey2018',
+        },
+        {
+          controller:
+            'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
+          id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-2',
+          publicKeyHex:
+            '0xe54bdd5e4f0929471fb333b17c0d865fc4f2cbc45364602bd1b85550328c3c62',
+          type: 'X25519Salsa20Poly1305Key2018',
+        },
+      ],
+      service: [
+        {
+          serviceEndpoint: 'http://myDID.kilt.io/service',
+          type: 'KiltMessagingService',
+        },
+      ],
+      signature:
+        '0xc1e24605bc58707e220ad760ba4c18a2b45b65c59731ba9ea1a83933afc67feb4f8f7107cf75b3189dd17617df29af26e55f19eb826e794ab3bdc7d375a3df0b',
+    })
+  })
+
+  it('creates signed default did document from identity', () => {
+    const identity = Identity.buildFromURI('//Alice')
+    expect(
+      Did.createDefaultDidDocumentSignedFromIdentity(
+        identity,
+        'http://myDID.kilt.io/service'
+      )
+    ).toEqual({
+      id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
+      '@context': 'https://w3id.org/did/v1',
+      authentication: {
+        type: 'Ed25519SignatureAuthentication2018',
+        publicKey: [
+          'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-1',
+        ],
+      },
+      publicKey: [
+        {
+          controller:
+            'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
+          id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-1',
+          publicKeyHex:
+            '0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee',
+          type: 'Ed25519VerificationKey2018',
+        },
+        {
+          controller:
+            'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu',
+          id: 'did:kilt:5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu#key-2',
+          publicKeyHex:
+            '0xe54bdd5e4f0929471fb333b17c0d865fc4f2cbc45364602bd1b85550328c3c62',
+          type: 'X25519Salsa20Poly1305Key2018',
+        },
+      ],
+      service: [
+        {
+          serviceEndpoint: 'http://myDID.kilt.io/service',
+          type: 'KiltMessagingService',
+        },
+      ],
+      signature:
+        '0xc1e24605bc58707e220ad760ba4c18a2b45b65c59731ba9ea1a83933afc67feb4f8f7107cf75b3189dd17617df29af26e55f19eb826e794ab3bdc7d375a3df0b',
+    })
+  })
+
+  it('verifies the did document signature (untampered data)', () => {
+    const identity = Identity.buildFromURI('//Alice')
+    const signedDidDoc = Did.createDefaultDidDocumentSignedFromIdentity(
+      identity,
+      'http://myDID.kilt.io/service'
+    )
+    expect(
+      Did.verifyDidDocumentSignature(signedDidDoc, identity.address)
+    ).toBeTruthy()
+  })
+
+  it('verifies the did document signature (tampered data)', () => {
+    const identity = Identity.buildFromURI('//Alice')
+    const signedDidDoc = Did.createDefaultDidDocumentSignedFromIdentity(
+      identity,
+      'http://myDID.kilt.io/service'
+    )
+    const tamperedSignedDidDoc = {
+      ...signedDidDoc,
+      authentication: {
+        type: 'Ed25519SignatureAuthentication2018',
+        publicKey: ['did:kilt:123'],
+      },
+    }
+    expect(
+      Did.verifyDidDocumentSignature(tamperedSignedDidDoc, identity.address)
+    ).toBeFalsy()
+  })
+
+  it("throws when verifying the did document signature if addresses don't match", () => {
+    const identityAlice = Identity.buildFromURI('//Alice')
+    const identityBob = Identity.buildFromURI('//Bob')
+    const signedDidDoc = Did.createDefaultDidDocumentSignedFromIdentity(
+      identityAlice,
+      'http://myDID.kilt.io/service'
+    )
+    expect(() => {
+      Did.verifyDidDocumentSignature(signedDidDoc, identityBob.address)
+    }).toThrowError(
+      new Error(
+        `The input address ${Did.getAddressFromIdentifier(
+          signedDidDoc.id
+        )} doesn't match the DID Document's address ${identityBob.address}`
+      )
+    )
   })
 
   it('gets identifier from address', () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -1,6 +1,7 @@
 import { Text, Tuple, Option, U8a } from '@polkadot/types'
 import { Did } from '..'
 import { IDid } from './Did'
+import Crypto from '../crypto'
 import Identity from '../identity/Identity'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
@@ -200,12 +201,19 @@ describe('DID', () => {
 
   it("throws when verifying the did document signature if addresses don't match", () => {
     const identityAlice = Identity.buildFromURI('//Alice')
-    const identityBob = Identity.buildFromURI('//Bob')
     const did = Did.fromIdentity(identityAlice, 'http://myDID.kilt.io')
     const didDocument = did.createDefaultDidDocument(
       'http://myDID.kilt.io/service'
     )
-    const signedDidDocument = Did.signDidDocument(didDocument, identityBob)
+    // sign as Bob, which shouldn't happen
+    // to sign, we're not signing with the correct identity, we're not using signDidDocument() method
+    // since it would throw
+    const identityBob = Identity.buildFromURI('//Bob')
+    const didDocumentHash = Crypto.hashObjectAsStr(didDocument)
+    const signedDidDocument = {
+      ...didDocument,
+      signature: identityBob.signStr(didDocumentHash),
+    }
     expect(() => {
       Did.verifyDidDocumentSignature(signedDidDocument, identityBob.address)
     }).toThrowError(

--- a/src/did/Did.ts
+++ b/src/did/Did.ts
@@ -233,36 +233,6 @@ export default class Did implements IDid {
   }
 
   /**
-   * [STATIC] Builds a signed default DID Document.
-   *
-   * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
-   * @param publicBoxKey The public encryption key of the DID subject of this KILT DID identifier.
-   * @param publicSigningKey The public signing key of the DID subject of this KILT DID identifier.
-   * @param signKeyringPair A signing keyring pair.
-   * @param kiltServiceEndpoint A URI pointing to the service endpoint.
-   * @returns The signed default DID Document.
-   */
-  public static createDefaultDidDocumentSigned(
-    identifier: string,
-    publicBoxKey: string,
-    publicSigningKey: string,
-    signKeyringPair: KeyringPair,
-    kiltServiceEndpoint?: string
-  ): IDidDocumentSigned {
-    const unsignedDidDoc = createDefaultDidDocument(
-      identifier,
-      publicBoxKey,
-      publicSigningKey,
-      kiltServiceEndpoint
-    )
-    const didDocumentHash = Crypto.hashObjectAsStr(unsignedDidDoc)
-    return {
-      ...unsignedDidDoc,
-      signature: Crypto.signStr(didDocumentHash, signKeyringPair),
-    }
-  }
-
-  /**
    * [STATIC] Builds a signed default DID Document from a KILT identity; convenience method.
    *
    * @param identity The [[Identity]], DID subject for this DID Document.

--- a/src/did/Did.ts
+++ b/src/did/Did.ts
@@ -35,7 +35,7 @@ export const CONTEXT = 'https://w3id.org/did/v1'
 
 export interface IDid {
   /**
-   * The DID identifier under which it is store on chain.
+   * The DID identifier under which this DID object is stored on-chain.
    */
   identifier: string
   /**
@@ -47,7 +47,7 @@ export interface IDid {
    */
   publicSigningKey: string
   /**
-   * The document store reference.
+   * The document store reference, usually a URL.
    */
   documentStore: string | null
 }
@@ -74,78 +74,6 @@ export interface IDidDocumentSigned extends IDidDocumentUnsigned {
 }
 
 export default class Did implements IDid {
-  /**
-   * Queries the [Did] from chain using the [identifier].
-   *
-   * @param identifier the DID identifier
-   * @returns promise containing the [[Did]] or [null]
-   */
-  public static queryByIdentifier(identifier: string): Promise<IDid | null> {
-    return queryByIdentifier(identifier)
-  }
-
-  /**
-   * Gets the complete KILT DID from an [address] (in KILT, the method-specific ID is an address). Reverse of [[getAddressFromIdentifier]].
-   *
-   * @param address An address, e.g. "5CtPYoDuQQF...".
-   * @returns The associated KILT DID, e.g. "did:kilt:5CtPYoDuQQF...".
-   */
-  public static getIdentifierFromAddress(
-    address: IPublicIdentity['address']
-  ): IDid['identifier'] {
-    return getIdentifierFromAddress(address)
-  }
-
-  /**
-   * Gets the [address] from a complete KILT DID (in KILT, the method-specific ID is an address). Reverse of [[getIdentifierFromAddress]].
-   *
-   * @param identifier A KILT DID, e.g. "did:kilt:5CtPYoDuQQF...".
-   * @returns The associated address, e.g. "5CtPYoDuQQF...".
-   */
-  public static getAddressFromIdentifier(
-    identifier: IDid['identifier']
-  ): IPublicIdentity['address'] {
-    return getAddressFromIdentifier(identifier)
-  }
-
-  /**
-   * Queries the [Did] from chain using the [address]
-   *
-   * @param address the DIDs address
-   * @returns promise containing the [[Did]] or [null]
-   */
-  public static queryByAddress(address: string): Promise<IDid | null> {
-    return queryByAddress(address)
-  }
-
-  /**
-   * Removes the [[Did]] attached to [identity] from chain
-   *
-   * @param identity the identity for which to delete the [[Did]]
-   * @returns promise containing the [[TxStatus]]
-   */
-  public static async remove(identity: Identity): Promise<TxStatus> {
-    log.debug(`Create tx for 'did.remove'`)
-    return remove(identity)
-  }
-
-  /**
-   * Builds a [[Did]] from the given [identity].
-   *
-   * @param identity the identity used to build the [[Did]]
-   * @param documentStore optional document store reference
-   * @returns the [[Did]]
-   */
-  public static fromIdentity(identity: Identity, documentStore?: string): Did {
-    const identifier = getIdentifierFromAddress(identity.address)
-    return new Did(
-      identifier,
-      identity.boxPublicKeyAsHex,
-      identity.signPublicKeyAsHex,
-      documentStore
-    )
-  }
-
   public readonly identifier: string
   public readonly publicBoxKey: string
   public readonly publicSigningKey: string
@@ -164,10 +92,82 @@ export default class Did implements IDid {
   }
 
   /**
-   * Stores the [[Did]] on chain
+   * Gets the complete KILT DID from an [address] (in KILT, the method-specific ID is an address). Reverse of [[getAddressFromIdentifier]].
    *
-   * @param identity the identity used to store the [[Did]] on chain
-   * @returns promise containing the [[TxStatus]]
+   * @param address An address, e.g. "5CtPYoDuQQF...".
+   * @returns The associated KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
+   */
+  public static getIdentifierFromAddress(
+    address: IPublicIdentity['address']
+  ): IDid['identifier'] {
+    return getIdentifierFromAddress(address)
+  }
+
+  /**
+   * Gets the [address] from a complete KILT DID (in KILT, the method-specific ID is an address). Reverse of [[getIdentifierFromAddress]].
+   *
+   * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
+   * @returns The associated address, e.g. "5CtPYoDuQQF...".
+   */
+  public static getAddressFromIdentifier(
+    identifier: IDid['identifier']
+  ): IPublicIdentity['address'] {
+    return getAddressFromIdentifier(identifier)
+  }
+
+  /**
+   * Queries the [[Did]] object from the chain using the [identifier].
+   *
+   * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
+   * @returns A promise containing the [[Did]] or [null].
+   */
+  public static queryByIdentifier(identifier: string): Promise<IDid | null> {
+    return queryByIdentifier(identifier)
+  }
+
+  /**
+   * Queries the [[Did]] object from the chain using the [address].
+   *
+   * @param address The address associated to this [[Did]].
+   * @returns A promise containing the [[Did]] or [null].
+   */
+  public static queryByAddress(address: string): Promise<IDid | null> {
+    return queryByAddress(address)
+  }
+
+  /**
+   * Removes the [[Did]] object attached to a given [identity] from the chain.
+   *
+   * @param identity The identity for which to delete the [[Did]].
+   * @returns A promise containing the [[TxStatus]] (transaction status).
+   */
+  public static async remove(identity: Identity): Promise<TxStatus> {
+    log.debug(`Create tx for 'did.remove'`)
+    return remove(identity)
+  }
+
+  /**
+   * Builds a [[Did]] object from the given [identity].
+   *
+   * @param identity The identity used to build the [[Did]] object.
+   * @param documentStore The storage location of the associated DID Document; usally a URL.
+   * @returns The [[Did]] object.
+   */
+  public static fromIdentity(identity: Identity, documentStore?: string): Did {
+    const identifier = getIdentifierFromAddress(identity.address)
+    return new Did(
+      identifier,
+      identity.boxPublicKeyAsHex,
+      identity.signPublicKeyAsHex,
+      documentStore
+    )
+  }
+
+  /**
+   * Stores the [[Did]] object on-chain.
+   *
+   * @param identity The identity used to store the [[Did]] object on-chain.
+   * @returns A promise containing the [[TxStatus]] (transaction status).
    */
   public async store(identity: Identity): Promise<TxStatus> {
     log.debug(`Create tx for 'did.add'`)
@@ -175,10 +175,10 @@ export default class Did implements IDid {
   }
 
   /**
-   * Builds the default DID document from this [[Did]] object.
+   * Builds the default DID Document from this [[Did]] object.
    *
-   * @param kiltServiceEndpoint - URI pointing to the service endpoint
-   * @returns The default DID document
+   * @param kiltServiceEndpoint A URI pointing to the service endpoint.
+   * @returns The default DID Document.
    */
   public createDefaultDidDocument(
     kiltServiceEndpoint?: string
@@ -192,10 +192,13 @@ export default class Did implements IDid {
   }
 
   /**
-   * Builds the default DID document from this [[Did]] object.
+   * [STATIC] Builds a default DID Document.
    *
-   * @param kiltServiceEndpoint - URI pointing to the service endpoint
-   * @returns The default DID document
+   * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
+   * @param publicBoxKey The public encryption key of the DID subject of this KILT DID identifier.
+   * @param publicSigningKey The public signing key of the DID subject of this KILT DID identifier.
+   * @param kiltServiceEndpoint A URI pointing to the service endpoint.
+   * @returns The default DID Document.
    */
   public static createDefaultDidDocument(
     identifier: string,
@@ -211,6 +214,13 @@ export default class Did implements IDid {
     )
   }
 
+  /**
+   * Builds the signed default DID Document from this [[Did]] object.
+   *
+   * @param signKeyringPair A signing keyring pair.
+   * @param kiltServiceEndpoint A URI pointing to the service endpoint.
+   * @returns The default DID Document.
+   */
   public createDefaultDidDocumentSigned(
     signKeyringPair: KeyringPair,
     kiltServiceEndpoint?: string
@@ -224,6 +234,16 @@ export default class Did implements IDid {
     }
   }
 
+  /**
+   * [STATIC] Builds a signed default DID Document.
+   *
+   * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
+   * @param publicBoxKey The public encryption key of the DID subject of this KILT DID identifier.
+   * @param publicSigningKey The public signing key of the DID subject of this KILT DID identifier.
+   * @param signKeyringPair A signing keyring pair.
+   * @param kiltServiceEndpoint A URI pointing to the service endpoint.
+   * @returns The signed default DID Document.
+   */
   public static createDefaultDidDocumentSigned(
     identifier: string,
     publicBoxKey: string,
@@ -245,6 +265,13 @@ export default class Did implements IDid {
     }
   }
 
+  /**
+   * [STATIC] Builds a signed default DID Document from a KILT identity; convenience method.
+   *
+   * @param identity The [[Identity]], DID subject for this DID Document.
+   * @param kiltServiceEndpoint A URI pointing to the service endpoint.
+   * @returns The signed default DID Document.
+   */
   public static createDefaultDidDocumentSignedFromIdentity(
     identity: Identity,
     kiltServiceEndpoint?: string
@@ -263,6 +290,13 @@ export default class Did implements IDid {
     }
   }
 
+  /**
+   * [STATIC] Verifies the signature of a DID Document, to check whether the data has been tampered with.
+   *
+   * @param didDocument A signed DID Document.
+   * @param address The address to use for signature verification.
+   * @returns Whether the DID Document's signature is valid.
+   */
   public static verifyDidDocumentSignature(
     didDocument: IDidDocumentSigned,
     address: string

--- a/src/did/Did.ts
+++ b/src/did/Did.ts
@@ -69,7 +69,6 @@ export interface IDidDocumentUnsigned
     Partial<IDidDocumentPpties> {}
 
 export interface IDidDocumentSigned extends IDidDocumentUnsigned {
-  didDocumentHash: string
   signature: string
 }
 
@@ -229,7 +228,6 @@ export default class Did implements IDid {
     const didDocumentHash = Crypto.hashObjectAsStr(unsignedDidDoc)
     return {
       ...unsignedDidDoc,
-      didDocumentHash,
       signature: Crypto.signStr(didDocumentHash, signKeyringPair),
     }
   }
@@ -260,7 +258,6 @@ export default class Did implements IDid {
     const didDocumentHash = Crypto.hashObjectAsStr(unsignedDidDoc)
     return {
       ...unsignedDidDoc,
-      didDocumentHash,
       signature: Crypto.signStr(didDocumentHash, signKeyringPair),
     }
   }
@@ -285,7 +282,6 @@ export default class Did implements IDid {
     const didDocumentHash = Crypto.hashObjectAsStr(unsignedDidDoc)
     return {
       ...unsignedDidDoc,
-      didDocumentHash,
       signature: identity.signStr(didDocumentHash),
     }
   }
@@ -301,18 +297,11 @@ export default class Did implements IDid {
     didDocument: IDidDocumentSigned,
     address: string
   ): boolean {
-    if (
-      !didDocument ||
-      !didDocument.didDocumentHash ||
-      !didDocument.signature ||
-      !address
-    ) {
+    if (!didDocument || !didDocument.signature || !address) {
       throw new Error(
         `Missing data for verification (either didDocument, didDocumentHash, signature, or address is missing):\n
           didDocument:\n
           ${didDocument}\n
-          didDocumentHash:\n
-          ${didDocument.didDocumentHash}\n
           signature:\n
           ${didDocument.signature}\n
           address:\n
@@ -322,11 +311,15 @@ export default class Did implements IDid {
     }
     if (getAddressFromIdentifier(didDocument.id) !== address) {
       throw new Error(
-        `The input address ${didDocument.id} doesn't match the DID Document's address ${address}`
+        `The input address ${getAddressFromIdentifier(
+          didDocument.id
+        )} doesn't match the DID Document's address ${address}`
       )
     }
+    const unsignedDidDocument = { ...didDocument }
+    delete unsignedDidDocument.signature
     return Crypto.verify(
-      didDocument.didDocumentHash,
+      Crypto.hashObjectAsStr(unsignedDidDocument),
       didDocument.signature,
       address
     )

--- a/src/did/Did.ts
+++ b/src/did/Did.ts
@@ -198,14 +198,14 @@ export default class Did implements IDid {
    * Verifies the signature of a DID Document, to check whether the data has been tampered with.
    *
    * @param didDocument A signed DID Document.
-   * @param address The address to use for signature verification.
+   * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
    * @returns Whether the DID Document's signature is valid.
    */
   public static verifyDidDocumentSignature(
     didDocument: IDidDocumentSigned,
-    address: string
+    identifier: string
   ): boolean {
-    return verifyDidDocumentSignature(didDocument, address)
+    return verifyDidDocumentSignature(didDocument, identifier)
   }
 
   /**

--- a/src/did/Did.utils.ts
+++ b/src/did/Did.utils.ts
@@ -98,9 +98,9 @@ export function createDefaultDidDocument(
 
 export function verifyDidDocumentSignature(
   didDocument: IDidDocumentSigned,
-  address: string
+  identifier: string
 ): boolean {
-  if (!didDocument || !didDocument.signature || !address) {
+  if (!didDocument || !didDocument.signature || !identifier) {
     throw new Error(
       `Missing data for verification (either didDocument, didDocumentHash, signature, or address is missing):\n
           didDocument:\n
@@ -108,15 +108,14 @@ export function verifyDidDocumentSignature(
           signature:\n
           ${didDocument.signature}\n
           address:\n
-          ${address}\n
+          ${identifier}\n
           `
     )
   }
-  if (getAddressFromIdentifier(didDocument.id) !== address) {
+  const { id } = didDocument
+  if (identifier !== id) {
     throw new Error(
-      `The input address ${getAddressFromIdentifier(
-        didDocument.id
-      )} doesn't match the DID Document's address ${address}`
+      `This identifier (${identifier}) doesn't match the DID Document's identifier (${id})`
     )
   }
   const unsignedDidDocument = { ...didDocument }
@@ -124,7 +123,7 @@ export function verifyDidDocumentSignature(
   return Crypto.verify(
     Crypto.hashObjectAsStr(unsignedDidDocument),
     didDocument.signature,
-    address
+    getAddressFromIdentifier(identifier)
   )
 }
 
@@ -132,16 +131,6 @@ export function signDidDocument(
   didDocument: IDidDocument,
   identity: Identity
 ): IDidDocumentSigned {
-  // extra security: only the DID subject can sign
-  const { id } = didDocument
-  const { address } = identity
-  if (getAddressFromIdentifier(id) !== address) {
-    throw new Error(
-      `The signing identity (address: ${getAddressFromIdentifier(
-        id
-      )}) doesn't match the DID Document subject (address: ${address}). Only the DID subject should sign their DID Document.`
-    )
-  }
   const didDocumentHash = Crypto.hashObjectAsStr(didDocument)
   return {
     ...didDocument,

--- a/src/did/Did.utils.ts
+++ b/src/did/Did.utils.ts
@@ -132,6 +132,16 @@ export function signDidDocument(
   didDocument: IDidDocument,
   identity: Identity
 ): IDidDocumentSigned {
+  // extra security: only the DID subject can sign
+  const { id } = didDocument
+  const { address } = identity
+  if (getAddressFromIdentifier(id) !== address) {
+    throw new Error(
+      `The signing identity (address: ${getAddressFromIdentifier(
+        id
+      )}) doesn't match the DID Document subject (address: ${address}). Only the DID subject should sign their DID Document.`
+    )
+  }
   const didDocumentHash = Crypto.hashObjectAsStr(didDocument)
   return {
     ...didDocument,

--- a/src/did/Did.utils.ts
+++ b/src/did/Did.utils.ts
@@ -9,7 +9,16 @@ import { isHex, hexToString } from '@polkadot/util'
 
 import IPublicIdentity from '../types/PublicIdentity'
 import { QueryResult } from '../blockchain/Blockchain'
-import Did, { IDid, IDENTIFIER_PREFIX } from './Did'
+import Did, {
+  IDid,
+  IDENTIFIER_PREFIX,
+  IDidDocumentUnsigned,
+  CONTEXT,
+  KEY_TYPE_AUTHENTICATION,
+  KEY_TYPE_SIGNATURE,
+  KEY_TYPE_ENCRYPTION,
+  SERVICE_KILT_MESSAGING,
+} from './Did'
 
 export function decodeDid(
   identifier: string,
@@ -44,4 +53,42 @@ export function getAddressFromIdentifier(
     throw new Error(`Not a KILT did: ${identifier}`)
   }
   return identifier.substr(IDENTIFIER_PREFIX.length)
+}
+
+export function createDefaultDidDocument(
+  identifier: string,
+  publicBoxKey: string,
+  publicSigningKey: string,
+  kiltServiceEndpoint?: string
+): IDidDocumentUnsigned {
+  return {
+    id: identifier,
+    '@context': CONTEXT,
+    authentication: {
+      type: KEY_TYPE_AUTHENTICATION,
+      publicKey: [`${identifier}#key-1`],
+    },
+    publicKey: [
+      {
+        id: `${identifier}#key-1`,
+        type: KEY_TYPE_SIGNATURE,
+        controller: identifier,
+        publicKeyHex: publicSigningKey,
+      },
+      {
+        id: `${identifier}#key-2`,
+        type: KEY_TYPE_ENCRYPTION,
+        controller: identifier,
+        publicKeyHex: publicBoxKey,
+      },
+    ],
+    service: kiltServiceEndpoint
+      ? [
+          {
+            type: SERVICE_KILT_MESSAGING,
+            serviceEndpoint: kiltServiceEndpoint,
+          },
+        ]
+      : [],
+  }
 }


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/170 

- Added a signature property to the generated Did Document and a verification utility method 
- Created dedicated interfaces
- Made sure to create both static and non-static versions of the new methods

## How to test:
`yarn test`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
