### PR TITLE
feat: multiple transactions per account

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -82,7 +82,9 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store(attester).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+    await ctype
+      .store(attester)
+      .then((tx) => submitSignedTx(tx, { resolveOn: IS_IN_BLOCK }))
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -85,7 +85,7 @@ async function setup(): Promise<{
     await ctype
       .store(attester)
       .then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
   } catch (e) {
     console.log(

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -10,7 +10,7 @@ import Kilt, {
   IRevocationHandle,
   PublicAttesterIdentity,
 } from '../src'
-import { IS_IN_BLOCK, submitSignedTx } from '../src/blockchain/Blockchain'
+import Blockchain, { IS_IN_BLOCK } from '../src/blockchain/Blockchain'
 import constants from '../src/test/constants'
 
 const NODE_URL = 'ws://127.0.0.1:9944'
@@ -84,7 +84,9 @@ async function setup(): Promise<{
   try {
     await ctype
       .store(attester)
-      .then((tx) => submitSignedTx(tx, { resolveOn: IS_IN_BLOCK }))
+      .then((tx) =>
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
+      )
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --coverage --group=-integration",
     "test:ci": "jest --ci -b --coverage --group=-integration",
-    "test:integration:run": "jest --group=integration -w 3",
+    "test:integration:run": "jest --group=integration -w 2",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --coverage --group=-integration",
     "test:ci": "jest --ci --coverage --group=-integration",
-    "test:integration:run": "jest --group=integration -b -w 2",
+    "test:integration:run": "jest --group=integration -b -w 2 --silent",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --coverage --group=-integration",
     "test:ci": "jest --ci --coverage --group=-integration",
-    "test:integration:run": "jest --group=integration -b -w 2 --silent",
+    "test:integration:run": "jest --group=integration -b -w 4 --silent",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --coverage --group=-integration",
     "test:ci": "jest --ci --coverage --group=-integration",
-    "test:integration:run": "jest --group=integration -b -w 2 --silent",
+    "test:integration:run": "jest --group=integration -b -w 3 --silent",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "typings": "./build/index.d.ts",
   "scripts": {
     "test": "jest --coverage --group=-integration",
-    "test:ci": "jest --ci --coverage --group=-integration",
-    "test:integration:run": "jest -b --runInBand --group=integration --silent",
+    "test:ci": "jest --ci -b --coverage --group=-integration",
+    "test:integration:run": "jest --group=integration -w 3",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "typings": "./build/index.d.ts",
   "scripts": {
     "test": "jest --coverage --group=-integration",
-    "test:ci": "jest --ci -b --coverage --group=-integration",
-    "test:integration:run": "jest --group=integration -w 2",
+    "test:ci": "jest --ci --coverage --group=-integration",
+    "test:integration:run": "jest --group=integration -b -w 2",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --coverage --group=-integration",
     "test:ci": "jest --ci --coverage --group=-integration",
-    "test:integration:run": "jest --group=integration -b -w 4 --silent",
+    "test:integration:run": "jest --group=integration -b -w 2 --silent",
     "test:integration": "if lsof -i :9944 > /dev/null; then yarn test:integration:run; else echo 'Can not connect to chain. Is it running?'; exit 1;fi",
     "test:watch": "yarn test --watch",
     "lint": "eslint 'src/**'",

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -47,7 +47,7 @@ describe('handling attestations that do not exist', () => {
   it('Attestation.revoke', async () => {
     return expect(
       Attestation.revoke('0x012012012', alice).then((tx) =>
-        Blockchain.submitSignedTx(tx, alice, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, alice, { resolveOn: IS_IN_BLOCK })
       )
     ).rejects.toThrow()
   }, 30_000)
@@ -68,7 +68,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_READY })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_READY })
       )
     }
   }, 60_000)
@@ -107,7 +107,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     await attestation
       .store(attester)
       .then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
@@ -142,11 +142,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
 
     await expect(
-      attestation
-        .store(bobbyBroke)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, bobbyBroke, { resolveOn: IS_IN_BLOCK })
-        )
+      attestation.store(bobbyBroke).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, bobbyBroke, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
     ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
       bobbyBroke,
@@ -188,11 +188,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
     await expect(
-      attestation
-        .store(attester)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
-        )
+      attestation.store(attester).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, attester, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
     ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
 
@@ -213,11 +213,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request,
         attester.getPublicIdentity()
       )
-      await attestation
-        .store(attester)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
-        )
+      await attestation.store(attester).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, attester, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
         request,
@@ -229,11 +229,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     it('should not be possible to attest the same claim twice', async () => {
       await expect(
-        attClaim.attestation
-          .store(attester)
-          .then((tx) =>
-            Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
-          )
+        attClaim.attestation.store(attester).then((tx) =>
+          Blockchain.submitTxWithReSign(tx, attester, {
+            resolveOn: IS_IN_BLOCK,
+          })
+        )
       ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
 
@@ -258,7 +258,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), claimer).then((tx) =>
-          Blockchain.submitSignedTx(tx, claimer, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitTxWithReSign(tx, claimer, { resolveOn: IS_IN_BLOCK })
         )
       ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
@@ -267,7 +267,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), attester).then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
@@ -277,7 +277,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_IN_BLOCK })
         )
       }
       await expect(
@@ -308,7 +308,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await licenseAuthorizationGranted
         .store(faucet)
         .then((tx) =>
-          Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_IN_BLOCK })
         )
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
@@ -336,7 +336,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
       const license = await Credential.fromRequestAndAttestation(
         claimer,

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -47,7 +47,7 @@ describe('handling attestations that do not exist', () => {
   it('Attestation.revoke', async () => {
     return expect(
       Attestation.revoke('0x012012012', alice).then((tx) =>
-        Blockchain.submitSignedTx(alice, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, alice, { resolveOn: IS_IN_BLOCK })
       )
     ).rejects.toThrow()
   }, 30_000)
@@ -68,7 +68,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_READY })
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_READY })
       )
     }
   }, 60_000)
@@ -107,7 +107,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     await attestation
       .store(attester)
       .then((tx) =>
-        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
@@ -145,7 +145,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attestation
         .store(bobbyBroke)
         .then((tx) =>
-          Blockchain.submitSignedTx(bobbyBroke, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, bobbyBroke, { resolveOn: IS_IN_BLOCK })
         )
     ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
@@ -191,7 +191,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attestation
         .store(attester)
         .then((tx) =>
-          Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
         )
     ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
@@ -216,7 +216,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await attestation
         .store(attester)
         .then((tx) =>
-          Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
         )
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
@@ -232,7 +232,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attClaim.attestation
           .store(attester)
           .then((tx) =>
-            Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+            Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
           )
       ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
@@ -258,7 +258,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), claimer).then((tx) =>
-          Blockchain.submitSignedTx(claimer, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, claimer, { resolveOn: IS_IN_BLOCK })
         )
       ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
@@ -267,7 +267,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), attester).then((tx) =>
-        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
@@ -277,7 +277,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
         )
       }
       await expect(
@@ -308,7 +308,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await licenseAuthorizationGranted
         .store(faucet)
         .then((tx) =>
-          Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
         )
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
@@ -336,7 +336,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
       const license = await Credential.fromRequestAndAttestation(
         claimer,

--- a/src/__integrationtests__/AttestationPE.spec.ts
+++ b/src/__integrationtests__/AttestationPE.spec.ts
@@ -11,7 +11,7 @@ import {
 import { Claim, IBlockchainApi, IClaim, Message } from '..'
 import { Attester, Claimer, Verifier } from '../actor'
 import { ClaimerAttestationSession } from '../actor/Claimer'
-import { submitSignedTx } from '../blockchain'
+import Blockchain from '../blockchain'
 import { IS_IN_BLOCK } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Credential from '../credential'
@@ -54,7 +54,7 @@ describe('Privacy enhanced claim, attestation, verification process', () => {
     // set up claim (ctype missing on fresh chain)
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        submitSignedTx(tx, IS_IN_BLOCK)
+        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
       )
     }
     claim = Claim.fromCTypeAndClaimContents(

--- a/src/__integrationtests__/AttestationPE.spec.ts
+++ b/src/__integrationtests__/AttestationPE.spec.ts
@@ -54,7 +54,7 @@ describe('Privacy enhanced claim, attestation, verification process', () => {
     // set up claim (ctype missing on fresh chain)
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
     }
     claim = Claim.fromCTypeAndClaimContents(

--- a/src/__integrationtests__/AttestationPE.spec.ts
+++ b/src/__integrationtests__/AttestationPE.spec.ts
@@ -54,7 +54,7 @@ describe('Privacy enhanced claim, attestation, verification process', () => {
     // set up claim (ctype missing on fresh chain)
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
       )
     }
     claim = Claim.fromCTypeAndClaimContents(

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -70,7 +70,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
     await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_IN_BLOCK })
     )
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
@@ -101,7 +101,7 @@ describe('When there are haves and have-nots', () => {
       stormyD.address,
       MIN_TRANSACTION
     ).then((tx) =>
-      Blockchain.submitSignedTx(tx, richieRich, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitTxWithReSign(tx, richieRich, { resolveOn: IS_IN_BLOCK })
     )
     const balanceTo = await getBalance(stormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
@@ -111,7 +111,9 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalance(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.submitSignedTx(tx, bobbyBroke, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, bobbyBroke, {
+          resolveOn: IS_IN_BLOCK,
+        })
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
@@ -126,7 +128,9 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        Blockchain.submitSignedTx(tx, richieRich, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, richieRich, {
+          resolveOn: IS_IN_BLOCK,
+        })
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -141,10 +145,10 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_READY })
+      Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_READY })
     )
     await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_IN_BLOCK })
     )
 
     expect(listener).toBeCalledWith(
@@ -160,10 +164,10 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_IN_BLOCK })
       ),
       makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, faucet, { resolveOn: IS_IN_BLOCK })
       ),
     ])
     expect(listener).toBeCalledWith(

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -70,7 +70,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
     await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
     )
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
@@ -101,7 +101,7 @@ describe('When there are haves and have-nots', () => {
       stormyD.address,
       MIN_TRANSACTION
     ).then((tx) =>
-      Blockchain.submitSignedTx(richieRich, tx, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitSignedTx(tx, richieRich, { resolveOn: IS_IN_BLOCK })
     )
     const balanceTo = await getBalance(stormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
@@ -111,7 +111,7 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalance(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.submitSignedTx(bobbyBroke, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, bobbyBroke, { resolveOn: IS_IN_BLOCK })
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
@@ -126,7 +126,7 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        Blockchain.submitSignedTx(richieRich, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, richieRich, { resolveOn: IS_IN_BLOCK })
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -141,10 +141,10 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_READY })
+      Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_READY })
     )
     await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
     )
 
     expect(listener).toBeCalledWith(
@@ -160,10 +160,10 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
       ),
       makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.submitSignedTx(faucet, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, faucet, { resolveOn: IS_IN_BLOCK })
       ),
     ])
     expect(listener).toBeCalledWith(

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -154,7 +154,7 @@ describe('When there are haves and have-nots', () => {
     expect(listener).toBeCalledTimes(2)
   }, 30_000)
 
-  xit('should be able to make multiple transactions at once', async () => {
+  it('should be able to make multiple transactions at once', async () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -166,7 +166,9 @@ describe('When there are haves and have-nots', () => {
       ),
     ])
     expect(listener).toBeCalledWith(
-      expect.objectContaining({ account: faucet.address })
+      faucet.address,
+      expect.anything(),
+      expect.anything()
     )
   }, 40_000)
 })

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -166,7 +166,7 @@ describe('When there are haves and have-nots', () => {
       ),
     ])
     expect(listener).toBeCalledWith(faucet.address)
-  }, 30_000)
+  }, 40_000)
 })
 
 afterAll(() => {

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -165,7 +165,9 @@ describe('When there are haves and have-nots', () => {
         submitSignedTx(tx, IS_IN_BLOCK)
       ),
     ])
-    expect(listener).toBeCalledWith(expect.objectContaining(faucet.address))
+    expect(listener).toBeCalledWith(
+      expect.objectContaining({ account: faucet.address })
+    )
   }, 40_000)
 })
 

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -165,7 +165,7 @@ describe('When there are haves and have-nots', () => {
         submitSignedTx(tx, IS_IN_BLOCK)
       ),
     ])
-    expect(listener).toBeCalledWith(faucet.address)
+    expect(listener).toBeCalledWith(expect.objectContaining(faucet.address))
   }, 40_000)
 })
 

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -48,22 +48,22 @@ describe('When there is an CtypeCreator and a verifier', () => {
       Identity.generateMnemonic()
     )
     await expect(
-      ctype
-        .store(bobbyBroke)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, bobbyBroke, { resolveOn: IS_IN_BLOCK })
-        )
+      ctype.store(bobbyBroke).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, bobbyBroke, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)
 
   it('should be possible to create a claim type', async () => {
     const ctype = makeCType()
-    await ctype
-      .store(ctypeCreator)
-      .then((tx) =>
-        Blockchain.submitSignedTx(tx, ctypeCreator, { resolveOn: IS_IN_BLOCK })
-      )
+    await ctype.store(ctypeCreator).then((tx) =>
+      Blockchain.submitTxWithReSign(tx, ctypeCreator, {
+        resolveOn: IS_IN_BLOCK,
+      })
+    )
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
       expect(ctype.verifyStored()).resolves.toBeTruthy(),
@@ -74,14 +74,14 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype
-      .store(ctypeCreator)
-      .then((tx) =>
-        Blockchain.submitSignedTx(tx, ctypeCreator, { resolveOn: IS_IN_BLOCK })
-      )
+    await ctype.store(ctypeCreator).then((tx) =>
+      Blockchain.submitTxWithReSign(tx, ctypeCreator, {
+        resolveOn: IS_IN_BLOCK,
+      })
+    )
     await expect(
       ctype.store(ctypeCreator).then((tx) =>
-        Blockchain.submitSignedTx(tx, ctypeCreator, {
+        Blockchain.submitTxWithReSign(tx, ctypeCreator, {
           resolveOn: IS_IN_BLOCK,
         })
       )

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -5,11 +5,9 @@
  */
 
 import { Identity } from '..'
-import {
+import Blockchain, {
   IS_IN_BLOCK,
-  IS_READY,
   IBlockchainApi,
-  submitSignedTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import CType from '../ctype/CType'
@@ -50,7 +48,11 @@ describe('When there is an CtypeCreator and a verifier', () => {
       Identity.generateMnemonic()
     )
     await expect(
-      ctype.store(bobbyBroke).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+      ctype
+        .store(bobbyBroke)
+        .then((tx) =>
+          Blockchain.submitSignedTx(bobbyBroke, tx, { resolveOn: IS_IN_BLOCK })
+        )
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)
@@ -59,7 +61,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
     const ctype = makeCType()
     await ctype
       .store(ctypeCreator)
-      .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+      .then((tx) =>
+        Blockchain.submitSignedTx(ctypeCreator, tx, { resolveOn: IS_IN_BLOCK })
+      )
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
       expect(ctype.verifyStored()).resolves.toBeTruthy(),
@@ -70,9 +74,17 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, IS_READY))
+    await ctype
+      .store(ctypeCreator)
+      .then((tx) =>
+        Blockchain.submitSignedTx(ctypeCreator, tx, { resolveOn: IS_IN_BLOCK })
+      )
     await expect(
-      ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+      ctype.store(ctypeCreator).then((tx) =>
+        Blockchain.submitSignedTx(ctypeCreator, tx, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
     ).rejects.toThrowError(ERROR_CTYPE_ALREADY_EXISTS)
     // console.log('Triggered error on re-submit')
     await expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address)

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -51,7 +51,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
       ctype
         .store(bobbyBroke)
         .then((tx) =>
-          Blockchain.submitSignedTx(bobbyBroke, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, bobbyBroke, { resolveOn: IS_IN_BLOCK })
         )
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
@@ -62,7 +62,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     await ctype
       .store(ctypeCreator)
       .then((tx) =>
-        Blockchain.submitSignedTx(ctypeCreator, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, ctypeCreator, { resolveOn: IS_IN_BLOCK })
       )
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
@@ -77,11 +77,11 @@ describe('When there is an CtypeCreator and a verifier', () => {
     await ctype
       .store(ctypeCreator)
       .then((tx) =>
-        Blockchain.submitSignedTx(ctypeCreator, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, ctypeCreator, { resolveOn: IS_IN_BLOCK })
       )
     await expect(
       ctype.store(ctypeCreator).then((tx) =>
-        Blockchain.submitSignedTx(ctypeCreator, tx, {
+        Blockchain.submitSignedTx(tx, ctypeCreator, {
           resolveOn: IS_IN_BLOCK,
         })
       )

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -52,7 +52,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_READY })
+        Blockchain.submitTxWithReSign(tx, attester, { resolveOn: IS_READY })
       )
     }
   }, 30_000)
@@ -66,7 +66,7 @@ describe('when there is an account hierarchy', () => {
     await rootNode
       .store(uncleSam)
       .then((tx) =>
-        Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_READY })
+        Blockchain.submitTxWithReSign(tx, uncleSam, { resolveOn: IS_READY })
       )
     const delegatedNode = new DelegationNode(
       UUID.generate(),
@@ -79,7 +79,7 @@ describe('when there is an account hierarchy', () => {
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
       .then((tx) =>
-        Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitTxWithReSign(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
       )
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
@@ -109,13 +109,13 @@ describe('when there is an account hierarchy', () => {
       await rootNode
         .store(uncleSam)
         .then((tx) =>
-          Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_READY })
+          Blockchain.submitTxWithReSign(tx, uncleSam, { resolveOn: IS_READY })
         )
-      await delegatedNode
-        .store(uncleSam, HashSignedByDelegate)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
-        )
+      await delegatedNode.store(uncleSam, HashSignedByDelegate).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, uncleSam, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -144,11 +144,11 @@ describe('when there is an account hierarchy', () => {
         request,
         attester.getPublicIdentity()
       )
-      await attestation
-        .store(attester)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
-        )
+      await attestation.store(attester).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, attester, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -159,11 +159,11 @@ describe('when there is an account hierarchy', () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
 
       // revoke attestation through root
-      await attClaim.attestation
-        .revoke(uncleSam)
-        .then((tx) =>
-          Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
-        )
+      await attClaim.attestation.revoke(uncleSam).then((tx) =>
+        Blockchain.submitTxWithReSign(tx, uncleSam, {
+          resolveOn: IS_IN_BLOCK,
+        })
+      )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -52,7 +52,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_READY })
+        Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_READY })
       )
     }
   }, 30_000)
@@ -66,7 +66,7 @@ describe('when there is an account hierarchy', () => {
     await rootNode
       .store(uncleSam)
       .then((tx) =>
-        Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_READY })
+        Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_READY })
       )
     const delegatedNode = new DelegationNode(
       UUID.generate(),
@@ -79,7 +79,7 @@ describe('when there is an account hierarchy', () => {
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
       .then((tx) =>
-        Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_IN_BLOCK })
+        Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
       )
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
@@ -109,12 +109,12 @@ describe('when there is an account hierarchy', () => {
       await rootNode
         .store(uncleSam)
         .then((tx) =>
-          Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_READY })
+          Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_READY })
         )
       await delegatedNode
         .store(uncleSam, HashSignedByDelegate)
         .then((tx) =>
-          Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
         )
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
@@ -147,7 +147,7 @@ describe('when there is an account hierarchy', () => {
       await attestation
         .store(attester)
         .then((tx) =>
-          Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, attester, { resolveOn: IS_IN_BLOCK })
         )
 
       const attClaim = await Credential.fromRequestAndAttestation(
@@ -162,7 +162,7 @@ describe('when there is an account hierarchy', () => {
       await attClaim.attestation
         .revoke(uncleSam)
         .then((tx) =>
-          Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_IN_BLOCK })
+          Blockchain.submitSignedTx(tx, uncleSam, { resolveOn: IS_IN_BLOCK })
         )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -7,11 +7,10 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { Identity } from '..'
 import Attestation from '../attestation/Attestation'
-import {
+import Blockchain, {
   IS_IN_BLOCK,
   IS_READY,
   IBlockchainApi,
-  submitSignedTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
@@ -53,7 +52,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        submitSignedTx(tx, IS_READY)
+        Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_READY })
       )
     }
   }, 30_000)
