### PR TITLE
test: added unit test for blank ctypes

### DIFF
--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -5,6 +5,7 @@ import ICType from '../types/CType'
 import TxStatus from '../blockchain/TxStatus'
 import Claim from '../claim/Claim'
 import { FINALIZED } from '../const/TxStatus'
+import requestForAttestation from '../requestforattestation/RequestForAttestation'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -84,5 +85,65 @@ describe('CType', () => {
     expect(() => {
       return CType.fromCType(wrongRawCtype)
     }).toThrow()
+  })
+})
+
+describe('blank ctypes', () => {
+  const identityAlice = Identity.buildFromURI('//Alice')
+
+  const ctypeSchema1: ICType['schema'] = {
+    $id: 'http://example.com/hasDriversLicense',
+    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    properties: {},
+    type: 'object',
+  }
+
+  const icytype1: ICType = {
+    schema: ctypeSchema1,
+    owner: identityAlice.address,
+    hash: '',
+  }
+
+  const ctypeSchema2: ICType['schema'] = {
+    $id: 'http://example.com/claimedSomething',
+    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    properties: {},
+    type: 'object',
+  }
+
+  const icytype2: ICType = {
+    schema: ctypeSchema2,
+    owner: identityAlice.address,
+    hash: '',
+  }
+
+  const ctype1 = CType.fromCType(icytype1)
+  const ctype2 = CType.fromCType(icytype2)
+
+  it('two ctypes with no properties have different hashes if id is different', () => {
+    expect(ctype1.owner).toEqual(ctype2.owner)
+    expect(ctype1.schema).not.toEqual(ctype2.schema)
+    expect(ctype1.hash).not.toEqual(ctype2.hash)
+  })
+
+  it('two claims on an empty ctypes will have different root hash', () => {
+    const claimA1 = Claim.fromCTypeAndClaimContents(
+      ctype1,
+      {},
+      identityAlice.address
+    )
+    const claimA2 = Claim.fromCTypeAndClaimContents(
+      ctype2,
+      {},
+      identityAlice.address
+    )
+
+    expect(
+      requestForAttestation.fromClaimAndIdentity(claimA1, identityAlice)
+        .rootHash
+    ).not.toEqual(
+      requestForAttestation.fromClaimAndIdentity(claimA2, identityAlice)
+        .rootHash
+    )
   })
 })


### PR DESCRIPTION
fixes https://github.com/KILTprotocol/ticket/issues/232
added tests that are making sure that ctypes with no properties can be stored and used
without conflicts as long as $id is different. This has been an issue in the past (see linked issue) and should be confirmed working going forward.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
