### PR TITLE
fix: take delegationId from request

### DIFF
--- a/src/attestation/Attestation.spec.ts
+++ b/src/attestation/Attestation.spec.ts
@@ -58,8 +58,7 @@ describe('Attestation', () => {
 
     const attestation: Attestation = Attestation.fromRequestAndPublicIdentity(
       requestForAttestation,
-      identityAlice,
-      null
+      identityAlice
     )
     expect(await attestation.verify()).toBeTruthy()
   })
@@ -91,8 +90,7 @@ describe('Attestation', () => {
 
     const attestation: Attestation = Attestation.fromRequestAndPublicIdentity(
       requestForAttestation,
-      identityAlice,
-      null
+      identityAlice
     )
     expect(await attestation.verify()).toBeFalsy()
   })

--- a/src/attestation/Attestation.ts
+++ b/src/attestation/Attestation.ts
@@ -19,7 +19,6 @@ import { factory } from '../config/ConfigLog'
 import Identity from '../identity/Identity'
 import IAttestation from '../types/Attestation'
 import { revoke, query, store } from './Attestation.chain'
-import { IDelegationBaseNode } from '../types/Delegation'
 import IPublicIdentity from '../types/PublicIdentity'
 
 const log = factory.getLogger('Attestation')
@@ -88,14 +87,13 @@ export default class Attestation implements IAttestation {
    */
   public static fromRequestAndPublicIdentity(
     request: IRequestForAttestation,
-    attesterPublicIdentity: IPublicIdentity,
-    delegationIdInput: IDelegationBaseNode['id'] | null
-  ) {
+    attesterPublicIdentity: IPublicIdentity
+  ): Attestation {
     return new Attestation({
       claimHash: request.rootHash,
       cTypeHash: request.claim.cTypeHash,
       owner: attesterPublicIdentity.address,
-      delegationId: delegationIdInput,
+      delegationId: request.delegationId,
       revoked: false,
     })
   }

--- a/src/attestedclaim/AttestedClaim.spec.ts
+++ b/src/attestedclaim/AttestedClaim.spec.ts
@@ -48,8 +48,7 @@ function buildAttestedClaim(
   // build attestation
   const testAttestation: Attestation = Attestation.fromRequestAndPublicIdentity(
     requestForAttestation,
-    attester,
-    null
+    attester
   )
   // combine to attested claim
   const attestedClaim: AttestedClaim = AttestedClaim.fromRequestAndAttestation(

--- a/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/src/requestforattestation/RequestForAttestation.spec.ts
@@ -62,8 +62,7 @@ describe('RequestForAttestation', () => {
   // build attestation
   const legitimationAttestation: Attestation = Attestation.fromRequestAndPublicIdentity(
     legitimationRequest,
-    identityCharlie,
-    null
+    identityCharlie
   )
   // combine to attested claim
   const legitimation: AttestedClaim = AttestedClaim.fromRequestAndAttestation(


### PR DESCRIPTION
## HOTFIX
The delegation id was not taken from the `RequestForAttestation`, but a new parameter. This is unnecessary, since it is already included there.
This also did break the demo-client.

## How to test:
- Make a delegation tree and make an attestation with that
- Look at the chain-explorer to see the inclusion of the delegation id in the attestation, which is written on-chain

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