@@ -64,7 +63,11 @@ describe('when there is an account hierarchy', () => {
       DriversLicense.hash,
       uncleSam.address
     )
-    await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, IS_READY))
+    await rootNode
+      .store(uncleSam)
+      .then((tx) =>
+        Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_READY })
+      )
     const delegatedNode = new DelegationNode(
       UUID.generate(),
       rootNode.id,
@@ -75,7 +78,9 @@ describe('when there is an account hierarchy', () => {
     const HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
-      .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+      .then((tx) =>
+        Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_IN_BLOCK })
+      )
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
       expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -101,10 +106,16 @@ describe('when there is an account hierarchy', () => {
         rootNode.id
       )
       HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
-      await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, IS_READY))
+      await rootNode
+        .store(uncleSam)
+        .then((tx) =>
+          Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_READY })
+        )
       await delegatedNode
         .store(uncleSam, HashSignedByDelegate)
-        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+        .then((tx) =>
+          Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_IN_BLOCK })
+        )
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -135,7 +146,9 @@ describe('when there is an account hierarchy', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+        .then((tx) =>
+          Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_IN_BLOCK })
+        )
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -148,7 +161,9 @@ describe('when there is an account hierarchy', () => {
       // revoke attestation through root
       await attClaim.attestation
         .revoke(uncleSam)
-        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
+        .then((tx) =>
+          Blockchain.submitSignedTx(uncleSam, tx, { resolveOn: IS_IN_BLOCK })
+        )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -24,7 +24,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
   const to = await Identity.buildFromMnemonic('')
   await expect(
     makeTransfer(alice, to.address, new BN(1)).then((tx) =>
-      Blockchain.submitSignedTx(tx, alice, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitTxWithReSign(tx, alice, { resolveOn: IS_IN_BLOCK })
     )
   ).rejects.toThrow(ERROR_UNKNOWN)
 }, 30_000)
@@ -41,7 +41,7 @@ it('records an extrinsic error when ctype does not exist', async () => {
   })
   const tx = await attestation.store(alice)
   await expect(
-    Blockchain.submitSignedTx(tx, alice, { resolveOn: IS_IN_BLOCK })
+    Blockchain.submitTxWithReSign(tx, alice, { resolveOn: IS_IN_BLOCK })
   ).rejects.toThrow(ERROR_CTYPE_NOT_FOUND)
 }, 30_000)
 

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -7,7 +7,7 @@
 import BN from 'bn.js'
 import { Attestation, IBlockchainApi } from '..'
 import { makeTransfer } from '../balance/Balance.chain'
-import { IS_IN_BLOCK, submitSignedTx } from '../blockchain/Blockchain'
+import Blockchain, { IS_IN_BLOCK } from '../blockchain/Blockchain'
 import { DEFAULT_WS_ADDRESS, getCached } from '../blockchainApiConnection'
 import { ERROR_CTYPE_NOT_FOUND, ERROR_UNKNOWN } from '../errorhandling'
 import Identity from '../identity'
@@ -24,7 +24,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
   const to = await Identity.buildFromMnemonic('')
   await expect(
     makeTransfer(alice, to.address, new BN(1)).then((tx) =>
-      submitSignedTx(tx, IS_IN_BLOCK)
+      Blockchain.submitSignedTx(alice, tx, { resolveOn: IS_IN_BLOCK })
     )
   ).rejects.toThrow(ERROR_UNKNOWN)
 }, 30_000)
@@ -40,9 +40,9 @@ it('records an extrinsic error when ctype does not exist', async () => {
     revoked: false,
   })
   const tx = await attestation.store(alice)
-  await expect(submitSignedTx(tx, IS_IN_BLOCK)).rejects.toThrow(
-    ERROR_CTYPE_NOT_FOUND
-  )
+  await expect(
+    Blockchain.submitSignedTx(alice, tx, { resolveOn: IS_IN_BLOCK })
+  ).rejects.toThrow(ERROR_CTYPE_NOT_FOUND)
 }, 30_000)
 
 afterAll(() => {

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -24,7 +24,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
   const to = await Identity.buildFromMnemonic('')
   await expect(
     makeTransfer(alice, to.address, new BN(1)).then((tx) =>
-      Blockchain.submitSignedTx(alice, tx, { resolveOn: IS_IN_BLOCK })
+      Blockchain.submitSignedTx(tx, alice, { resolveOn: IS_IN_BLOCK })
     )
   ).rejects.toThrow(ERROR_UNKNOWN)
 }, 30_000)
@@ -41,7 +41,7 @@ it('records an extrinsic error when ctype does not exist', async () => {
   })
   const tx = await attestation.store(alice)
   await expect(
-    Blockchain.submitSignedTx(alice, tx, { resolveOn: IS_IN_BLOCK })
+    Blockchain.submitSignedTx(tx, alice, { resolveOn: IS_IN_BLOCK })
   ).rejects.toThrow(ERROR_CTYPE_NOT_FOUND)
 }, 30_000)
 

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -92,7 +92,7 @@ export async function issueAttestation(
   }
   await attestation
     .store(attester)
-    .then((tx) => Blockchain.submitSignedTx(tx, attester))
+    .then((tx) => Blockchain.submitTxWithReSign(tx, attester))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -1,5 +1,5 @@
 import * as gabi from '@kiltprotocol/portablegabi'
-import Blockchain, { IS_FINALIZED } from '../blockchain/Blockchain'
+import Blockchain from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import { getCached } from '../blockchainApiConnection'
 import {
@@ -92,9 +92,7 @@ export async function issueAttestation(
   }
   await attestation
     .store(attester)
-    .then((tx) =>
-      Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_FINALIZED })
-    )
+    .then((tx) => Blockchain.submitSignedTx(attester, tx))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -1,5 +1,5 @@
 import * as gabi from '@kiltprotocol/portablegabi'
-import { IS_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
+import Blockchain, { IS_FINALIZED } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import { getCached } from '../blockchainApiConnection'
 import {
@@ -92,7 +92,9 @@ export async function issueAttestation(
   }
   await attestation
     .store(attester)
-    .then((tx) => submitSignedTx(tx, IS_FINALIZED))
+    .then((tx) =>
+      Blockchain.submitSignedTx(attester, tx, { resolveOn: IS_FINALIZED })
+    )
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -92,7 +92,7 @@ export async function issueAttestation(
   }
   await attestation
     .store(attester)
-    .then((tx) => Blockchain.submitSignedTx(attester, tx))
+    .then((tx) => Blockchain.submitSignedTx(tx, attester))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -68,7 +68,7 @@ describe('Balance', () => {
       alice,
       bob.address,
       new BN(100)
-    ).then((tx) => Blockchain.submitSignedTx(tx, alice))
+    ).then((tx) => Blockchain.submitTxWithReSign(tx, alice))
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })
@@ -84,7 +84,7 @@ describe('Balance', () => {
       bob.address,
       amount,
       exponent
-    ).then((tx) => Blockchain.submitSignedTx(tx, alice))
+    ).then((tx) => Blockchain.submitTxWithReSign(tx, alice))
     expect(blockchainApi.tx.balances.transfer).toHaveBeenCalledWith(
       bob.address,
       expectedAmount

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -68,7 +68,7 @@ describe('Balance', () => {
       alice,
       bob.address,
       new BN(100)
-    ).then((tx) => Blockchain.submitSignedTx(alice, tx))
+    ).then((tx) => Blockchain.submitSignedTx(tx, alice))
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })
@@ -84,7 +84,7 @@ describe('Balance', () => {
       bob.address,
       amount,
       exponent
-    ).then((tx) => Blockchain.submitSignedTx(alice, tx))
+    ).then((tx) => Blockchain.submitSignedTx(tx, alice))
     expect(blockchainApi.tx.balances.transfer).toHaveBeenCalledWith(
       bob.address,
       expectedAmount

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -9,7 +9,7 @@ import {
   makeTransfer,
 } from './Balance.chain'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
-import { submitSignedTx } from '../blockchain'
+import Blockchain from '../blockchain'
 import BalanceUtils from './Balance.utils'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
@@ -68,7 +68,7 @@ describe('Balance', () => {
       alice,
       bob.address,
       new BN(100)
-    ).then((tx) => submitSignedTx(tx))
+    ).then((tx) => Blockchain.submitSignedTx(alice, tx))
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })
@@ -84,7 +84,7 @@ describe('Balance', () => {
       bob.address,
       amount,
       exponent
-    ).then((tx) => submitSignedTx(tx))
+    ).then((tx) => Blockchain.submitSignedTx(alice, tx))
     expect(blockchainApi.tx.balances.transfer).toHaveBeenCalledWith(
       bob.address,
       expectedAmount

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -41,9 +41,9 @@ describe('queries', () => {
     expect(unsubscribe()).toBeUndefined()
   })
 })
