### PR TITLE
test: updating unit tests to use Option return values

### DIFF
--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -26,11 +26,11 @@ const UncleSam = alice
 const claimer = bob
 
 describe('handling attestations that do not exist', () => {
-  xtest('Attestation.query', async () => {
+  it('Attestation.query', async () => {
     return expect(Attestation.query('0x012012012')).resolves.toBeNull()
   }, 30_000)
 
-  test('Attestation.revoke', async () => {
+  it('Attestation.revoke', async () => {
     return expect(
       Attestation.revoke('0x012012012', Identity.buildFromURI('//Alice'))
     ).rejects.toThrow()

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -13,7 +13,7 @@ describe('When there is an CtypeCreator and a verifier', async () => {
 
   const ctype = CType.fromCType({
     schema: {
-      $id: 'http://example.com/ctype-1',
+      $id: 'http://example.com/ctype-10',
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       properties: {
         name: { type: 'string' },

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -137,7 +137,7 @@ describe('handling queries to data not on chain', () => {
     return expect(DelegationNode.query('0x012012012')).resolves.toBeNull()
   })
 
-  xit('DelegationRootNode.query on empty', async () => {
+  it('DelegationRootNode.query on empty', async () => {
     return expect(DelegationRootNode.query('0x012012012')).resolves.toBeNull()
   })
 

--- a/src/__integrationtests__/Did.spec.ts
+++ b/src/__integrationtests__/Did.spec.ts
@@ -9,7 +9,7 @@ import getCached from '../blockchainApiConnection'
 
 const ident = NewIdentity()
 
-xdescribe('querying DIDs that do not exist', () => {
+describe('querying DIDs that do not exist', () => {
   it('queryByAddress', async () => {
     return expect(queryByAddress(ident.address)).resolves.toBeNull()
   })

--- a/src/attestation/Attestation.spec.ts
+++ b/src/attestation/Attestation.spec.ts
@@ -1,6 +1,7 @@
 import { Text } from '@polkadot/types'
 import Bool from '@polkadot/types/primitive/Bool'
-import { Tuple } from '@polkadot/types/codec'
+import AccountId from '@polkadot/types/primitive/Generic/AccountId'
+import { Tuple, Option } from '@polkadot/types/codec'
 import Identity from '../identity/Identity'
 import Attestation from './Attestation'
 import CType from '../ctype/CType'
@@ -49,9 +50,12 @@ describe('Attestation', () => {
 
   it('stores attestation', async () => {
     Blockchain.api.query.attestation.attestations = jest.fn(() => {
-      const tuple = new Tuple(
-        [Text, Text, Text, Bool],
-        [testCType.hash, identityAlice.address, undefined, false]
+      const tuple = new Option(
+        Tuple,
+        new Tuple(
+          [Text, AccountId, Text, Bool],
+          [testCType.hash, identityAlice.address, undefined, false]
+        )
       )
       return Promise.resolve(tuple)
     })
@@ -65,7 +69,7 @@ describe('Attestation', () => {
 
   it('verify attestations not on chain', async () => {
     Blockchain.api.query.attestation.attestations = jest.fn(() => {
-      return Promise.resolve(new Tuple([], []))
+      return Promise.resolve(new Option(Tuple))
     })
 
     const attestation: Attestation = Attestation.fromAttestation({
@@ -80,10 +84,13 @@ describe('Attestation', () => {
   it('verify attestation revoked', async () => {
     Blockchain.api.query.attestation.attestations = jest.fn(() => {
       return Promise.resolve(
-        new Tuple(
-          // Attestations: claim-hash -> (ctype-hash, account, delegation-id?, revoked)
-          [Text, Text, Text, Bool],
-          [testCType.hash, identityAlice, undefined, true]
+        new Option(
+          Tuple,
+          new Tuple(
+            // Attestations: claim-hash -> (ctype-hash, account, delegation-id?, revoked)
+            [Text, AccountId, Text, Bool],
+            [testCType.hash, identityAlice.address, undefined, true]
+          )
         )
       )
     })

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -5,7 +5,7 @@ import { listenToBalanceChanges, makeTransfer } from './Balance.chain'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
-describe('Balance', async () => {
+describe('Balance', () => {
   const blockchain = require('../blockchain/Blockchain').default
 
   blockchain.api.query.balances.freeBalance = jest.fn((accountAddress, cb) => {

--- a/src/delegation/Delegation.spec.ts
+++ b/src/delegation/Delegation.spec.ts
@@ -1,6 +1,7 @@
-import { Text, Tuple } from '@polkadot/types'
+import { Text, Tuple, Vec, Option } from '@polkadot/types'
 import Bool from '@polkadot/types/primitive/Bool'
 import U32 from '@polkadot/types/primitive/U32'
+import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 import { Crypto, Identity } from '..'
 import DelegationNode from './DelegationNode'
 import { getAttestationHashes } from './Delegation.chain'
@@ -17,69 +18,81 @@ describe('Delegation', () => {
     return Promise.resolve()
   })
   blockchain.api.query.attestation.delegatedAttestations = jest.fn(() => {
-    const tuple = new Tuple(
+    const vector = new Vec(
       //  (claim-hash)
-      [Text, Text, Text],
+      Text,
       ['0x123', '0x456', '0x789']
     )
-    return Promise.resolve(tuple)
+    return Promise.resolve(vector)
   })
   blockchain.api.query.delegation.root = jest.fn(() => {
-    const tuple = new Tuple(
-      // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-      [Tuple.with([Text, Text, Bool])],
-      [[ctypeHash, identityAlice.address, false]]
+    const tuple = new Option(
+      Tuple,
+      new Tuple(
+        // Root-Delegation: root-id -> (ctype-hash, account, revoked)
+        [Text, AccountId, Bool],
+        [[ctypeHash, identityAlice.address, false]]
+      )
     )
     return Promise.resolve(tuple)
   })
   blockchain.api.query.delegation.delegations = jest.fn(delegationId => {
     let result = null
     if (delegationId === 'firstChild') {
-      result = new Tuple(
-        // Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
-        [Text, Text, Text, U32, Bool],
-        [
-          'rootId',
-          'myNodeId',
-          identityAlice.getPublicIdentity().address,
-          2,
-          false,
-        ]
+      result = new Option(
+        Tuple,
+        new Tuple(
+          // Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
+          [Text, Text, AccountId, U32, Bool],
+          [
+            'rootId',
+            'myNodeId',
+            identityAlice.getPublicIdentity().address,
+            2,
+            false,
+          ]
+        )
       )
     } else if (delegationId === 'secondChild') {
-      result = new Tuple(
-        // Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
-        [Text, Text, Text, U32, Bool],
-        [
-          'rootId',
-          'myNodeId',
-          identityAlice.getPublicIdentity().address,
-          1,
-          false,
-        ]
+      result = new Option(
+        Tuple,
+        new Tuple(
+          // Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
+          [Text, Text, AccountId, U32, Bool],
+          [
+            'rootId',
+            'myNodeId',
+            identityAlice.getPublicIdentity().address,
+            1,
+            false,
+          ]
+        )
       )
     } else if (delegationId === 'thirdChild') {
-      result = new Tuple(
-        // Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
-        [Text, Text, Text, U32, Bool],
-        [
-          'rootId',
-          'myNodeId',
-          identityAlice.getPublicIdentity().address,
-          0,
-          false,
-        ]
+      result = new Option(
+        Tuple,
+        new Tuple(
+          // Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
+          [Text, Text, AccountId, U32, Bool],
+          [
+            'rootId',
+            'myNodeId',
+            identityAlice.getPublicIdentity().address,
+            0,
+            false,
+          ]
+        )
       )
     }
     return Promise.resolve(result)
   })
   blockchain.api.query.delegation.children = jest.fn(() => {
-    const tuple = new Tuple(
+    const vector = new Vec(
       // Children: delegation-id -> [delegation-ids]
-      [Text, Text, Text],
+      Text,
       ['firstChild', 'secondChild', 'thirdChild']
     )
-    return Promise.resolve(tuple)
+    return Promise.resolve(vector)
   })
 
   it('get children', async () => {

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -42,17 +42,23 @@ describe('Delegation', () => {
     require('../blockchain/Blockchain').default.__mockQueryDelegationDelegations = jest.fn(
       id => {
         if (id === 'success') {
-          const tuple = new Tuple(
-            // (root-id, parent-id?, account, permissions, revoked)
-            [Text, Option, Text, U32, Bool],
-            ['myRootId', null, 'myAccount', 1, false]
+          const tuple = new Option(
+            Tuple,
+            new Tuple(
+              // (root-id, parent-id?, account, permissions, revoked)
+              [Text, Option, Text, U32, Bool],
+              ['myRootId', null, 'myAccount', 1, false]
+            )
           )
           return Promise.resolve(tuple)
         }
-        const tuple = new Tuple(
-          // (root-id, parent-id?, account, permissions, revoked)
-          [Text, Option, Text, U32, Bool],
-          ['myRootId', null, 'myAccount', 1, true]
+        const tuple = new Option(
+          Tuple,
+          new Tuple(
+            // (root-id, parent-id?, account, permissions, revoked)
+            [Text, Option, Text, U32, Bool],
+            ['myRootId', null, 'myAccount', 1, true]
+          )
         )
         return Promise.resolve(tuple)
       }
@@ -82,14 +88,17 @@ describe('Delegation', () => {
 
     require('../blockchain/Blockchain').default.__mockQueryDelegationRoot = jest.fn(
       () => {
-        const tuple = new Tuple(
-          // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-          [H256, Text, Bool],
-          [
-            '0x1234000000000000000000000000000000000000000000000000000000000000',
-            identityAlice.address,
-            false,
-          ]
+        const tuple = new Option(
+          Tuple,
+          new Tuple(
+            // Root-Delegation: root-id -> (ctype-hash, account, revoked)
+            [H256, Text, Bool],
+            [
+              '0x1234000000000000000000000000000000000000000000000000000000000000',
+              identityAlice.address,
+              false,
+            ]
+          )
         )
         return Promise.resolve(tuple)
       }

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -1,4 +1,5 @@
-import { Text, Tuple, H256 } from '@polkadot/types'
+import { Text, Tuple, H256, Option } from '@polkadot/types'
+import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 import Bool from '@polkadot/types/primitive/Bool'
 import { Crypto, Identity } from '..'
 import DelegationRootNode from './DelegationRootNode'
@@ -7,24 +8,29 @@ jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
 describe('Delegation', () => {
   const identityAlice = Identity.buildFromURI('//Alice')
-
   const ctypeHash = Crypto.hashStr('testCtype')
   require('../blockchain/Blockchain').default.__mockQueryDelegationRoot = jest.fn(
     () => {
-      const tuple = new Tuple(
-        // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-        [H256, Text, Bool],
-        [ctypeHash, identityAlice.address, false]
+      const tuple = new Option(
+        Tuple,
+        new Tuple(
+          // Root-Delegation: root-id -> (ctype-hash, account, revoked)
+          [H256, AccountId, Bool],
+          [ctypeHash, identityAlice.address, false]
+        )
       )
       return Promise.resolve(tuple)
     }
   )
   require('../blockchain/Blockchain').default.__mockQueryDelegationDelegation = jest.fn(
     () => {
-      const tuple = new Tuple(
-        // Root-Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
-        [H256, Text, Bool],
-        [ctypeHash, identityAlice.address, false]
+      const tuple = new Option(
+        Tuple,
+        new Tuple(
+          // Root-Delegation: delegation-id -> (root-id, parent-id?, account, permissions, revoked)
+          [H256, AccountId, Bool],
+          [ctypeHash, identityAlice.address, false]
+        )
       )
       return Promise.resolve(tuple)
     }
@@ -59,17 +65,23 @@ describe('Delegation', () => {
     require('../blockchain/Blockchain').default.__mockQueryDelegationRoot = jest.fn(
       rootId => {
         if (rootId === 'success') {
-          const tuple = new Tuple(
-            // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-            [Text, Text, Bool],
-            ['myCtypeHash', 'myAccount', false]
+          const tuple = new Option(
+            Tuple,
+            new Tuple(
+              // Root-Delegation: root-id -> (ctype-hash, account, revoked)
+              [Text, Text, Bool],
+              ['myCtypeHash', 'myAccount', false]
+            )
           )
           return Promise.resolve(tuple)
         }
-        const tuple = new Tuple(
-          // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-          [Text, Text, Bool],
-          ['myCtypeHash', 'myAccount', true]
+        const tuple = new Option(
+          Tuple,
+          new Tuple(
+            // Root-Delegation: root-id -> (ctype-hash, account, revoked)
+            [Text, Text, Bool],
+            ['myCtypeHash', 'myAccount', true]
+          )
         )
         return Promise.resolve(tuple)
       }

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -11,17 +11,23 @@ describe('DID', () => {
   require('../blockchain/Blockchain').default.__mockQueryDidDids = jest.fn(
     address => {
       if (address === 'withDocumentStore') {
-        const tuple = new Tuple(
-          // (publicBoxKey, publicSigningKey, documentStore?)
-          [Text, Text, U8a],
-          ['0x987', '0x123', '0x687474703a2f2f6d794449442e6b696c742e696f']
+        const tuple = new Option(
+          Tuple,
+          new Tuple(
+            // (publicBoxKey, publicSigningKey, documentStore?)
+            [Text, Text, U8a],
+            ['0x987', '0x123', '0x687474703a2f2f6d794449442e6b696c742e696f']
+          )
         )
         return Promise.resolve(tuple)
       }
-      const tuple = new Tuple(
-        // (publicBoxKey, publicSigningKey, documentStore?)
-        [Text, Text, Option],
-        ['0x987', '0x123', null]
+      const tuple = new Option(
+        Tuple,
+        new Tuple(
+          // (publicBoxKey, publicSigningKey, documentStore?)
+          [Text, Text, Option],
+          ['0x987', '0x123', null]
+        )
       )
       return Promise.resolve(tuple)
     }

--- a/src/identity/PublicIdentity.spec.ts
+++ b/src/identity/PublicIdentity.spec.ts
@@ -1,4 +1,4 @@
-import { Text, Tuple, U8a } from '@polkadot/types'
+import { Text, Tuple, U8a, Option } from '@polkadot/types'
 import PublicIdentity, { IURLResolver } from './PublicIdentity'
 import IPublicIdentity from '../types/PublicIdentity'
 
@@ -13,17 +13,23 @@ describe('PublicIdentity', () => {
       let tuple
       switch (id) {
         case '1':
-          tuple = new Tuple(
-            // (public-signing-key, public-encryption-key, did-reference?)
-            [Text, Text, U8a],
-            ['pub-key', 'box-key', [14, 75, 23, 14, 55]]
+          tuple = new Option(
+            Tuple,
+            new Tuple(
+              // (public-signing-key, public-encryption-key, did-reference?)
+              [Text, Text, U8a],
+              ['pub-key', 'box-key', [14, 75, 23, 14, 55]]
+            )
           )
           break
         case '2':
-          tuple = new Tuple(
-            // (public-signing-key, public-encryption-key, did-reference?)
-            [Text, Text, Text],
-            ['pub-key', 'box-key', undefined]
+          tuple = new Option(
+            Tuple,
+            new Tuple(
+              // (public-signing-key, public-encryption-key, did-reference?)
+              [Text, Text, Text],
+              ['pub-key', 'box-key', undefined]
+            )
           )
           break
         default:


### PR DESCRIPTION
fixes https://github.com/KILTprotocol/ticket/issues/304
Option return values are introduced in KILTprotocol/mashnet-node#78
This change set is compatible with the current SDK. This PR just updates the mocked return values to reflect that objects of type `Option` are returned in most `api.query.` calls to ensure they accurately reflect the behaviour of the actual mashnet node.

## How to test:
`yarn test`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