-describe('Blockchain', async () => {
+describe('Blockchain', () => {
+  const alice = Identity.buildFromURI('//Alice')
   it('should increment nonce for account', async () => {
-    const alice = Identity.buildFromURI('//Alice')
     const chain = new Blockchain(mockedApi)
     // eslint-disable-next-line dot-notation
     const initialNonce = await chain['retrieveNonce'](alice.address)
@@ -54,7 +54,6 @@ describe('Blockchain', async () => {
   })
 
   it('should return incrementing nonces', async () => {
-    const alice = Identity.buildFromURI('//Alice')
     const promisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain(mockedApi)
     for (let i = 0; i < 25; i += 1) {
@@ -68,7 +67,6 @@ describe('Blockchain', async () => {
   })
 
   it('should return separate incrementing nonces per account', async () => {
-    const alice = Identity.buildFromURI('//Alice')
     const bob = Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const bobPromisedNonces: Array<Promise<Index>> = []

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -98,20 +98,6 @@ describe('queries', () => {
       expect(value.toNumber()).toEqual(new UInt(index).toNumber())
     })
   })
-
-  // this tests logic that was changed to have chain connectivity
-  // as the map entry is only deleted after chain response
-  xit('should delete map entry after completion of queue', async () => {
-    const alice = Identity.buildFromURI('//Alice')
-    const alicePromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(mockedApi)
-    for (let i = 0; i < 12; i += 1) {
-      alicePromisedNonces.push(chain.getNonce(alice.address))
-    }
-    Promise.all(alicePromisedNonces).then(() => {
-      expect(chain.accountNonces.has(alice.address)).toBeFalsy()
-    })
-  })
 })
 const errorSetupApi = ({
   query: {

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -42,6 +42,18 @@ describe('queries', () => {
   })
 })
 describe('Blockchain', async () => {
+  it('should increment nonce for account', async () => {
+    const chain = new Blockchain({} as ApiPromise)
+    const alice = Identity.buildFromURI('//Alice')
+    const initialNonce = new UInt(Math.random() * 10 + 1) as Index
+    chain.accountNonces.set(alice.address, initialNonce)
+    // eslint-disable-next-line dot-notation
+    const incrNonce = await chain['retrieveNonce'](alice.address)
+    expect(incrNonce.toNumber()).toEqual(initialNonce.toNumber())
+    expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
+      initialNonce.toNumber() + 1
+    )
+  })
   it('should return incrementing nonces', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const promisedNonces: Array<Promise<Index>> = []

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -19,6 +19,19 @@ const mockedApi = ({
   },
 } as any) as ApiPromise
 
+const errorSetupApi = ({
+  query: {
+    system: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      accountNonce: () => {
+        return new Promise((res, rej) => {
+          rej(new Error('Test Nonce Retrieval Error handling'))
+        })
+      },
+    },
+  },
+} as any) as ApiPromise
+
 describe('queries', () => {
   const alice = Identity.buildFromURI('//Alice')
 
@@ -97,6 +110,24 @@ describe('queries', () => {
       expect(value.toNumber()).toEqual(new UInt(index).toNumber())
     })
   })
+
+  it('should handle error when chain returns error', async () => {
+    const chain = new Blockchain(errorSetupApi)
+    // eslint-disable-next-line dot-notation
+    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow(
+      'Test Nonce Retrieval Error handling'
+    )
+  })
+
+  // it('should handle errors when accessing account nonces', async () => {
+  //   // For this test to run, TS diagnostics have to be disabled in [jest-config].globals.ts-jest.diagnostics
+  //   const chain = new Blockchain(mockedApi)
+  //   chain.accountNonces.set(alice.address, undefined)
+  //   // eslint-disable-next-line dot-notation
+  //   await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow(
+  //     `Nonce Retrieval Failed for : ${alice.address}`
+  //   )
+  // })
 })
 const errorSetupApi = ({
   query: {

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -97,6 +97,18 @@ describe('queries', () => {
       expect(value.toNumber()).toEqual(new UInt(index).toNumber())
     })
   })
+
+  it('should delete map entry after queue is done', async () => {
+    const alice = Identity.buildFromURI('//Alice')
+    const alicePromisedNonces: Array<Promise<Index>> = []
+    const chain = new Blockchain(mockedApi)
+    for (let i = 0; i < 12; i += 1) {
+      alicePromisedNonces.push(chain.getNonce(alice.address))
+    }
+    Promise.all(alicePromisedNonces).then(v => {
+      expect(!chain.accountNonces.has(alice.address)).toBeTruthy()
+    })
+  })
 })
 const errorSetupApi = ({
   query: {

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -56,7 +56,10 @@ describe('nonce retrieval logic', () => {
       },
     },
   } as any) as ApiPromise
-
+  const dispatchTransactions = async (address: string): Promise<Index> => {
+    const chain = await getCached()
+    return chain.getNonce(address)
+  }
   it('should increment nonce for account', async () => {
     const chain = new Blockchain((await getCached()).api)
 
@@ -67,7 +70,17 @@ describe('nonce retrieval logic', () => {
       initialNonce.toNumber() + 1
     )
   })
-
+  it('should return nonces from different closures', async () => {
+    const promisedNonces: Array<Promise<Index>> = []
+    for (let i = 0; i < 25; i += 1) {
+      promisedNonces.push(dispatchTransactions(alice.address))
+    }
+    const nonces = await Promise.all(promisedNonces)
+    expect(nonces.length).toEqual(25)
+    nonces.forEach((value, index) => {
+      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+    })
+  })
   it('should return incrementing nonces', async () => {
     const promisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain((await getCached()).api)

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -1,10 +1,21 @@
 /* eslint-disable dot-notation */
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
+import { SubmittableResult } from '@polkadot/api/submittable'
 import { Text } from '@polkadot/types'
-import { Index } from '@polkadot/types/interfaces/types'
+import { Index, SignerPayload } from '@polkadot/types/interfaces/types'
+import { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
 import getCached from '../blockchainApiConnection/BlockchainApiConnection'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
-import Blockchain from './Blockchain'
+import Blockchain, {
+  EXTRINSIC_FAILED,
+  IS_ERROR,
+  IS_FINALIZED,
+  IS_USURPED,
+  parseSubscriptionOptions,
+  ResultEvaluator,
+  submitSignedTx,
+} from './Blockchain'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -40,81 +51,258 @@ describe('queries', () => {
     expect(unsubscribe()).toBeUndefined()
   })
 })
-describe('nonce retrieval logic', () => {
+
+describe('Tx logic', () => {
   let alice: Identity
+  let bob: Identity
   const api = require('../blockchainApiConnection/BlockchainApiConnection')
     .__mocked_api
-  const dispatchTransactions = async (address: string): Promise<Index> => {
+  const setDefault = require('../blockchainApiConnection/BlockchainApiConnection')
+    .__setDefaultResult
+  const dispatchNonceRetrieval = async (address: string): Promise<Index> => {
     const chain = await getCached()
     return chain.getNonce(address)
   }
   beforeAll(async () => {
     alice = await Identity.buildFromURI('//Alice')
+    bob = await Identity.buildFromURI('//Bob')
   })
-  it('should increment nonce for account', async () => {
-    const chain = new Blockchain(api)
+  describe('getNonce', () => {
+    it('should increment nonce for account', async () => {
+      const chain = new Blockchain(api)
+      const initialNonce = await chain.getNonce(alice.address)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(chain['accountNonces'].get(alice.address)!.toNumber()).toEqual(
+        initialNonce.toNumber() + 1
+      )
+    })
+    it('should return incrementing nonces', async () => {
+      const promisedNonces: Array<Promise<Index>> = []
+      const chain = new Blockchain(api)
+      for (let i = 0; i < 25; i += 1) {
+        promisedNonces.push(chain.getNonce(alice.address))
+      }
+      const nonces = await Promise.all(promisedNonces)
+      expect(nonces.length).toEqual(25)
+      nonces.forEach((value, index) => {
+        expect(value.toNumber()).toEqual(index)
+      })
+    })
+    it('should return nonces from different closures', async () => {
+      const promisedNonces: Array<Promise<Index>> = []
+      for (let i = 0; i < 10; i += 1) {
+        promisedNonces.push(dispatchNonceRetrieval(alice.address))
+        promisedNonces.push(dispatchNonceRetrieval(alice.address))
+      }
+      const nonces = await Promise.all(promisedNonces)
+      expect(nonces.length).toEqual(20)
+      nonces.forEach((value, index) => {
+        expect(value.toNumber()).toEqual(index)
+      })
+    })
 
-    const initialNonce = await chain['retrieveNonce'](alice.address)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(chain['accountNonces'].get(alice.address)!.toNumber()).toEqual(
-      initialNonce.toNumber() + 1
+    it('should return separate incrementing nonces per account', async () => {
+      const alicePromisedNonces: Array<Promise<Index>> = []
+      const bobPromisedNonces: Array<Promise<Index>> = []
+      const chain = new Blockchain(api)
+      for (let i = 0; i < 50; i += 1) {
+        if (i % 2 === 0) {
+          alicePromisedNonces.push(chain.getNonce(alice.address))
+        } else bobPromisedNonces.push(chain.getNonce(bob.address))
+      }
+      const aliceNonces = await Promise.all(alicePromisedNonces)
+      const bobNonces = await Promise.all(bobPromisedNonces)
+      expect(aliceNonces.length).toEqual(25)
+      expect(bobNonces.length).toEqual(25)
+      aliceNonces.forEach((value, index) => {
+        expect(value.toNumber()).toEqual(index)
+      })
+      bobNonces.forEach((value, index) => {
+        expect(value.toNumber()).toEqual(index)
+      })
+    })
+
+    it('should return the highest read Nonce (mapped Index 1st read)', async () => {
+      const chain = new Blockchain(api)
+      const indexMap = jest
+        .spyOn(chain['accountNonces'], 'get')
+        .mockReturnValue(chain.api.registry.createType('Index', '1191220'))
+      const nonce = await chain.getNonce(alice.address, true)
+
+      expect(nonce.toNumber()).toEqual(1191220)
+      indexMap.mockRestore()
+    })
+
+    it('should return the highest read Nonce (mapped Index 2nd read)', async () => {
+      const chain = new Blockchain(api)
+      const indexMap = jest
+        .spyOn(chain['accountNonces'], 'get')
+        .mockReturnValue(chain.api.registry.createType('Index', '11912201'))
+        .mockReturnValueOnce(undefined)
+      const nonce = await chain.getNonce(alice.address, true)
+
+      expect(nonce.toNumber()).toEqual(11912201)
+      indexMap.mockRestore()
+    })
+    it('should return the highest read Nonce (chain Index >= secondQuery)', async () => {
+      const chain = new Blockchain(api)
+      api.rpc.system.accountNextIndex.mockResolvedValue(
+        chain.api.registry.createType('Index', '11912202')
+      )
+
+      const indexMap = jest
+        .spyOn(chain['accountNonces'], 'get')
+        .mockReturnValue(chain.api.registry.createType('Index', '11912201'))
+        .mockReturnValueOnce(undefined)
+      const nonce = await chain.getNonce(alice.address, true)
+
+      expect(nonce.toNumber()).toEqual(11912202)
+      indexMap.mockRestore()
+    })
+    it('should return the highest read Nonce (chain Index, !secondQuery)', async () => {
+      const chain = new Blockchain(api)
+      api.rpc.system.accountNextIndex.mockResolvedValue(
+        chain.api.registry.createType('Index', '11912203')
+      )
+
+      const indexMap = jest
+        .spyOn(chain['accountNonces'], 'get')
+        .mockReturnValue(undefined)
+      const nonce = await chain.getNonce(alice.address, true)
+
+      expect(nonce.toNumber()).toEqual(11912203)
+      indexMap.mockRestore()
+    })
+    it('should handle error when chain returns error', async () => {
+      api.rpc.system.accountNextIndex.mockRejectedValue('Reason')
+      const chain = new Blockchain(api)
+      await expect(chain.getNonce(alice.address)).rejects.toThrow(
+        Error(`Chain failed to retrieve nonce for : ${alice.address}`)
+      )
+    })
+    it('should reset the mapped index', async () => {
+      const chain = new Blockchain(api)
+      chain['accountNonces'].set(
+        alice.address,
+        chain.api.registry.createType('Index', 100)
+      )
+      api.rpc.system.accountNextIndex.mockResolvedValue(
+        chain.api.registry.createType('Index', 0)
+      )
+
+      const nonce = await chain.getNonce(alice.address, true)
+      expect(nonce.toNumber()).toEqual(0)
+    })
+  })
+  describe('reSignTx', () => {
+    const submittable: SubmittableExtrinsic = ({
+      signature: {
+        toHuman: jest.fn(),
+      },
+      addSignature: jest.fn(),
+      nonce: { toHuman: jest.fn() },
+      method: { data: 'unchanged', toHex: jest.fn() },
+    } as unknown) as SubmittableExtrinsic
+    it('fetches updated Nonce and applies updated signature to Extrinsic', async () => {
+      api.createType = jest
+        .fn()
+        .mockReturnValue({
+          sign: jest.fn().mockReturnValue({ signature: 'signature' }),
+        })
+        .mockReturnValueOnce(({
+          toPayload: jest
+            .fn()
+            .mockReturnValue(({} as unknown) as SignerPayloadJSON),
+        } as unknown) as SignerPayload)
+      const chain = new Blockchain(api)
+      const getNonceSpy = jest
+        .spyOn(chain, 'getNonce')
+        .mockResolvedValue(chain.api.registry.createType('Index', 1))
+      const reSigned = await chain.reSignTx(alice, submittable)
+      expect(reSigned.method.data).toEqual(submittable.method.data)
+      expect(getNonceSpy).toHaveBeenCalledWith(alice.address, true)
+      expect(submittable.addSignature).toHaveBeenCalledWith(
+        alice.address,
+        expect.anything(),
+        expect.anything()
+      )
+    })
+  })
+  describe('submitSignedTx', () => {
+    it('catches ERROR_TRANSACTION_USURPED and rejects Promise with Error Reason "Recoverable"', async () => {
+      setDefault({ isUsurped: true })
+      const chain = new Blockchain(api)
+      const tx = chain.api.tx.balances.transfer(bob.address, 100)
+      tx.signAsync(alice.signKeyringPair)
+      await expect(
+        submitSignedTx(tx, parseSubscriptionOptions())
+      ).rejects.toThrow(Error('Recoverable'))
+    }, 20_000)
+  })
+})
+describe('parseSubscriptionOptions', () => {
+  it('takes incomplete SubscriptionPromiseOptions and sets default values where needed', async () => {
+    const testfunction: ResultEvaluator = (result) => true
+    expect(JSON.stringify(parseSubscriptionOptions())).toEqual(
+      JSON.stringify({
+        resolveOn: IS_FINALIZED,
+        rejectOn: (result: SubmittableResult) =>
+          IS_ERROR(result) || EXTRINSIC_FAILED(result) || IS_USURPED(result),
+        timeout: undefined,
+      })
     )
-  })
-  it('should return nonces from different closures', async () => {
-    const promisedNonces: Array<Promise<Index>> = []
-    for (let i = 0; i < 25; i += 1) {
-      promisedNonces.push(dispatchTransactions(alice.address))
-    }
-    const nonces = await Promise.all(promisedNonces)
-    expect(nonces.length).toEqual(25)
-    nonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(index)
-    })
-  })
-  it('should return incrementing nonces', async () => {
-    const promisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(api)
-    for (let i = 0; i < 25; i += 1) {
-      promisedNonces.push(chain.getNonce(alice.address))
-    }
-    const nonces = await Promise.all(promisedNonces)
-    expect(nonces.length).toEqual(25)
-    nonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(index)
-    })
-  })
-
-  it('should return separate incrementing nonces per account', async () => {
-    const bob = await Identity.buildFromURI('//Bob')
-    const alicePromisedNonces: Array<Promise<Index>> = []
-    const bobPromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(api)
-    for (let i = 0; i < 50; i += 1) {
-      if (i % 2 === 0) {
-        alicePromisedNonces.push(chain.getNonce(alice.address))
-      } else bobPromisedNonces.push(chain.getNonce(bob.address))
-    }
-    const aliceNonces = await Promise.all(alicePromisedNonces)
-    const bobNonces = await Promise.all(bobPromisedNonces)
-    expect(aliceNonces.length).toEqual(25)
-    expect(bobNonces.length).toEqual(25)
-    aliceNonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(index)
-    })
-    bobNonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(index)
-    })
-  })
-
-  it('should handle error when chain returns error', async () => {
-    api.rpc.system.accountNextIndex.mockReturnValue(() => Promise.reject())
-    const chain = new Blockchain(api)
-    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow()
-  })
-
-  it('should handle errors when accessing account nonces', async () => {
-    const chain = new Blockchain(api)
-    chain['accountNonces'].set(alice.address, (undefined as unknown) as Index)
-    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow()
+    expect(
+      JSON.stringify(parseSubscriptionOptions({ resolveOn: testfunction }))
+    ).toEqual(
+      JSON.stringify({
+        resolveOn: testfunction,
+        rejectOn: (result: SubmittableResult) =>
+          IS_ERROR(result) || EXTRINSIC_FAILED(result) || IS_USURPED(result),
+        timeout: undefined,
+      })
+    )
+    expect(
+      JSON.stringify(
+        parseSubscriptionOptions({
+          resolveOn: testfunction,
+          rejectOn: testfunction,
+        })
+      )
+    ).toEqual(
+      JSON.stringify({
+        resolveOn: testfunction,
+        rejectOn: testfunction,
+        timeout: undefined,
+      })
+    )
+    expect(
+      JSON.stringify(
+        parseSubscriptionOptions({
+          resolveOn: testfunction,
+          timeout: 10,
+        })
+      )
+    ).toEqual(
+      JSON.stringify({
+        resolveOn: testfunction,
+        rejectOn: (result: SubmittableResult) =>
+          IS_ERROR(result) || EXTRINSIC_FAILED(result) || IS_USURPED(result),
+        timeout: 10,
+      })
+    )
+    expect(
+      JSON.stringify(
+        parseSubscriptionOptions({
+          timeout: 10,
+        })
+      )
+    ).toEqual(
+      JSON.stringify({
+        resolveOn: IS_FINALIZED,
+        rejectOn: (result: SubmittableResult) =>
+          IS_ERROR(result) || EXTRINSIC_FAILED(result) || IS_USURPED(result),
+        timeout: 10,
+      })
+    )
   })
 })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -56,6 +56,7 @@ describe('queries', () => {
     const chain = new Blockchain(mockedApi)
     // eslint-disable-next-line dot-notation
     const initialNonce = await chain['retrieveNonce'](alice.address)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
       initialNonce.toNumber() + 1
     )
@@ -98,7 +99,7 @@ describe('queries', () => {
     })
   })
 
-  it('should delete map entry after queue is done', async () => {
+  it('should delete map entry after completion of queue', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain(mockedApi)

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -40,6 +40,18 @@ describe('queries', () => {
     expect(unsubscribe()).toBeUndefined()
   })
 
+  it('should increment nonce for account', async () => {
+    const chain = new Blockchain({} as ApiPromise)
+    const alice = Identity.buildFromURI('//Alice')
+    const initialNonce = new UInt(Math.random() * 10 + 1) as Index
+    chain.accountNonces.set(alice.address, initialNonce)
+    // eslint-disable-next-line dot-notation
+    const incrNonce = await chain['retrieveNonce'](alice.address)
+    expect(incrNonce.toNumber()).toEqual(initialNonce.toNumber())
+    expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
+      initialNonce.toNumber() + 1
+    )
+  })
   it('should return incrementing nonces', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const promisedNonces: Array<Promise<Index>> = []

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -43,22 +43,19 @@ describe('queries', () => {
 })
 describe('Blockchain', async () => {
   it('should increment nonce for account', async () => {
-    const chain = new Blockchain({} as ApiPromise)
     const alice = Identity.buildFromURI('//Alice')
-    const initialNonce = new UInt(Math.random() * 10 + 1) as Index
-    chain.accountNonces.set(alice.address, initialNonce)
+    const chain = new Blockchain(mockedApi)
     // eslint-disable-next-line dot-notation
-    const incrNonce = await chain['retrieveNonce'](alice.address)
-    expect(incrNonce.toNumber()).toEqual(initialNonce.toNumber())
+    const initialNonce = await chain['retrieveNonce'](alice.address)
     expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
       initialNonce.toNumber() + 1
     )
   })
+
   it('should return incrementing nonces', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const promisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain({} as ApiPromise)
-    chain.accountNonces.set(alice.address, new UInt(0) as Index)
+    const chain = new Blockchain(mockedApi)
     for (let i = 0; i < 25; i += 1) {
       promisedNonces.push(chain.getNonce(alice.address))
     }
@@ -74,17 +71,14 @@ describe('Blockchain', async () => {
     const bob = Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const bobPromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain({} as ApiPromise)
-    chain.accountNonces.set(alice.address, new UInt(0) as Index)
-    chain.accountNonces.set(bob.address, new UInt(0) as Index)
+    const chain = new Blockchain(mockedApi)
     for (let i = 0; i < 50; i += 1) {
       if (i % 2 === 0) {
         alicePromisedNonces.push(chain.getNonce(alice.address))
       } else bobPromisedNonces.push(chain.getNonce(bob.address))
     }
     const aliceNonces = await Promise.all(alicePromisedNonces)
-    const bobNonces = await Promise.all(alicePromisedNonces)
-
+    const bobNonces = await Promise.all(bobPromisedNonces)
     expect(aliceNonces.length).toEqual(25)
     expect(bobNonces.length).toEqual(25)
     aliceNonces.forEach((value, index) => {

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -12,7 +12,7 @@ const mockedApi = ({
   query: {
     system: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      accountNonce: (address: any) => {
+      accountNonce: () => {
         return new UInt(0) as Index
       },
     },
@@ -105,7 +105,7 @@ describe('queries', () => {
     for (let i = 0; i < 12; i += 1) {
       alicePromisedNonces.push(chain.getNonce(alice.address))
     }
-    Promise.all(alicePromisedNonces).then(v => {
+    Promise.all(alicePromisedNonces).then(() => {
       expect(!chain.accountNonces.has(alice.address)).toBeTruthy()
     })
   })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-disable dot-notation */
-import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { SubmittableResult } from '@polkadot/api/submittable'
 import { Text } from '@polkadot/types'
 import { SignerPayload } from '@polkadot/types/interfaces/types'
 import { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
 import BN from 'bn.js'
+import { SubmittableExtrinsic } from '..'
 import getCached from '../blockchainApiConnection/BlockchainApiConnection'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import { ERROR_TRANSACTION_RECOVERABLE } from '../errorhandling/SDKErrors'
@@ -179,6 +179,14 @@ describe('Tx logic', () => {
     })
   })
   describe('reSignTx', () => {
+    const submittable: SubmittableExtrinsic = ({
+      signature: {
+        toHuman: jest.fn(),
+      },
+      addSignature: jest.fn(),
+      nonce: { toHuman: jest.fn() },
+      method: { data: 'unchanged', toHex: jest.fn() },
+    } as unknown) as SubmittableExtrinsic
     it('fetches updated Nonce and applies updated signature to Extrinsic', async () => {
       api.createType = jest
         .fn()
@@ -191,10 +199,9 @@ describe('Tx logic', () => {
             .mockReturnValue(({} as unknown) as SignerPayloadJSON),
         } as unknown) as SignerPayload)
       const chain = new Blockchain(api)
-      const submittable = chain.api.tx.balances.transfer(bob.address, 100)
       const getNonceSpy = jest
         .spyOn(chain, 'getNonce')
-        .mockResolvedValue(chain.api.registry.createType('Index', 1))
+        .mockResolvedValue(new BN(1))
       const deleteEntrySpy = jest.spyOn(chain['accountNonces'], 'delete')
       const reSigned = await chain.reSignTx(alice, submittable)
       expect(deleteEntrySpy).toHaveBeenCalledWith(alice.address)

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -47,6 +47,7 @@ describe('Blockchain', async () => {
     const chain = new Blockchain(mockedApi)
     // eslint-disable-next-line dot-notation
     const initialNonce = await chain['retrieveNonce'](alice.address)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
       initialNonce.toNumber() + 1
     )
@@ -89,7 +90,7 @@ describe('Blockchain', async () => {
     })
   })
 
-  it('should delete map entry after queue is done', async () => {
+  it('should delete map entry after completion of queue', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain(mockedApi)

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -8,6 +8,17 @@ import Blockchain from './Blockchain'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
+const mockedApi = ({
+  query: {
+    system: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      accountNonce: (address: any) => {
+        return new UInt(0) as Index
+      },
+    },
+  },
+} as any) as ApiPromise
+
 describe('queries', () => {
   beforeAll(() => {
     const api = require('../blockchainApiConnection/BlockchainApiConnection')
@@ -41,22 +52,19 @@ describe('queries', () => {
   })
 
   it('should increment nonce for account', async () => {
-    const chain = new Blockchain({} as ApiPromise)
     const alice = Identity.buildFromURI('//Alice')
-    const initialNonce = new UInt(Math.random() * 10 + 1) as Index
-    chain.accountNonces.set(alice.address, initialNonce)
+    const chain = new Blockchain(mockedApi)
     // eslint-disable-next-line dot-notation
-    const incrNonce = await chain['retrieveNonce'](alice.address)
-    expect(incrNonce.toNumber()).toEqual(initialNonce.toNumber())
+    const initialNonce = await chain['retrieveNonce'](alice.address)
     expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
       initialNonce.toNumber() + 1
     )
   })
+
   it('should return incrementing nonces', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const promisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain({} as ApiPromise)
-    chain.accountNonces.set(alice.address, new UInt(0) as Index)
+    const chain = new Blockchain(mockedApi)
     for (let i = 0; i < 25; i += 1) {
       promisedNonces.push(chain.getNonce(alice.address))
     }
@@ -72,17 +80,14 @@ describe('queries', () => {
     const bob = Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const bobPromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain({} as ApiPromise)
-    chain.accountNonces.set(alice.address, new UInt(0) as Index)
-    chain.accountNonces.set(bob.address, new UInt(0) as Index)
+    const chain = new Blockchain(mockedApi)
     for (let i = 0; i < 50; i += 1) {
       if (i % 2 === 0) {
         alicePromisedNonces.push(chain.getNonce(alice.address))
       } else bobPromisedNonces.push(chain.getNonce(bob.address))
     }
     const aliceNonces = await Promise.all(alicePromisedNonces)
-    const bobNonces = await Promise.all(alicePromisedNonces)
-
+    const bobNonces = await Promise.all(bobPromisedNonces)
     expect(aliceNonces.length).toEqual(25)
     expect(bobNonces.length).toEqual(25)
     aliceNonces.forEach((value, index) => {

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -96,7 +96,7 @@ describe('Blockchain', async () => {
     for (let i = 0; i < 12; i += 1) {
       alicePromisedNonces.push(chain.getNonce(alice.address))
     }
-    Promise.all(alicePromisedNonces).then(v => {
+    Promise.all(alicePromisedNonces).then(() => {
       expect(!chain.accountNonces.has(alice.address)).toBeTruthy()
     })
   })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -233,7 +233,33 @@ describe('Tx logic', () => {
       const chain = new Blockchain(api)
       const tx = chain.api.tx.balances.transfer(bob.address, 100)
       tx.signAsync(alice.signKeyringPair)
-      tx.send = jest.fn().mockRejectedValue(Error('Priority'))
+      tx.send = jest
+        .fn()
+        .mockRejectedValue(Error('1014: Priority is too low: '))
+      await expect(
+        submitSignedTx(tx, parseSubscriptionOptions())
+      ).rejects.toThrow(Error('Recoverable'))
+    }, 20_000)
+    it('catches Already Imported error and rejects Promise with Error Reason "Recoverable"', async () => {
+      setDefault()
+      const chain = new Blockchain(api)
+      const tx = chain.api.tx.balances.transfer(bob.address, 100)
+      tx.signAsync(alice.signKeyringPair)
+      tx.send = jest.fn().mockRejectedValue(Error('Transaction Already'))
+      await expect(
+        submitSignedTx(tx, parseSubscriptionOptions())
+      ).rejects.toThrow(Error('Recoverable'))
+    }, 20_000)
+    it('catches Outdated/Stale Tx error and rejects Promise with Error Reason "Recoverable"', async () => {
+      setDefault()
+      const chain = new Blockchain(api)
+      const tx = chain.api.tx.balances.transfer(bob.address, 100)
+      tx.signAsync(alice.signKeyringPair)
+      tx.send = jest
+        .fn()
+        .mockRejectedValue(
+          Error('1010: Invalid Transaction: Transaction is outdated')
+        )
       await expect(
         submitSignedTx(tx, parseSubscriptionOptions())
       ).rejects.toThrow(Error('Recoverable'))

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -3,7 +3,6 @@ import { Index } from '@polkadot/types/interfaces/types'
 import { ApiPromise } from '@polkadot/api'
 import getCached from '../blockchainApiConnection/BlockchainApiConnection'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
-
 import Identity from '../identity/Identity'
 import Blockchain from './Blockchain'
 
@@ -39,6 +38,47 @@ describe('queries', () => {
     const unsubscribe = await blockchain.listenToBlocks(listener)
     expect(listener).toBeCalledWith('mockHead')
     expect(unsubscribe()).toBeUndefined()
+  })
+
+  it('should return incrementing nonces', async () => {
+    const alice = Identity.buildFromURI('//Alice')
+    const promisedNonces: Array<Promise<Index>> = []
+    const chain = new Blockchain({} as ApiPromise)
+    chain.accountNonces.set(alice.address, new UInt(0) as Index)
+    for (let i = 0; i < 25; i += 1) {
+      promisedNonces.push(chain.getNonce(alice.address))
+    }
+    const nonces = await Promise.all(promisedNonces)
+    expect(nonces.length).toEqual(25)
+    nonces.forEach((value, index) => {
+      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+    })
+  })
+
+  it('should return separate incrementing nonces per account', async () => {
+    const alice = Identity.buildFromURI('//Alice')
+    const bob = Identity.buildFromURI('//Bob')
+    const alicePromisedNonces: Array<Promise<Index>> = []
+    const bobPromisedNonces: Array<Promise<Index>> = []
+    const chain = new Blockchain({} as ApiPromise)
+    chain.accountNonces.set(alice.address, new UInt(0) as Index)
+    chain.accountNonces.set(bob.address, new UInt(0) as Index)
+    for (let i = 0; i < 50; i += 1) {
+      if (i % 2 === 0) {
+        alicePromisedNonces.push(chain.getNonce(alice.address))
+      } else bobPromisedNonces.push(chain.getNonce(bob.address))
+    }
+    const aliceNonces = await Promise.all(alicePromisedNonces)
+    const bobNonces = await Promise.all(alicePromisedNonces)
+
+    expect(aliceNonces.length).toEqual(25)
+    expect(bobNonces.length).toEqual(25)
+    aliceNonces.forEach((value, index) => {
+      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+    })
+    bobNonces.forEach((value, index) => {
+      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+    })
   })
 })
 const errorSetupApi = ({

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -67,7 +67,7 @@ describe('Blockchain', async () => {
     })
   })
 
-  it('should return seperate incrementing nonces per account', async () => {
+  it('should return separate incrementing nonces per account', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const bob = Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
@@ -90,7 +90,9 @@ describe('Blockchain', async () => {
     })
   })
 
-  it('should delete map entry after completion of queue', async () => {
+  // this tests logic that was changed to have chain connectivity
+  // as the map entry is only deleted after chain response
+  xit('should delete map entry after completion of queue', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain(mockedApi)
@@ -98,7 +100,7 @@ describe('Blockchain', async () => {
       alicePromisedNonces.push(chain.getNonce(alice.address))
     }
     Promise.all(alicePromisedNonces).then(() => {
-      expect(!chain.accountNonces.has(alice.address)).toBeTruthy()
+      expect(chain.accountNonces.has(alice.address)).toBeFalsy()
     })
   })
 })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -5,19 +5,9 @@ import getCached from '../blockchainApiConnection/BlockchainApiConnection'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import Blockchain from './Blockchain'
+import getCached from '../blockchainApiConnection'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
-
-const mockedApi = ({
-  query: {
-    system: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      accountNonce: () => {
-        return new UInt(0) as Index
-      },
-    },
-  },
-} as any) as ApiPromise
 
 const errorSetupApi = ({
   query: {
@@ -67,7 +57,8 @@ describe('queries', () => {
   })
 
   it('should increment nonce for account', async () => {
-    const chain = new Blockchain(mockedApi)
+    const blockchain = await getCached()
+    const chain = new Blockchain(blockchain.api)
     // eslint-disable-next-line dot-notation
     const initialNonce = await chain['retrieveNonce'](alice.address)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -78,7 +69,8 @@ describe('queries', () => {
 
   it('should return incrementing nonces', async () => {
     const promisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(mockedApi)
+    const blockchain = await getCached()
+    const chain = new Blockchain(blockchain.api)
     for (let i = 0; i < 25; i += 1) {
       promisedNonces.push(chain.getNonce(alice.address))
     }
@@ -93,7 +85,8 @@ describe('queries', () => {
     const bob = Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const bobPromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(mockedApi)
+    const blockchain = await getCached()
+    const chain = new Blockchain(blockchain.api)
     for (let i = 0; i < 50; i += 1) {
       if (i % 2 === 0) {
         alicePromisedNonces.push(chain.getNonce(alice.address))

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -69,6 +69,7 @@ describe('Tx logic', () => {
     alice = await Identity.buildFromURI('//Alice')
     bob = await Identity.buildFromURI('//Bob')
   })
+
   describe('getNonce', () => {
     it('should increment nonce for account', async () => {
       const chain = new Blockchain(api)
@@ -78,6 +79,7 @@ describe('Tx logic', () => {
         initialNonce.toNumber() + 1
       )
     })
+
     it('should return incrementing nonces', async () => {
       const promisedNonces: Array<Promise<BN>> = []
       const chain = new Blockchain(api)
@@ -90,6 +92,7 @@ describe('Tx logic', () => {
         expect(value.toNumber()).toEqual(index)
       })
     })
+
     it('should return nonces from different closures', async () => {
       const promisedNonces: Array<Promise<BN>> = []
       for (let i = 0; i < 10; i += 1) {
@@ -102,6 +105,7 @@ describe('Tx logic', () => {
         expect(value.toNumber()).toEqual(index)
       })
     })
+
     it('should return separate incrementing nonces per account', async () => {
       const alicePromisedNonces: Array<Promise<BN>> = []
       const bobPromisedNonces: Array<Promise<BN>> = []
@@ -122,6 +126,7 @@ describe('Tx logic', () => {
         expect(value.toNumber()).toEqual(index)
       })
     })
+
     it('should return the highest read Nonce (mapped Index 1st read)', async () => {
       const chain = new Blockchain(api)
       const indexMap = jest
@@ -132,6 +137,7 @@ describe('Tx logic', () => {
       expect(nonce.toNumber()).toEqual(1191220)
       indexMap.mockRestore()
     })
+
     it('should return the highest read Nonce (mapped Index 2nd read)', async () => {
       const chain = new Blockchain(api)
       const indexMap = jest
@@ -143,6 +149,7 @@ describe('Tx logic', () => {
       expect(nonce.toNumber()).toEqual(11912201)
       indexMap.mockRestore()
     })
+
     it('should return the highest read Nonce (chain Index > secondQuery)', async () => {
       const chain = new Blockchain(api)
       api.rpc.system.accountNextIndex.mockResolvedValue(new BN(11912202))
@@ -156,6 +163,7 @@ describe('Tx logic', () => {
       expect(nonce.toNumber()).toEqual(11912202)
       indexMap.mockRestore()
     })
+
     it('should return the highest read Nonce (chain Index, !secondQuery)', async () => {
       const chain = new Blockchain(api)
       api.rpc.system.accountNextIndex.mockResolvedValue(
@@ -170,6 +178,7 @@ describe('Tx logic', () => {
       expect(nonce.toNumber()).toEqual(11912203)
       indexMap.mockRestore()
     })
+
     it('should reject when chain returns error', async () => {
       api.rpc.system.accountNextIndex.mockRejectedValue('Reason')
       const chain = new Blockchain(api)
@@ -178,6 +187,7 @@ describe('Tx logic', () => {
       )
     })
   })
+
   describe('reSignTx', () => {
     const submittable: SubmittableExtrinsic = ({
       signature: {
@@ -187,6 +197,7 @@ describe('Tx logic', () => {
       nonce: { toHuman: jest.fn() },
       method: { data: 'unchanged', toHex: jest.fn() },
     } as unknown) as SubmittableExtrinsic
+
     it('fetches updated Nonce and applies updated signature to Extrinsic', async () => {
       api.createType = jest
         .fn()
@@ -214,6 +225,7 @@ describe('Tx logic', () => {
       )
     })
   })
+
   describe('exported function submitSignedTx', () => {
     it('catches ERROR_TRANSACTION_USURPED and rejects Promise with ERROR_TRANSACTION_RECOVERABLE', async () => {
       setDefault({ isUsurped: true })
@@ -224,6 +236,7 @@ describe('Tx logic', () => {
         submitSignedTx(tx, parseSubscriptionOptions())
       ).rejects.toThrow(ERROR_TRANSACTION_RECOVERABLE())
     }, 20_000)
+
     it('catches priority error and rejects Promise with ERROR_TRANSACTION_RECOVERABLE', async () => {
       setDefault()
       const chain = new Blockchain(api)
@@ -234,6 +247,7 @@ describe('Tx logic', () => {
         submitSignedTx(tx, parseSubscriptionOptions())
       ).rejects.toThrow(ERROR_TRANSACTION_RECOVERABLE())
     }, 20_000)
+
     it('catches Already Imported error and rejects Promise with ERROR_TRANSACTION_RECOVERABLE', async () => {
       setDefault()
       const chain = new Blockchain(api)
@@ -244,6 +258,7 @@ describe('Tx logic', () => {
         submitSignedTx(tx, parseSubscriptionOptions())
       ).rejects.toThrow(ERROR_TRANSACTION_RECOVERABLE())
     }, 20_000)
+
     it('catches Outdated/Stale Tx error and rejects Promise with ERROR_TRANSACTION_RECOVERABLE', async () => {
       setDefault()
       const chain = new Blockchain(api)
@@ -259,6 +274,7 @@ describe('Tx logic', () => {
       ).rejects.toThrow(ERROR_TRANSACTION_RECOVERABLE())
     }, 20_000)
   })
+
   describe('Blockchain class method submitSignedTx', () => {
     it('Retries to send up to two times if recoverable error is caught', async () => {
       setDefault({ isUsurped: true })
@@ -270,7 +286,7 @@ describe('Tx logic', () => {
         .mockImplementation(async (id, Tx) => {
           return Tx
         })
-      await expect(chain.submitSignedTx(tx, alice)).rejects.toThrow(
+      await expect(chain.submitTxWithReSign(tx, alice)).rejects.toThrow(
         ERROR_TRANSACTION_RECOVERABLE()
       )
 
@@ -278,6 +294,7 @@ describe('Tx logic', () => {
     })
   })
 })
+
 describe('parseSubscriptionOptions', () => {
   it('takes incomplete SubscriptionPromiseOptions and sets default values where needed', async () => {
     const testfunction: ResultEvaluator = () => true

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -1,11 +1,10 @@
-import { Text, UInt } from '@polkadot/types'
+/* eslint-disable dot-notation */
+import { Text } from '@polkadot/types'
 import { Index } from '@polkadot/types/interfaces/types'
-import { ApiPromise } from '@polkadot/api'
 import getCached from '../blockchainApiConnection/BlockchainApiConnection'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import Blockchain from './Blockchain'
-import getCached from '../blockchainApiConnection'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -17,7 +16,7 @@ describe('queries', () => {
     api.rpc.system.chain.mockResolvedValue(new Text(TYPE_REGISTRY, 'mockchain'))
     api.rpc.system.name.mockResolvedValue(new Text(TYPE_REGISTRY, 'KILT node'))
 
-    api.rpc.chain.subscribeNewHeads = jest.fn(async listener => {
+    api.rpc.chain.subscribeNewHeads = jest.fn(async (listener) => {
       listener('mockHead')
       return jest.fn()
     })
@@ -42,31 +41,22 @@ describe('queries', () => {
   })
 })
 describe('nonce retrieval logic', () => {
-  const alice = Identity.buildFromURI('//Alice')
-
-  const errorSetupApi = ({
-    query: {
-      system: {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        accountNonce: () => {
-          return new Promise((res, rej) => {
-            rej(new Error('Test Nonce Retrieval Error handling'))
-          })
-        },
-      },
-    },
-  } as any) as ApiPromise
+  let alice: Identity
+  const api = require('../blockchainApiConnection/BlockchainApiConnection')
+    .__mocked_api
   const dispatchTransactions = async (address: string): Promise<Index> => {
     const chain = await getCached()
     return chain.getNonce(address)
   }
+  beforeAll(async () => {
+    alice = await Identity.buildFromURI('//Alice')
+  })
   it('should increment nonce for account', async () => {
-    const chain = new Blockchain((await getCached()).api)
+    const chain = new Blockchain(api)
 
-    // eslint-disable-next-line dot-notation
     const initialNonce = await chain['retrieveNonce'](alice.address)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
+    expect(chain['accountNonces'].get(alice.address)!.toNumber()).toEqual(
       initialNonce.toNumber() + 1
     )
   })
@@ -78,27 +68,27 @@ describe('nonce retrieval logic', () => {
     const nonces = await Promise.all(promisedNonces)
     expect(nonces.length).toEqual(25)
     nonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+      expect(value.toNumber()).toEqual(index)
     })
   })
   it('should return incrementing nonces', async () => {
     const promisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain((await getCached()).api)
+    const chain = new Blockchain(api)
     for (let i = 0; i < 25; i += 1) {
       promisedNonces.push(chain.getNonce(alice.address))
     }
     const nonces = await Promise.all(promisedNonces)
     expect(nonces.length).toEqual(25)
     nonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+      expect(value.toNumber()).toEqual(index)
     })
   })
 
   it('should return separate incrementing nonces per account', async () => {
-    const bob = Identity.buildFromURI('//Bob')
+    const bob = await Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const bobPromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain((await getCached()).api)
+    const chain = new Blockchain(api)
     for (let i = 0; i < 50; i += 1) {
       if (i % 2 === 0) {
         alicePromisedNonces.push(chain.getNonce(alice.address))
@@ -109,105 +99,22 @@ describe('nonce retrieval logic', () => {
     expect(aliceNonces.length).toEqual(25)
     expect(bobNonces.length).toEqual(25)
     aliceNonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+      expect(value.toNumber()).toEqual(index)
     })
     bobNonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
+      expect(value.toNumber()).toEqual(index)
     })
   })
 
   it('should handle error when chain returns error', async () => {
-    const chain = new Blockchain(errorSetupApi)
-    // eslint-disable-next-line dot-notation
-    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow(
-      'Test Nonce Retrieval Error handling'
-    )
+    api.rpc.system.accountNextIndex.mockReturnValue(() => Promise.reject())
+    const chain = new Blockchain(api)
+    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow()
   })
 
-  // it('should handle errors when accessing account nonces', async () => {
-  //   // For this test to run, TS diagnostics have to be disabled in [jest-config].globals.ts-jest.diagnostics
-  //   const chain = new Blockchain(mockedApi)
-  //   chain.accountNonces.set(alice.address, undefined)
-  //   // eslint-disable-next-line dot-notation
-  //   await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow(
-  //     `Nonce Retrieval Failed for : ${alice.address}`
-  //   )
-  // })
-})
-const errorSetupApi = ({
-  query: {
-    system: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      accountNonce: () => {
-        return new Promise((res, rej) => {
-          rej(new Error('Test Nonce Retrieval Error handling'))
-        })
-      },
-    },
-  },
-} as any) as ApiPromise
-describe('Blockchain', () => {
-  const alice = Identity.buildFromURI('//Alice')
-  it('should increment nonce for account', async () => {
-    const chain = new Blockchain(mockedApi)
-    // eslint-disable-next-line dot-notation
-    const initialNonce = await chain['retrieveNonce'](alice.address)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(chain.accountNonces.get(alice.address)!.toNumber()).toEqual(
-      initialNonce.toNumber() + 1
-    )
+  it('should handle errors when accessing account nonces', async () => {
+    const chain = new Blockchain(api)
+    chain['accountNonces'].set(alice.address, (undefined as unknown) as Index)
+    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow()
   })
-
-  it('should return incrementing nonces', async () => {
-    const promisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(mockedApi)
-    for (let i = 0; i < 25; i += 1) {
-      promisedNonces.push(chain.getNonce(alice.address))
-    }
-    const nonces = await Promise.all(promisedNonces)
-    expect(nonces.length).toEqual(25)
-    nonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
-    })
-  })
-
-  it('should return separate incrementing nonces per account', async () => {
-    const bob = Identity.buildFromURI('//Bob')
-    const alicePromisedNonces: Array<Promise<Index>> = []
-    const bobPromisedNonces: Array<Promise<Index>> = []
-    const chain = new Blockchain(mockedApi)
-    for (let i = 0; i < 50; i += 1) {
-      if (i % 2 === 0) {
-        alicePromisedNonces.push(chain.getNonce(alice.address))
-      } else bobPromisedNonces.push(chain.getNonce(bob.address))
-    }
-    const aliceNonces = await Promise.all(alicePromisedNonces)
-    const bobNonces = await Promise.all(bobPromisedNonces)
-    expect(aliceNonces.length).toEqual(25)
-    expect(bobNonces.length).toEqual(25)
-    aliceNonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
-    })
-    bobNonces.forEach((value, index) => {
-      expect(value.toNumber()).toEqual(new UInt(index).toNumber())
-    })
-  })
-
-  it('should handle error when chain returns error', async () => {
-    const chain = new Blockchain(errorSetupApi)
-    // eslint-disable-next-line dot-notation
-    await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow(
-      'Test Nonce Retrieval Error handling'
-    )
-  })
-
-  // it('should handle errors when accessing account nonces', async () => {
-  //   // For this test to run, TS diagnostics have to be disabled in [jest-config].globals.ts-jest.diagnostics
-  //   const chain = new Blockchain(mockedApi)
-  //   chain.accountNonces.set(alice.address, undefined)
-  //   // eslint-disable-next-line dot-notation
-  //   await expect(chain['retrieveNonce'](alice.address)).rejects.toThrow(
-  //     `Nonce Retrieval Failed for : ${alice.address}`
-  //   )
-  // })
 })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -99,7 +99,9 @@ describe('queries', () => {
     })
   })
 
-  it('should delete map entry after completion of queue', async () => {
+  // this tests logic that was changed to have chain connectivity
+  // as the map entry is only deleted after chain response
+  xit('should delete map entry after completion of queue', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain(mockedApi)
@@ -107,7 +109,7 @@ describe('queries', () => {
       alicePromisedNonces.push(chain.getNonce(alice.address))
     }
     Promise.all(alicePromisedNonces).then(() => {
-      expect(!chain.accountNonces.has(alice.address)).toBeTruthy()
+      expect(chain.accountNonces.has(alice.address)).toBeFalsy()
     })
   })
 })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -88,4 +88,16 @@ describe('Blockchain', async () => {
       expect(value.toNumber()).toEqual(new UInt(index).toNumber())
     })
   })
+
+  it('should delete map entry after queue is done', async () => {
+    const alice = Identity.buildFromURI('//Alice')
+    const alicePromisedNonces: Array<Promise<Index>> = []
+    const chain = new Blockchain(mockedApi)
+    for (let i = 0; i < 12; i += 1) {
+      alicePromisedNonces.push(chain.getNonce(alice.address))
+    }
+    Promise.all(alicePromisedNonces).then(v => {
+      expect(!chain.accountNonces.has(alice.address)).toBeTruthy()
+    })
+  })
 })

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -270,7 +270,7 @@ describe('Tx logic', () => {
         .mockImplementation(async (id, Tx) => {
           return Tx
         })
-      await expect(chain.submitSignedTx(alice, tx)).rejects.toThrow(
+      await expect(chain.submitSignedTx(tx, alice)).rejects.toThrow(
         ERROR_TRANSACTION_RECOVERABLE()
       )
 

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -20,6 +20,8 @@ const mockedApi = ({
 } as any) as ApiPromise
 
 describe('queries', () => {
+  const alice = Identity.buildFromURI('//Alice')
+
   beforeAll(() => {
     const api = require('../blockchainApiConnection/BlockchainApiConnection')
       .__mocked_api
@@ -52,7 +54,6 @@ describe('queries', () => {
   })
 
   it('should increment nonce for account', async () => {
-    const alice = Identity.buildFromURI('//Alice')
     const chain = new Blockchain(mockedApi)
     // eslint-disable-next-line dot-notation
     const initialNonce = await chain['retrieveNonce'](alice.address)
@@ -63,7 +64,6 @@ describe('queries', () => {
   })
 
   it('should return incrementing nonces', async () => {
-    const alice = Identity.buildFromURI('//Alice')
     const promisedNonces: Array<Promise<Index>> = []
     const chain = new Blockchain(mockedApi)
     for (let i = 0; i < 25; i += 1) {
@@ -77,7 +77,6 @@ describe('queries', () => {
   })
 
   it('should return separate incrementing nonces per account', async () => {
-    const alice = Identity.buildFromURI('//Alice')
     const bob = Identity.buildFromURI('//Bob')
     const alicePromisedNonces: Array<Promise<Index>> = []
     const bobPromisedNonces: Array<Promise<Index>> = []

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -167,9 +167,7 @@ export default class Blockchain implements IBlockchainApi {
   }
 
   public async getNonce(accountAddress: string): Promise<Index> {
-    const unlock: () => Promise<Index> = await this.lock(accountAddress)
-    const nonce: Index = await unlock()
-    return nonce
+    return (await this.lock(accountAddress))()
   }
 
   private handleQueue(accountAddress: Identity['address']): void {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -276,7 +276,7 @@ export default class Blockchain implements IBlockchainApi {
    *
    * @param accountAddress The address of the identity that we retrieve the nonce for.
    * @param reset Specify whether the entry for the account is outdated and has to be reset.
-   * @returns [[Index]] representation of the Tx nonce for the identity.
+   * @returns [[BN]] representation of the Tx nonce for the identity.
    *
    */
   public async getNonce(accountAddress: string, reset = false): Promise<BN> {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -200,11 +200,11 @@ export default class Blockchain implements IBlockchainApi {
                   this.errorHandler.getExtrinsicError(result) || ERROR_UNKNOWN
 
                 log.warn(`Extrinsic error ocurred: ${extrinsicError}`)
-                this.resetQueue(identity.address)
+                this.resetAccountQueue(identity.address)
                 reject(extrinsicError)
               }
               if (result.isFinalized) {
-                this.resetQueue(identity.address)
+                this.resetAccountQueue(identity.address)
                 resolve(new SubmittableResult(result))
               } else if (result.isError) {
                 reject(
@@ -219,7 +219,7 @@ export default class Blockchain implements IBlockchainApi {
         })
       }
     } catch (err) {
-      this.resetQueue(identity.address)
+      this.resetAccountQueue(identity.address)
       return new Promise<SubmittableResult>((resolve, reject) => reject(err))
     }
 >>>>>>> feat: reset q on new block (chain response)
@@ -294,7 +294,7 @@ export default class Blockchain implements IBlockchainApi {
     return nonce
   }
 
-  private resetQueue(accountAddress: Identity['address']): void {
+  private resetAccountQueue(accountAddress: Identity['address']): void {
     if (this.pending.has(accountAddress) && !this.pending.get(accountAddress)) {
       this.accountNonces.delete(accountAddress)
     }

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -68,12 +68,15 @@ export interface IBlockchainApi {
     tx: SubmittableExtrinsic
   ): Promise<SubmittableExtrinsic>
 }
-
 const TxOutdated = '1010: Invalid Transaction: Transaction is outdated'
 const TxPriority = '1014: Priority is too low:'
 const TxAlreadyImported = 'Transaction Already'
+
 export const IS_RELEVANT_ERROR: ErrorEvaluator = (err: Error) => {
-  return err.message.includes(TxOutdated || TxPriority || TxAlreadyImported)
+  return new RegExp(
+    `${TxAlreadyImported}|${TxOutdated}|${TxPriority}`,
+    'g'
+  ).test(err.message)
 }
 export const IS_READY: ResultEvaluator = (result) => result.status.isReady
 export const IS_IN_BLOCK: ResultEvaluator = (result) => result.isInBlock

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -119,7 +119,12 @@ export default class Blockchain implements IBlockchainApi {
   public api: ApiPromise
   public readonly portablegabi: gabi.Blockchain
   public accountNonces: Map<Identity['address'], Index>
-  private pending = false
+
+  private pending: Map<Identity['address'], boolean> = new Map<
+    Identity['address'],
+    boolean
+  >()
+
   private nonceQueue: Map<
     Identity['address'],
     Array<(unlock: () => Promise<Index>) => void>
@@ -181,14 +186,17 @@ export default class Blockchain implements IBlockchainApi {
   private lock(
     accountAddress: Identity['address']
   ): Promise<() => Promise<Index>> {
+    if (!this.pending.has(accountAddress)) {
+      this.pending.set(accountAddress, false)
+    }
     const lock = new Promise<() => Promise<Index>>(resolve => {
       if (!this.nonceQueue.has(accountAddress)) {
         this.nonceQueue.set(accountAddress, [resolve])
-      } else if (this.nonceQueue.has(accountAddress)) {
+      } else {
         this.nonceQueue.get(accountAddress)!.push(resolve)
       }
     })
-    if (!this.pending) {
+    if (!this.pending.get(accountAddress)) {
       this.handleQueue(accountAddress)
     }
     return lock
@@ -199,7 +207,7 @@ export default class Blockchain implements IBlockchainApi {
       this.nonceQueue.has(accountAddress) &&
       this.nonceQueue.get(accountAddress)!.length > 0
     ) {
-      this.pending = true
+      this.pending.set(accountAddress, true)
       const resolve = this.nonceQueue.get(accountAddress)!.shift()
       if (resolve) {
         resolve(async () => {
@@ -209,7 +217,7 @@ export default class Blockchain implements IBlockchainApi {
         })
       }
     } else {
-      this.pending = false
+      this.pending.set(accountAddress, false)
     }
   }
 

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -192,7 +192,7 @@ export default class Blockchain implements IBlockchainApi {
     const lock = new Promise<() => Promise<Index>>(resolve => {
       if (!this.nonceQueue.has(accountAddress)) {
         this.nonceQueue.set(accountAddress, [resolve])
-      } else {
+      } else if (this.nonceQueue.has(accountAddress)) {
         this.nonceQueue.get(accountAddress)!.push(resolve)
       }
     })

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /**
  * Blockchain bridges that connects the SDK and the KILT Blockchain.
  *
@@ -193,6 +192,7 @@ export default class Blockchain implements IBlockchainApi {
       if (!this.nonceQueue.has(accountAddress)) {
         this.nonceQueue.set(accountAddress, [resolve])
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.nonceQueue.get(accountAddress)!.push(resolve)
       }
     })
@@ -203,11 +203,9 @@ export default class Blockchain implements IBlockchainApi {
   }
 
   private handleQueue(accountAddress: Identity['address']): void {
-    if (
-      this.nonceQueue.has(accountAddress) &&
-      this.nonceQueue.get(accountAddress)!.length > 0
-    ) {
+    if ((this.nonceQueue.get(accountAddress) || []).length > 0) {
       this.pending.set(accountAddress, true)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const resolve = this.nonceQueue.get(accountAddress)!.shift()
       if (resolve) {
         resolve(async () => {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -41,12 +41,6 @@ export interface IBlockchainApi {
   api: ApiPromise
   portablegabi: gabi.Blockchain
 
-  // nonceQueue: Map<
-  //   Identity['address'],
-  //   Array<(unlock: () => Promise<Index>) => void>
-  // >
-  // pending: Map<Identity['address'], boolean>
-  // accountNonces: Map<Identity['address'], Index>
   getStats(): Promise<Stats>
   listenToBlocks(listener: (header: Header) => void): Promise<() => void>
   signTx(
@@ -247,8 +241,8 @@ export default class Blockchain implements IBlockchainApi {
       const resolve = this.nonceQueue.get(accountAddress)!.shift()
       if (resolve) {
         // resolve with a function that returns the retrieveNonce Promise
-        resolve(() => {
-          const nonce = this.retrieveNonce(accountAddress)
+        resolve(async () => {
+          const nonce = await this.retrieveNonce(accountAddress)
           // recursive execution of handleQueue
           this.handleQueue(accountAddress)
           return nonce

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -12,7 +12,6 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
-import { Text } from '@polkadot/types'
 import { Header, Index } from '@polkadot/types/interfaces/types'
 import { AnyJson, Codec } from '@polkadot/types/types'
 import { Evaluator, makeSubscriptionPromise } from '../util/SubscriptionPromise'
@@ -160,7 +159,6 @@ export default class Blockchain implements IBlockchainApi {
   public async signTx(
     identity: Identity,
     tx: SubmittableExtrinsic
-<<<<<<< HEAD
   ): Promise<SubmittableExtrinsic> {
     const nonce = await this.getNonce(identity.address)
     const signed: SubmittableExtrinsic = identity.signSubmittableExtrinsic(
@@ -177,48 +175,6 @@ export default class Blockchain implements IBlockchainApi {
   ): Promise<SubmittableResult> {
     const signedTx = await this.signTx(identity, tx)
     return Blockchain.submitSignedTx(signedTx, opts)
-=======
-  ): Promise<SubmittableResult> {
-    try {
-      const nonce: Index = await this.getNonce(identity.address)
-      const signed = identity.signSubmittableExtrinsic(tx, nonce.toHex())
-      log.info(`Submitting ${tx.method} with Nonce ${nonce}`)
-      return new Promise<SubmittableResult>((resolve, reject) => {
-        signed
-          .send(result => {
-            log.info(`Got tx status '${result.status.type}'`)
-            const { status } = result
-            if (ErrorHandler.extrinsicFailed(result)) {
-              log.warn(`Extrinsic execution failed`)
-              log.debug(
-                `Transaction detail: ${JSON.stringify(result, null, 2)}`
-              )
-              const extrinsicError: ExtrinsicError =
-                this.errorHandler.getExtrinsicError(result) || ERROR_UNKNOWN
-
-              log.warn(`Extrinsic error ocurred: ${extrinsicError}`)
-              this.resetAccountQueue(identity.address)
-              reject(extrinsicError)
-            }
-            if (result.isFinalized) {
-              this.resetAccountQueue(identity.address)
-              resolve(new SubmittableResult(result))
-            } else if (result.isError) {
-              reject(
-                new Error(`Transaction failed with status '${status.type}'`)
-              )
-            }
-          })
-          .catch((error: Error) => {
-            // just reject with the original tx error from the chain
-            reject(error)
-          })
-      })
-    } catch (error) {
-      this.resetAccountQueue(identity.address)
-      throw error
-    }
->>>>>>> feat: reset q on new block (chain response)
   }
 
   public async getNonce(accountAddress: string): Promise<Index> {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -13,13 +13,19 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Header, Index } from '@polkadot/types/interfaces/types'
 import { AnyJson, Codec } from '@polkadot/types/types'
-import { Evaluator, makeSubscriptionPromise } from '../util/SubscriptionPromise'
 import { Text } from '@polkadot/types'
+import { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
+import { ERROR_TRANSACTION_USURPED } from '../errorhandling/SDKErrors'
+import {
+  Evaluator,
+  makeSubscriptionPromise,
+  TerminationOptions,
+} from '../util/SubscriptionPromise'
 import { factory as LoggerFactory } from '../config/ConfigLog'
 import { ErrorHandler } from '../errorhandling'
 import { ERROR_UNKNOWN as UNKNOWN_EXTRINSIC_ERROR } from '../errorhandling/ExtrinsicError'
 import Identity from '../identity/Identity'
-import { ERROR_UNKNOWN } from '../errorhandling/SDKErrors'
+import getCached from '../blockchainApiConnection'
 
 const log = LoggerFactory.getLogger('Blockchain')
 
@@ -30,13 +36,8 @@ export type Stats = {
 }
 
 export type ResultEvaluator = Evaluator<SubmittableResult>
-
-export interface SubscriptionPromiseOptions {
-  resolveOn?: ResultEvaluator
-  rejectOn?: ResultEvaluator
-  timeout?: number
-}
-
+export type ErrorEvaluator = Evaluator<Error>
+export type SubscriptionPromiseOptions = TerminationOptions<SubmittableResult>
 export interface IBlockchainApi {
   api: ApiPromise
   portablegabi: gabi.Blockchain
@@ -47,56 +48,103 @@ export interface IBlockchainApi {
     identity: Identity,
     tx: SubmittableExtrinsic
   ): Promise<SubmittableExtrinsic>
+  submitSignedTx(
+    identity: Identity,
+    tx: SubmittableExtrinsic,
+    opts?: SubscriptionPromiseOptions
+  ): Promise<SubmittableResult>
   submitTx(
     identity: Identity,
     tx: SubmittableExtrinsic,
     opts?: SubscriptionPromiseOptions
   ): Promise<SubmittableResult>
-  getNonce(accountAddress: string): Promise<Index>
+  getNonce(accountAddress: string, reset?: boolean): Promise<Index>
+  reSignTx(
+    identity: Identity,
+    tx: SubmittableExtrinsic
+  ): Promise<SubmittableExtrinsic>
 }
 
+export const IS_RELEVANT_ERROR: ErrorEvaluator = (err: Error) => {
+  return /Priority|Transaction Already|outdated/g.test(err.message)
+}
 export const IS_READY: ResultEvaluator = (result) => result.status.isReady
 export const IS_IN_BLOCK: ResultEvaluator = (result) => result.isInBlock
 export const EXTRINSIC_EXECUTED: ResultEvaluator = (result) =>
   ErrorHandler.extrinsicSuccessful(result)
 export const IS_FINALIZED: ResultEvaluator = (result) => result.isFinalized
-
-export const IS_ERROR: ResultEvaluator = (result) =>
-  result.isError && ERROR_UNKNOWN()
-export const EXTRINSIC_FAILED: ResultEvaluator = (result) =>
-  ErrorHandler.extrinsicFailed(result) &&
-  (ErrorHandler.getExtrinsicError(result) || UNKNOWN_EXTRINSIC_ERROR)
-
+export const IS_USURPED: ResultEvaluator = (result) =>
+  result.status.isUsurped && ERROR_TRANSACTION_USURPED()
+export const IS_ERROR: ResultEvaluator = (result) => {
+  return (
+    (result.status.isDropped && Error('isDropped')) ||
+    (result.status.isInvalid && Error('isInvalid')) ||
+    (result.status.isFinalityTimeout && Error('isFinalityTimeout'))
+  )
+}
+export const EXTRINSIC_FAILED: ResultEvaluator = (result) => {
+  return (
+    ErrorHandler.extrinsicFailed(result) &&
+    (ErrorHandler.getExtrinsicError(result) || UNKNOWN_EXTRINSIC_ERROR)
+  )
+}
 /**
- * Submits a signed [[SubmittableExtrinsic]] and attaches a callback to monitor the inclusion status of the transaction
+ * Parses potentially incomplete or undefined opts and returns complete [[SubscriptionPromiseOptions]].
+ *
+ * @param opts Potentially undefined opts to parse into complete SubscriptionPromiseOptions.
+ * @returns Complete [[SubscriptionPromiseOptions]].
+ */
+export function parseSubscriptionOptions(
+  opts?: Partial<SubscriptionPromiseOptions>
+): SubscriptionPromiseOptions {
+  const {
+    resolveOn = IS_FINALIZED,
+    rejectOn = (result: SubmittableResult) =>
+      IS_ERROR(result) || EXTRINSIC_FAILED(result) || IS_USURPED(result),
+    timeout,
+  } = { ...opts }
+  return { resolveOn, rejectOn, timeout }
+}
+/**
+ * [ASYNC] Submits a signed [[SubmittableExtrinsic]] and attaches a callback to monitor the inclusion status of the transaction
  * and possible errors in the execution of extrinsics. Returns a promise to that end which by default resolves upon
  * finalization and rejects any errors occur during submission or execution of extrinsics. This behavior can be adjusted via optional parameters.
+ *
+ * This function will re-sign and try to resend the given transaction two times, if recoverable errors are encountered.
+ * If the submitted extrinsic is usurped, this function will call itself.
  *
  * Transaction fees will apply whenever a transaction fee makes it into a block, even if extrinsics fail to execute correctly!
  *
  * @param tx The [[SubmittableExtrinsic]] to be submitted. Most transactions need to be signed, this must be done beforehand.
- * @param resolveOn A function which triggers the resolution of the promise. Defaults to resolution on finalization.
- * @param rejectOn A function which triggers the rejection of the promise and specifies the rejection reason.
- * Defaults to rejection if either the submission of the transaction failed or if the execution of extrinsics emitted an error event.
- * @param timeout Optional timeout in ms. If set, an unresolved promise will reject after this period of time.
+ * @param opts [[SubscriptionPromiseOptions]]: Criteria for resolving/rejecting the promise.
  * @returns A promise which can be used to track transaction status.
  * If resolved, this promise returns [[SubmittableResult]] that has led to its resolution.
  */
 export async function submitSignedTx(
   tx: SubmittableExtrinsic,
-  resolveOn: ResultEvaluator = IS_FINALIZED,
-  rejectOn: ResultEvaluator = (result) =>
-    IS_ERROR(result) || EXTRINSIC_FAILED(result),
-  timeout?: number
+  opts: SubscriptionPromiseOptions
 ): Promise<SubmittableResult> {
-  log.info(`Submitting ${tx.method}`)
-  const { promise, subscription } = makeSubscriptionPromise(
-    resolveOn,
-    rejectOn,
-    timeout
-  )
-  const unsubscribe = await tx.send(subscription)
-  return promise.finally(() => unsubscribe())
+  const { promise, subscription } = makeSubscriptionPromise(opts)
+
+  const unsubscribe = await tx
+    .send(subscription)
+    .catch(async (reason: Error) => {
+      if (IS_RELEVANT_ERROR(reason)) {
+        return Promise.reject(Error('Recoverable'))
+      }
+      return Promise.reject(reason)
+    })
+
+  const result = await promise
+    .catch(async (reason: Error) => {
+      if (reason.message === ERROR_TRANSACTION_USURPED().message) {
+        return Promise.reject(Error('Recoverable'))
+      }
+      return Promise.reject(reason)
+    })
+    .finally(() => unsubscribe())
+
+  return result
 }
 
 // Code taken from
@@ -109,29 +157,36 @@ export default class Blockchain implements IBlockchainApi {
     return []
   }
 
-  public static submitSignedTx(
+  /**
+   *  [STATIC] [ASYNC] Submits a signed [[SubmittableExtrinsic]] and attaches a callback to monitor the inclusion status of the transaction
+   * and possible errors in the execution of extrinsics. Returns a promise to that end which by default resolves upon
+   * finalization and rejects any errors occur during submission or execution of extrinsics. This behavior can be adjusted via optional parameters.
+   *
+   * This function will try to re-sign and resend the given transaction two times recursively, if recoverable errors are encountered.
+   *
+   * Transaction fees will apply whenever a transaction fee makes it into a block, even if extrinsics fail to execute correctly!
+   *
+   * @param identity The [[SubmittableExtrinsic]] to be submitted. Most transactions need to be signed, this must be done beforehand.
+   * @param tx The [[SubmittableExtrinsic]] to be submitted. Most transactions need to be signed, this must be done beforehand.
+   * @param opts Criteria for resolving/rejecting the promise.
+   * @returns A promise which can be used to track transaction status.
+   * If resolved, this promise returns [[SubmittableResult]] that has led to its resolution.
+   */
+  public static async submitSignedTx(
+    identity: Identity,
     tx: SubmittableExtrinsic,
-    opts: SubscriptionPromiseOptions = {}
+    opts?: SubscriptionPromiseOptions
   ): Promise<SubmittableResult> {
-    return submitSignedTx(tx, opts.resolveOn, opts.rejectOn, opts.timeout)
+    const chain = await getCached()
+    const time = Date.now()
+    const result = await chain.submitSignedTx(identity, tx, opts)
+    log.error(`Timeframe: ${Date.now() - time}`)
+    return result
   }
 
   public api: ApiPromise
   public readonly portablegabi: gabi.Blockchain
   private accountNonces: Map<Identity['address'], Index>
-
-  private pending: Map<Identity['address'], boolean> = new Map<
-    Identity['address'],
-    boolean
-  >()
-
-  private nonceQueue: Map<
-    Identity['address'],
-    Array<(unlock: () => Promise<Index>) => void>
-  > = new Map<
-    Identity['address'],
-    Array<(unlock: () => Promise<Index>) => void>
-  >()
 
   public constructor(api: ApiPromise) {
     this.api = api
@@ -156,140 +211,158 @@ export default class Blockchain implements IBlockchainApi {
     return this.api.rpc.chain.subscribeNewHeads(listener)
   }
 
+  /**
+   * [ASYNC] Signs the SubmittableExtrinsic with the given identity.
+   *
+   * @param identity The [[Identity]] to sign the Tx with.
+   * @param tx The unsigned SubmittableExtrinsic.
+   * @returns Signed SubmittableExtrinsic.
+   *
+   */
   public async signTx(
     identity: Identity,
     tx: SubmittableExtrinsic
   ): Promise<SubmittableExtrinsic> {
     const nonce = await this.getNonce(identity.address)
-    const signed: SubmittableExtrinsic = identity.signSubmittableExtrinsic(
+    const signed: SubmittableExtrinsic = await identity.signSubmittableExtrinsic(
       tx,
-      nonce.toHex()
+      nonce
     )
     return signed
   }
 
+  /**
+   * [STATIC] [ASYNC] Submits a signed [[SubmittableExtrinsic]] and attaches a callback to monitor the inclusion status of the transaction
+   * and possible errors in the execution of extrinsics. Returns a promise to that end which by default resolves upon
+   * finalization and rejects any errors occur during submission or execution of extrinsics. This behavior can be adjusted via optional parameters.
+   *
+   * This function will try to re-sign and resend the given transaction two times recursively, if recoverable errors are encountered.
+   *
+   * Transaction fees will apply whenever a transaction fee makes it into a block, even if extrinsics fail to execute correctly!
+   *
+   * @param identity The [[SubmittableExtrinsic]] to be submitted. Most transactions need to be signed, this must be done beforehand.
+   * @param tx The [[SubmittableExtrinsic]] to be submitted. Most transactions need to be signed, this must be done beforehand.
+   * @param opts Criteria for resolving/rejecting the promise.
+   * @returns A promise which can be used to track transaction status.
+   * If resolved, this promise returns [[SubmittableResult]] that has led to its resolution.
+   */
+  public async submitSignedTx(
+    identity: Identity,
+    tx: SubmittableExtrinsic,
+    opts?: SubscriptionPromiseOptions
+  ): Promise<SubmittableResult> {
+    const options = parseSubscriptionOptions(opts)
+    return submitSignedTx(tx, options)
+      .catch(async (reason: Error) => {
+        if (reason.message === 'Recoverable') {
+          return submitSignedTx(await this.reSignTx(identity, tx), options)
+        }
+        throw reason
+      })
+      .catch(async (reason: Error) => {
+        if (reason.message === 'Recoverable') {
+          return submitSignedTx(await this.reSignTx(identity, tx), options)
+        }
+        throw reason
+      })
+  }
+
+  /**
+   * [ASYNC] Signs and submits the SubmittableExtrinsic with optional resolving and rejection criteria.
+   *
+   * @param identity The [[Identity]] that we retrieve the nonce for.
+   * @param tx The generated unsigned SubmittableExtrinsic to submit.
+   * @param opts Optional [[SubscriptionPromiseOptions]].
+   * @returns Promise Result of The Extrinsic.
+   *
+   */
   public async submitTx(
     identity: Identity,
     tx: SubmittableExtrinsic,
-    opts: SubscriptionPromiseOptions = {}
+    opts?: SubscriptionPromiseOptions
   ): Promise<SubmittableResult> {
     const signedTx = await this.signTx(identity, tx)
-    return Blockchain.submitSignedTx(signedTx, opts)
+    return this.submitSignedTx(identity, signedTx, opts)
   }
 
   /**
-   * Initiates the Nonce retrieval for the given identity.
+   * [ASYNC] Retrieves the Nonce for Transaction signing for the specified account, and increments the in accountNonces mapped Index.
    *
    * @param accountAddress The address of the identity that we retrieve the nonce for.
-   * @returns Promise of the [[Index]] representation of the Transaction nonce of the identity.
+   * @param reset Specify whether the entry for the account is outdated and has to be reset.
+   * @returns [[Index]] representation of the Tx nonce for the identity.
    *
    */
-  public async getNonce(accountAddress: string): Promise<Index> {
-    // Initiate nonceRetrieval
-    const unlock = await this.lock(accountAddress)
-    // Await execution of the in handleQueue defined resolve function
-    const nonce = await unlock()
-    return nonce
-  }
-
-  /**
-   * Creates Promise and queues it's resolve CB into nonceQueue for later processing, starts recursive execution of handleQueue.
-   *
-   * @param accountAddress The address of the identity that we retrieve the nonce for.
-   * @returns The Promise with the queued up resolve CB.
-   *
-   */
-  private lock(
-    accountAddress: Identity['address']
-  ): Promise<() => Promise<Index>> {
-    // Create entry in pending Map for account.
-    // Pending Map indicates whether the nonceQueue is being processed for the account
-    if (!this.pending.has(accountAddress)) {
-      this.pending.set(accountAddress, false)
-    }
-    // lock Promise, whose resolve CB is put into the nonceQueue for the specific account
-    const lock = new Promise<() => Promise<Index>>((resolve) => {
-      // if the queue doesn't exist for the account, create entry.
-      if (!this.nonceQueue.has(accountAddress)) {
-        this.nonceQueue.set(accountAddress, [resolve])
-      } else {
-        // if queue exists for account, append.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.nonceQueue.get(accountAddress)!.push(resolve)
-      }
-    })
-    // If nonceQueue is not yet being processed for the account, start now.
-    if (!this.pending.get(accountAddress)) {
-      this.handleQueue(accountAddress)
-    }
-    // The promise, whose resolve CB was put into nonceQueue and is getting resolved inside handleQueue.
-    return lock
-  }
-
-  /**
-   * Handles the entries in nonceQueue for accountAddress, resolves the resolve() with the actual anonymous function for nonce retrieval and recursion.
-   *
-   * @param accountAddress The address of the identity that we handle nonceQueue for.
-   */
-  private handleQueue(accountAddress: Identity['address']): void {
-    // Check whether nonceQueue has entries for account
-    if ((this.nonceQueue.get(accountAddress) || []).length > 0) {
-      // Set pending map to true for account, indicating that nonceQueue is being processed for account.
-      this.pending.set(accountAddress, true)
-      // Retrieve the resolve CB put into nonceQueue in lock
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const resolve = this.nonceQueue.get(accountAddress)!.shift()
-      if (resolve) {
-        // resolve with a function that returns the retrieveNonce Promise
-        resolve(async () => {
-          const nonce = await this.retrieveNonce(accountAddress)
-          // recursive execution of handleQueue
-          this.handleQueue(accountAddress)
-          return nonce
-        })
-      }
-    } else {
-      // if account is not registered or has no entries in nonceQueue
-      // set pending for account to false and remove accountNonces entry for account.
-      this.pending.set(accountAddress, false)
+  public async getNonce(accountAddress: string, reset = false): Promise<Index> {
+    if (reset) {
       this.accountNonces.delete(accountAddress)
     }
-  }
-
-  /**
-   * Retrieves the Nonce for the specific account either directly from the API or from the previously to the account mapped accountNonce.
-   *
-   * @param accountAddress The address of the identity that we handle nonceQueue for.
-   * @returns Promise of the [[Index]] representation of the Transaction nonce of the identity.
-   */
-  private async retrieveNonce(
-    accountAddress: Identity['address']
-  ): Promise<Index> {
-    let nonce: Index
-    if (!this.accountNonces.has(accountAddress)) {
-      nonce = await this.api.rpc.system.accountNextIndex<Index>(accountAddress)
+    const initialQuery = this.accountNonces.get(accountAddress)
+    if (initialQuery) {
       this.accountNonces.set(
         accountAddress,
-        this.api.registry.createType('Index', nonce.addn(1))
+        this.api.registry.createType('Index', initialQuery.addn(1))
       )
-    } else {
-      const temp: Index | undefined = this.accountNonces.get(accountAddress)
-      if (!temp) {
-        throw new Error(`Nonce Retrieval Failed for : ${accountAddress}`)
-      } else {
-        nonce = temp
-        this.accountNonces.set(
-          accountAddress,
-          this.api.registry.createType('Index', nonce.addn(1))
-        )
-      }
+      return initialQuery
     }
-    return nonce
+    const chainNonce = await this.api.rpc.system
+      .accountNextIndex(accountAddress)
+      .catch((reason) => {
+        log.error(
+          `Onchain Nonce Retrieval failed for account ${accountAddress}\nwith Reason: ${reason}`
+        )
+        throw Error(`Chain failed to retrieve nonce for : ${accountAddress}`)
+      })
+    const secondQuery = this.accountNonces.get(accountAddress)
+    if (chainNonce && (!secondQuery || secondQuery.lte(chainNonce))) {
+      this.accountNonces.set(
+        accountAddress,
+        this.api.registry.createType('Index', chainNonce.addn(1))
+      )
+      return chainNonce
+    }
+    if (secondQuery) {
+      this.accountNonces.set(
+        accountAddress,
+        this.api.registry.createType('Index', secondQuery.addn(1))
+      )
+      return secondQuery
+    }
+    throw Error(`Nonce Retrieval Failed for : ${accountAddress}`)
   }
 
-  private resetAccountQueue(accountAddress: Identity['address']): void {
-    if (this.pending.has(accountAddress) && !this.pending.get(accountAddress)) {
-      this.accountNonces.delete(accountAddress)
-    }
+  /**
+   * [ASYNC] Re-signs the given SubmittableExtrinsic with an updated Nonce.
+   *
+   * @param identity The [[Identity]] to re-sign the Tx with.
+   * @param tx The previously with recoverable Error failed Tx.
+   * @returns Original Tx, injected with updated signature payload.
+   *
+   */
+  public async reSignTx(
+    identity: Identity,
+    tx: SubmittableExtrinsic
+  ): Promise<SubmittableExtrinsic> {
+    const nonce: Index = await this.getNonce(identity.address, true)
+    const signerPayload: SignerPayloadJSON = this.api
+      .createType('SignerPayload', {
+        method: tx.method.toHex(),
+        nonce,
+        genesisHash: this.api.genesisHash,
+        blockHash: this.api.genesisHash,
+        runtimeVersion: this.api.runtimeVersion,
+        version: this.api.extrinsicVersion,
+      })
+      .toPayload()
+    tx.addSignature(
+      identity.address,
+      this.api
+        .createType('ExtrinsicPayload', signerPayload, {
+          version: this.api.extrinsicVersion,
+        })
+        .sign(identity.signKeyringPair).signature,
+      signerPayload
+    )
+    return tx
   }
 }

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -287,6 +287,7 @@ export default class Blockchain implements IBlockchainApi {
   public async getNonce(accountAddress: string): Promise<BN> {
     let nonce = this.accountNonces.get(accountAddress)
     if (!nonce) {
+      // the account nonce is unknown, we will query it from chain
       const chainNonce = await this.api.rpc.system
         .accountNextIndex(accountAddress)
         .catch((reason) => {
@@ -295,6 +296,7 @@ export default class Blockchain implements IBlockchainApi {
           )
           throw Error(`Chain failed to retrieve nonce for : ${accountAddress}`)
         })
+      // ensure that the nonce we queried is still up to date and no newer nonce was queried during the await above
       const secondQuery = this.accountNonces.get(accountAddress)
       nonce = BN.max(chainNonce, secondQuery || new BN(0))
     }

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -192,7 +192,7 @@ export default class Blockchain implements IBlockchainApi {
     const lock = new Promise<() => Promise<Index>>(resolve => {
       if (!this.nonceQueue.has(accountAddress)) {
         this.nonceQueue.set(accountAddress, [resolve])
-      } else if (this.nonceQueue.has(accountAddress)) {
+      } else {
         this.nonceQueue.get(accountAddress)!.push(resolve)
       }
     })

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -167,7 +167,9 @@ export default class Blockchain implements IBlockchainApi {
   }
 
   public async getNonce(accountAddress: string): Promise<Index> {
-    return (await this.lock(accountAddress))()
+    const unlock: () => Promise<Index> = await this.lock(accountAddress)
+    const nonce: Index = await unlock()
+    return nonce
   }
 
   private handleQueue(accountAddress: Identity['address']): void {
@@ -184,7 +186,9 @@ export default class Blockchain implements IBlockchainApi {
               )
               this.accountNonces.set(accountAddress, new UInt(nonce.addn(1)))
             } else {
-              const temp = this.accountNonces.get(accountAddress)
+              const temp: Index | undefined = this.accountNonces.get(
+                accountAddress
+              )
               if (!temp) {
                 throw new Error(
                   `Nonce Retrieval Failed for : ${accountAddress}`
@@ -210,9 +214,9 @@ export default class Blockchain implements IBlockchainApi {
   private lock(
     accountAddress: Identity['address']
   ): Promise<() => Promise<Index>> {
-    const lock = new Promise<() => Promise<Index>>(resolve =>
-      this.nonceQueue.push(resolve)
-    )
+    const lock: Promise<() => Promise<Index>> = new Promise<
+      () => Promise<Index>
+    >(resolve => this.nonceQueue.push(resolve))
     if (!this.pending) {
       this.handleQueue(accountAddress)
     }

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -185,7 +185,6 @@ export default class Blockchain implements IBlockchainApi {
       if (!this.nonceQueue.has(accountAddress)) {
         this.nonceQueue.set(accountAddress, [resolve])
       } else if (this.nonceQueue.has(accountAddress)) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.nonceQueue.get(accountAddress)!.push(resolve)
       }
     })
@@ -198,11 +197,9 @@ export default class Blockchain implements IBlockchainApi {
   private handleQueue(accountAddress: Identity['address']): void {
     if (
       this.nonceQueue.has(accountAddress) &&
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.nonceQueue.get(accountAddress)!.length > 0
     ) {
       this.pending = true
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const resolve = this.nonceQueue.get(accountAddress)!.shift()
       if (resolve) {
         resolve(async () => {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -218,6 +218,7 @@ export default class Blockchain implements IBlockchainApi {
       }
     } else {
       this.pending.set(accountAddress, false)
+      this.accountNonces.delete(accountAddress)
     }
   }
 

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -162,7 +162,18 @@ export default class Blockchain implements IBlockchainApi {
     return Blockchain.submitSignedTx(signedTx, opts)
   }
 
-  public async getNonce(accountAddress: string): Promise<Index> {
-    return this.api.rpc.system.accountNextIndex(accountAddress)
+  public async getNonce(accountAddress: string): Promise<Codec> {
+    if (!this.currentNonce) {
+      this.currentNonce = await this.api.query.system.accountNonce<Index>(
+        accountAddress
+      )
+      if (!this.currentNonce) {
+        throw Error(`Nonce not found for account ${accountAddress}`)
+      }
+    } else {
+      this.currentNonce.addn(1)
+    }
+
+    return this.currentNonce
   }
 }

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -132,6 +132,7 @@ export async function submitSignedTx(
   tx: SubmittableExtrinsic,
   opts: SubscriptionPromiseOptions
 ): Promise<SubmittableResult> {
+  log.info(`Submitting ${tx.method}`)
   const { promise, subscription } = makeSubscriptionPromise(opts)
 
   const unsubscribe = await tx
@@ -248,7 +249,6 @@ export default class Blockchain implements IBlockchainApi {
     identity?: Identity,
     opts?: Partial<SubscriptionPromiseOptions>
   ): Promise<SubmittableResult> {
-    log.info(`Submitting ${tx.method}`)
     const options = parseSubscriptionOptions(opts)
     const retry = async (reason: Error): Promise<SubmittableResult> => {
       if (

--- a/src/blockchain/index.ts
+++ b/src/blockchain/index.ts
@@ -3,4 +3,4 @@
  * @ignore
  */
 
-export { default, IBlockchainApi, submitSignedTx } from './Blockchain'
+export { default, IBlockchainApi } from './Blockchain'

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -134,8 +134,9 @@ function __getMockSubmittableExtrinsic(): SubmittableExtrinsic {
 function __makeSubmittableResult(
   opts: Partial<ExtrinsicStatus>
 ): SubmittableResult {
+  const finalized = opts? !Object.keys(opts)[0]: true
   const status: ExtrinsicStatus = {
-    isFinalized: !Object.keys(opts)[0],
+    isFinalized: finalized,
     isDropped: false,
     isInvalid: false,
     isUsurped: false,

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -49,7 +49,6 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { AccountInfo, ExtrinsicStatus, Index } from '@polkadot/types/interfaces'
 import U64 from '@polkadot/types/primitive/U64'
-import Blockchain from '../../blockchain/Blockchain'
 import IPublicIdentity from '../../types/PublicIdentity'
 import TYPE_REGISTRY, { mockChainQueryReturn } from './BlockchainQuery'
 
@@ -330,6 +329,7 @@ const __mocked_api: any = {
       modules: [],
     },
   },
+  registry: TYPE_REGISTRY
 }
 
 BlockchainApiConnection.getCached = getCached

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -44,6 +44,7 @@
  *
  */
 
+import Blockchain from '../../blockchain/Blockchain'
 import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { AccountInfo, ExtrinsicStatus, Index } from '@polkadot/types/interfaces'

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -102,7 +102,7 @@ describe('CType', () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
     const tx = await ctype.store(identityAlice)
-    const result = await Blockchain.submitSignedTx(tx, identityAlice)
+    const result = await Blockchain.submitTxWithReSign(tx, identityAlice)
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,7 +1,7 @@
 import { SubmittableResult } from '@polkadot/api'
 import { TypeRegistry } from '@polkadot/types'
 import { Option } from '@polkadot/types/codec'
-import { submitSignedTx } from '../blockchain'
+import Blockchain from '../blockchain'
 import Claim from '../claim/Claim'
 import {
   ERROR_ADDRESS_INVALID,
@@ -102,7 +102,7 @@ describe('CType', () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
     const tx = await ctype.store(identityAlice)
-    const result = await submitSignedTx(tx)
+    const result = await Blockchain.submitSignedTx(identityAlice, tx)
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -102,7 +102,7 @@ describe('CType', () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
     const tx = await ctype.store(identityAlice)
-    const result = await Blockchain.submitSignedTx(identityAlice, tx)
+    const result = await Blockchain.submitSignedTx(tx, identityAlice)
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -93,7 +93,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationNode
       .revoke(identityAlice)
-      .then((tx) => Blockchain.submitSignedTx(tx, identityAlice))
+      .then((tx) => Blockchain.submitTxWithReSign(tx, identityAlice))
 
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -1,5 +1,7 @@
 import { submitSignedTx } from '../blockchain'
-import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
+import TYPE_REGISTRY, {
+  mockChainQueryReturn,
+} from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import { Permission } from '../types/Delegation'
 import DelegationNode from './DelegationNode'
@@ -14,6 +16,8 @@ beforeAll(async () => {
 })
 
 describe('Delegation', () => {
+  const api = require('../blockchainApiConnection/BlockchainApiConnection')
+    .__mocked_api
   it('delegation generate hash', () => {
     const node = new DelegationNode(
       '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -43,26 +47,25 @@ describe('Delegation', () => {
   })
 
   it('delegation verify / revoke', async () => {
-    require('../blockchainApiConnection/BlockchainApiConnection').__mocked_api.query.delegation.delegations = jest.fn(
-      async (id) => {
-        if (id === 'success') {
-          return mockChainQueryReturn('delegation', 'delegations', [
-            'myRootId',
-            null,
-            identityAlice.address,
-            1,
-            false,
-          ])
-        }
+    api.query.delegation.delegations = jest.fn(async (id) => {
+      if (id === 'success') {
         return mockChainQueryReturn('delegation', 'delegations', [
           'myRootId',
           null,
           identityAlice.address,
           1,
-          true,
+          false,
         ])
       }
-    )
+      return mockChainQueryReturn('delegation', 'delegations', [
+        'myRootId',
+        null,
+        identityAlice.address,
+        1,
+        true,
+      ])
+    })
+    api.registry = TYPE_REGISTRY
 
     expect(
       await new DelegationNode(

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -93,7 +93,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationNode
       .revoke(identityAlice)
-      .then((tx) => Blockchain.submitSignedTx(identityAlice, tx))
+      .then((tx) => Blockchain.submitSignedTx(tx, identityAlice))
 
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -1,4 +1,4 @@
-import { submitSignedTx } from '../blockchain'
+import Blockchain from '../blockchain'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
@@ -93,7 +93,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationNode
       .revoke(identityAlice)
-      .then((tx) => submitSignedTx(tx))
+      .then((tx) => Blockchain.submitSignedTx(identityAlice, tx))
 
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -42,7 +42,7 @@ describe('Delegation', () => {
     )
     await rootDelegation
       .store(identityAlice)
-      .then((tx) => Blockchain.submitSignedTx(identityAlice, tx))
+      .then((tx) => Blockchain.submitSignedTx(tx, identityAlice))
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
@@ -105,7 +105,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationRootNode
       .revoke(identityAlice)
-      .then((tx) => Blockchain.submitSignedTx(identityAlice, tx))
+      .then((tx) => Blockchain.submitSignedTx(tx, identityAlice))
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith('myRootId')
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -1,5 +1,5 @@
 import { Crypto, Identity } from '..'
-import { submitSignedTx } from '../blockchain'
+import Blockchain from '../blockchain'
 import getCached from '../blockchainApiConnection'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import DelegationRootNode from './DelegationRootNode'
@@ -40,7 +40,9 @@ describe('Delegation', () => {
       ctypeHash,
       identityAlice.address
     )
-    await rootDelegation.store(identityAlice).then((tx) => submitSignedTx(tx))
+    await rootDelegation
+      .store(identityAlice)
+      .then((tx) => Blockchain.submitSignedTx(identityAlice, tx))
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
@@ -103,7 +105,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationRootNode
       .revoke(identityAlice)
-      .then((tx) => submitSignedTx(tx))
+      .then((tx) => Blockchain.submitSignedTx(identityAlice, tx))
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith('myRootId')
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -42,7 +42,7 @@ describe('Delegation', () => {
     )
     await rootDelegation
       .store(identityAlice)
-      .then((tx) => Blockchain.submitSignedTx(tx, identityAlice))
+      .then((tx) => Blockchain.submitTxWithReSign(tx, identityAlice))
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
@@ -105,7 +105,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationRootNode
       .revoke(identityAlice)
-      .then((tx) => Blockchain.submitSignedTx(tx, identityAlice))
+      .then((tx) => Blockchain.submitTxWithReSign(tx, identityAlice))
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith('myRootId')
     expect(revokeStatus).toBeDefined()
   })

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -74,7 +74,7 @@ describe('DID', () => {
     const alice = await Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
     const tx = await did.store(alice)
-    await expect(blockchain.submitSignedTx(alice, tx)).resolves.toHaveProperty(
+    await expect(blockchain.submitSignedTx(tx, alice)).resolves.toHaveProperty(
       'isFinalized',
       true
     )

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -74,10 +74,9 @@ describe('DID', () => {
     const alice = await Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
     const tx = await did.store(alice)
-    await expect(blockchain.submitSignedTx(tx, alice)).resolves.toHaveProperty(
-      'isFinalized',
-      true
-    )
+    await expect(
+      blockchain.submitTxWithReSign(tx, alice)
+    ).resolves.toHaveProperty('isFinalized', true)
   })
 
   it('creates default did document', async () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -1,6 +1,6 @@
 import { U8aFixed } from '@polkadot/types'
 import { Did, IDid } from '..'
-import { submitSignedTx } from '../blockchain'
+import blockchain from '../blockchain'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
@@ -74,7 +74,7 @@ describe('DID', () => {
     const alice = await Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
     const tx = await did.store(alice)
-    await expect(submitSignedTx(tx)).resolves.toHaveProperty(
+    await expect(blockchain.submitSignedTx(alice, tx)).resolves.toHaveProperty(
       'isFinalized',
       true
     )

--- a/src/errorhandling/SDKErrors.ts
+++ b/src/errorhandling/SDKErrors.ts
@@ -9,6 +9,7 @@
 import { NonceHash } from '../types/RequestForAttestation'
 
 export enum ErrorCode {
+  ERROR_TRANSACTION_RECOVERABLE = 1000,
   ERROR_TRANSACTION_OUTDATED = 1010,
   ERROR_TRANSACTION_PRIORITY = 1014,
   ERROR_TRANSACTION_USURPED = 1015,
@@ -81,16 +82,22 @@ export class SDKError extends Error {
     this.errorCode = errorCode
   }
 }
-export const ERROR_TRANSACTION_PRIORITY: () => SDKError = () => {
+export const ERROR_TRANSACTION_RECOVERABLE: () => SDKError = () => {
   return new SDKError(
-    ErrorCode.ERROR_TRANSACTION_PRIORITY,
-    'Tx Priority too low to replace existing Tx with equal nonce'
+    ErrorCode.ERROR_TRANSACTION_RECOVERABLE,
+    'Tx failed due to nonce collision, this is recoverable by re-signing!'
   )
 }
 export const ERROR_TRANSACTION_OUTDATED: () => SDKError = () => {
   return new SDKError(
     ErrorCode.ERROR_TRANSACTION_OUTDATED,
     'Tx was signed with outdated Nonce'
+  )
+}
+export const ERROR_TRANSACTION_PRIORITY: () => SDKError = () => {
+  return new SDKError(
+    ErrorCode.ERROR_TRANSACTION_PRIORITY,
+    'Tx Priority too low to replace existing Tx with equal nonce'
   )
 }
 export const ERROR_TRANSACTION_USURPED: () => SDKError = () => {

--- a/src/errorhandling/SDKErrors.ts
+++ b/src/errorhandling/SDKErrors.ts
@@ -9,6 +9,9 @@
 import { NonceHash } from '../types/RequestForAttestation'
 
 export enum ErrorCode {
+  ERROR_TRANSACTION_OUTDATED = 1010,
+  ERROR_TRANSACTION_PRIORITY = 1014,
+  ERROR_TRANSACTION_USURPED = 1015,
   // Data is missing
   ERROR_CTYPE_HASH_NOT_PROVIDED = 10001,
   ERROR_CLAIM_HASH_NOT_PROVIDED = 10002,
@@ -77,6 +80,24 @@ export class SDKError extends Error {
     super(message)
     this.errorCode = errorCode
   }
+}
+export const ERROR_TRANSACTION_PRIORITY: () => SDKError = () => {
+  return new SDKError(
+    ErrorCode.ERROR_TRANSACTION_PRIORITY,
+    'Tx Priority too low to replace existing Tx with equal nonce'
+  )
+}
+export const ERROR_TRANSACTION_OUTDATED: () => SDKError = () => {
+  return new SDKError(
+    ErrorCode.ERROR_TRANSACTION_OUTDATED,
+    'Tx was signed with outdated Nonce'
+  )
+}
+export const ERROR_TRANSACTION_USURPED: () => SDKError = () => {
+  return new SDKError(
+    ErrorCode.ERROR_TRANSACTION_USURPED,
+    'Tx was replaced by another TX with the same Nonce and higher Priority'
+  )
 }
 export const ERROR_CTYPE_HASH_NOT_PROVIDED: () => SDKError = () => {
   return new SDKError(

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -331,6 +331,6 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => Blockchain.submitSignedTx(tx, this))
+      .then((tx) => Blockchain.submitTxWithReSign(tx, this))
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -8,7 +8,7 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { KeyringPair } from '@polkadot/keyring/types'
 import * as u8aUtil from '@polkadot/util/u8a'
-import { IS_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
+import Blockchain, { IS_FINALIZED } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import getCached from '../blockchainApiConnection'
 import {
@@ -313,7 +313,7 @@ export default class AttesterIdentity extends Identity {
     const bc = await getCached()
     const tx = bc.portablegabi.buildUpdateAccumulatorTX(acc)
     this.accumulator = acc
-    await bc.portablegabi.signAndSend(tx, this.signKeyringPair)
+    await bc.submitTx(this, tx)
   }
 
   /**
@@ -331,6 +331,8 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => submitSignedTx(tx, IS_FINALIZED))
+      .then((tx) =>
+        Blockchain.submitSignedTx(this, tx, { resolveOn: IS_FINALIZED })
+      )
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -331,6 +331,6 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => Blockchain.submitSignedTx(this, tx))
+      .then((tx) => Blockchain.submitSignedTx(tx, this))
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -8,7 +8,7 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { KeyringPair } from '@polkadot/keyring/types'
 import * as u8aUtil from '@polkadot/util/u8a'
-import Blockchain, { IS_FINALIZED } from '../blockchain/Blockchain'
+import Blockchain from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import getCached from '../blockchainApiConnection'
 import {
@@ -331,8 +331,6 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) =>
-        Blockchain.submitSignedTx(this, tx, { resolveOn: IS_FINALIZED })
-      )
+      .then((tx) => Blockchain.submitSignedTx(this, tx))
   }
 }

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -17,11 +17,13 @@ import { Claimer } from '@kiltprotocol/portablegabi'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Keyring } from '@polkadot/keyring'
 import { KeyringPair } from '@polkadot/keyring/types'
+import { Index } from '@polkadot/types/interfaces'
 import { mnemonicToMiniSecret } from '@polkadot/util-crypto'
 import generate from '@polkadot/util-crypto/mnemonic/generate'
 import validate from '@polkadot/util-crypto/mnemonic/validate'
 import { hexToU8a } from '@polkadot/util/hex'
 import * as u8aUtil from '@polkadot/util/u8a'
+import BN from 'bn.js'
 // see node_modules/@polkadot/util-crypto/nacl/keypair/fromSeed.js
 // as util-crypto is providing a wrapper only for signing keypair
 // and not for box keypair, we use TweetNaCl directly
@@ -425,21 +427,21 @@ export default class Identity {
    * Signs a submittable extrinsic (transaction), in preparation to pushing it to the blockchain.
    *
    * @param submittableExtrinsic - A chain transaction.
-   * @param nonceAsHex - The nonce of the address operating the transaction.
+   * @param nonce - The nonce of the address operating the transaction.
    * @returns The signed SubmittableExtrinsic.
    * @example ```javascript
    * const alice = Identity.buildFromMnemonic('car dog ...');
    * const tx = await blockchain.api.tx.ctype.add(ctype.hash);
    * const nonce = await blockchain.api.rpc.system.accountNextIndex(alice.address);
-   * alice.signSubmittableExtrinsic(tx, nonce.toHex());
+   * alice.signSubmittableExtrinsic(tx, nonce);
    * ```
    */
-  public signSubmittableExtrinsic(
+  public async signSubmittableExtrinsic(
     submittableExtrinsic: SubmittableExtrinsic,
-    nonceAsHex: string
-  ): SubmittableExtrinsic {
-    return submittableExtrinsic.sign(this.signKeyringPair, {
-      nonce: nonceAsHex,
+    nonce: number | Index | BN
+  ): Promise<SubmittableExtrinsic> {
+    return submittableExtrinsic.signAsync(this.signKeyringPair, {
+      nonce,
     })
   }
 

--- a/src/util/SubscriptionPromise.spec.ts
+++ b/src/util/SubscriptionPromise.spec.ts
@@ -9,29 +9,29 @@ const RESOLVE_ON: Evaluator<string> = (value) => value === RESOLVE
 const REJECT_ON: Evaluator<string> = (value) => value === REJECT && 'error'
 
 it('rejects promise on timeout', async () => {
-  const { promise, subscription } = makeSubscriptionPromise(
-    RESOLVE_ON,
-    REJECT_ON,
-    500
-  )
+  const { promise, subscription } = makeSubscriptionPromise({
+    resolveOn: RESOLVE_ON,
+    rejectOn: REJECT_ON,
+    timeout: 500,
+  })
   subscription('something else')
   await expect(promise).rejects.toThrow(ERROR_TIMEOUT())
 })
 
 it('resolves the promise', async () => {
-  const { promise, subscription } = makeSubscriptionPromise(
-    RESOLVE_ON,
-    REJECT_ON
-  )
+  const { promise, subscription } = makeSubscriptionPromise({
+    resolveOn: RESOLVE_ON,
+    rejectOn: REJECT_ON,
+  })
   subscription(RESOLVE)
   await expect(promise).resolves.toEqual(RESOLVE)
 })
 
 it('rejects the promise', async () => {
-  const { promise, subscription } = makeSubscriptionPromise(
-    RESOLVE_ON,
-    REJECT_ON
-  )
+  const { promise, subscription } = makeSubscriptionPromise({
+    resolveOn: RESOLVE_ON,
+    rejectOn: REJECT_ON,
+  })
   subscription(REJECT)
   await expect(promise).rejects.toEqual('error')
 })

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -25,12 +25,12 @@ export interface TerminationOptions<SubscriptionType> {
  * This promise is resolved with the value of latest update when a resolution criterion is met.
  * It is rejected with a custom error/reason if a rejection criterion is met or on timeout (optional). Rejection takes precedent.
  *
- * @param terminationOptions Object provides:
- * resolveOn: Resolution criterion. A function that evaluates an incoming update from the subscription.
+ * @param terminationOptions .
+ * @param terminationOptions.resolveOn Resolution criterion. A function that evaluates an incoming update from the subscription.
  * If it returns a truthy value, the promise is resolved with the value of the latest update.
- * optional rejectOn: Rejection criterion. A function that evaluates an incoming update from the subscription.
+ * @param terminationOptions.rejectOn Rejection criterion. A function that evaluates an incoming update from the subscription.
  * If it returns a truthy value, this value is used as rejection reason.
- * optional timeout: Timeout in ms. If set, the promise will reject if not resolved before the time is up.
+ * @param terminationOptions.timeout Timeout in ms. If set, the promise will reject if not resolved before the time is up.
  * @returns An object containing both a subscription callback
  * and a promise which resolves or rejects depending on the values pushed to the callback.
  */

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -12,26 +12,35 @@ export interface Evaluator<SubscriptionType> {
 }
 
 /**
+ * Object to provide termination Criteria for the created Subscription Promise.
+ */
+export interface TerminationOptions<SubscriptionType> {
+  resolveOn: Evaluator<SubscriptionType>
+  rejectOn?: Evaluator<SubscriptionType>
+  timeout?: number
+}
+
+/**
  * Helps building a promise associated to a subscription callback through which updates can be pushed to the promise.
  * This promise is resolved with the value of latest update when a resolution criterion is met.
  * It is rejected with a custom error/reason if a rejection criterion is met or on timeout (optional). Rejection takes precedent.
  *
- * @param resolveOn Resolution criterion. A function that evaluates an incoming update from the subscription.
+ * @param terminationOptions Object provides:
+ * resolveOn: Resolution criterion. A function that evaluates an incoming update from the subscription.
  * If it returns a truthy value, the promise is resolved with the value of the latest update.
- * @param rejectOn Rejection criterion. A function that evaluates an incoming update from the subscription.
+ * optional rejectOn: Rejection criterion. A function that evaluates an incoming update from the subscription.
  * If it returns a truthy value, this value is used as rejection reason.
- * @param timeout Timeout in ms. If set, the promise will reject if not resolved before the time is up.
+ * optional timeout: Timeout in ms. If set, the promise will reject if not resolved before the time is up.
  * @returns An object containing both a subscription callback
  * and a promise which resolves or rejects depending on the values pushed to the callback.
  */
 export function makeSubscriptionPromise<SubscriptionType>(
-  resolveOn: Evaluator<SubscriptionType>,
-  rejectOn?: Evaluator<SubscriptionType>,
-  timeout?: number
+  terminationOptions: TerminationOptions<SubscriptionType>
 ): {
   promise: Promise<SubscriptionType>
   subscription: (value: SubscriptionType) => void
 } {
+  const { resolveOn, rejectOn, timeout } = { ...terminationOptions }
   let resolve: (value: SubscriptionType) => void
   let reject: (reason: any) => void
   const promise = new Promise<SubscriptionType>((res, rej) => {
@@ -65,23 +74,15 @@ export function makeSubscriptionPromise<SubscriptionType>(
  * and an array of promises which resolve or reject depending on the values pushed to the callback.
  */
 export function makeSubscriptionPromiseMulti<SubscriptionType>(
-  args: Array<{
-    resolveOn: Evaluator<SubscriptionType>
-    rejectOn?: Evaluator<SubscriptionType>
-    timeout?: number
-  }>
+  args: Array<TerminationOptions<SubscriptionType>>
 ): {
   promises: Array<Promise<SubscriptionType>>
   subscription: (value: SubscriptionType) => void
 } {
   const promises: Array<Promise<SubscriptionType>> = []
   const subscriptions: Array<(value: SubscriptionType) => void> = []
-  args.forEach(({ resolveOn, rejectOn, timeout }) => {
-    const { promise, subscription } = makeSubscriptionPromise(
-      resolveOn,
-      rejectOn,
-      timeout
-    )
+  args.forEach((options: TerminationOptions<SubscriptionType>) => {
+    const { promise, subscription } = makeSubscriptionPromise(options)
     promises.push(promise)
     subscriptions.push(subscription)
   })


### PR DESCRIPTION
## fixes KILTprotocol/ticket#167
## fixes KILTprotocol/ticket#820

This PR adds support for doing multiple transactions per account at once, by managing a account specific nonce map and re-signing and re-sending tx that failed with an recoverable error.

Added or Refactored:
 - `IS_RELEVANT_ERROR`: regexp based `ErrorEvaluator` that matches recoverable errors.

 - `parseSubscriptionOptions`: `SubscriptionPromiseOptions` can be completely or partially omitted when calling any of the Blockchain methods.

 - `submitSignedTx`: exported function tries to send tx, catches errors, and rejects either with the original rejection reason, or rejects with ERROR_TRANSACTION_RECOVERABLE if the error can be recovered when re-signing.

 - `submitSignedTx`: Blockchain class method, calls exported function submitSignedTx, catches recoverable errors and re-signs and re-sends the tx up to two times, if identity was supplied.

 - `getNonce`: Uses `api.rpc.system.accountNextIndex` to determine the highest known nonce for the specified account. This nonce might be outdated when using multiple off-chain workers with the same account.

 - `reSignTx`: purges account from map, re-fetches the nonce, generates updated `SignerPayload` and injects it into the existing provided tx.


## How to test:
- Trigger multiple blockchain transactions
- All should go through
- Run CI without --runInBand, with realistic worker count (8 threads:` -w 7`)

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
