### PR TITLE
test: refactoring tests for alice & bob w/ tokens

### DIFF
--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -106,8 +106,7 @@ describe('When there is an attester, claimer and ctype drivers license', async (
     expect(request.verifySignature()).toBeTruthy()
     const attestation = Attestation.fromRequestAndPublicIdentity(
       request,
-      attester.getPublicIdentity(),
-      null
+      attester.getPublicIdentity()
     )
 
     const BobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -7,7 +7,6 @@ import {
   alice,
   bob,
   DriversLicense,
-  endow,
   CtypeOnChain,
   IsOfficialLicenseAuthority,
 } from './utils'
@@ -21,8 +20,8 @@ import CType from '../ctype/CType'
 import ICType from '../types/CType'
 import { Identity } from '..'
 
-const attester = faucet
-const UncleSam = alice
+const UncleSam = faucet
+const attester = alice
 const claimer = bob
 
 describe('handling attestations that do not exist', () => {
@@ -88,6 +87,34 @@ describe('When there is an attester, claimer and ctype drivers license', async (
     const aClaim = AttestedClaim.fromRequestAndAttestation(request, attestation)
     expect(aClaim.verifyData()).toBeTruthy()
     await expect(aClaim.verify()).resolves.toBeTruthy()
+  }, 60_000)
+
+  it('should not be possible to attest a claim w/o tokens', async () => {
+    const content = { name: 'Ralfi', age: 10 }
+    const claim = Claim.fromCTypeAndClaimContents(
+      DriversLicense,
+      content,
+      claimer.address
+    )
+    const request = RequestForAttestation.fromClaimAndIdentity(
+      claim,
+      claimer,
+      [],
+      null
+    )
+    expect(request.verifyData()).toBeTruthy()
+    expect(request.verifySignature()).toBeTruthy()
+    const attestation = Attestation.fromRequestAndPublicIdentity(
+      request,
+      attester.getPublicIdentity(),
+      null
+    )
+
+    const BobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
+
+    await expect(attestation.store(BobbyBroke)).rejects.toThrow()
+    const aClaim = AttestedClaim.fromRequestAndAttestation(request, attestation)
+    await expect(aClaim.verify()).resolves.toBeFalsy()
   }, 60_000)
 
   it('should not be possible to attest a claim on a Ctype that is not on chain', async () => {
@@ -161,7 +188,6 @@ describe('When there is an attester, claimer and ctype drivers license', async (
     }, 15000)
 
     it('should not be possible for the claimer to revoke an attestation', async () => {
-      await endow(claimer)
       await expect(revoke(AttClaim.getHash(), claimer)).rejects.toThrowError(
         'not permitted'
       )
@@ -178,9 +204,8 @@ describe('When there is an attester, claimer and ctype drivers license', async (
 
   describe('when there is another Ctype that works as a legitimation', async () => {
     beforeAll(async () => {
-      await endow(UncleSam)
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
-        await IsOfficialLicenseAuthority.store(attester)
+        await IsOfficialLicenseAuthority.store(UncleSam)
       }
       await expect(
         CtypeOnChain(IsOfficialLicenseAuthority)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -86,8 +86,8 @@ describe('When there are haves and have-nots', async () => {
       getBalance(RichieRich.address),
       getBalance(BobbyBroke.address),
     ])
-    expect(zeroBalance.toNumber()).toBe(0)
-    expect(newBalance.toNumber()).toBe(RichieBalance.sub(GAS).toNumber())
+    expect(zeroBalance.toString()).toEqual('0')
+    expect(newBalance.toString()).toEqual(RichieBalance.sub(GAS).toString())
   }, 15000)
 
   xit('should be able to make multiple transactions at once', async () => {

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -9,13 +9,7 @@ import {
   makeTransfer,
   listenToBalanceChanges,
 } from '../balance/Balance.chain'
-import {
-  GAS,
-  MIN_TRANSACTION,
-  faucet,
-  transferTokens,
-  NewIdentity,
-} from './utils'
+import { GAS, MIN_TRANSACTION, faucet, bob, alice, NewIdentity } from './utils'
 import getCached from '../blockchainApiConnection'
 
 describe('when there is a dev chain with a faucet', async () => {
@@ -23,6 +17,16 @@ describe('when there is a dev chain with a faucet', async () => {
     const balance = await getBalance(faucet.address)
     expect(balance.gt(new BN(100000000))).toBeTruthy()
     // console.log(`Faucet has ${Number(balance)} micro Kilt`)
+  })
+
+  it('Bob has tokens', async () => {
+    const balance = await getBalance(bob.address)
+    expect(balance.gt(new BN(100_000_000))).toBeTruthy()
+  })
+
+  it('Alice has tokens', async () => {
+    const balance = await getBalance(alice.address)
+    expect(balance.gt(new BN(100_000_000))).toBeTruthy()
   })
 
   it('getBalance should return 0 for new identity', async () => {
@@ -35,8 +39,15 @@ describe('when there is a dev chain with a faucet', async () => {
     const ident = NewIdentity()
     const funny = jest.fn()
     listenToBalanceChanges(ident.address, funny)
-    await transferTokens(faucet, ident, MIN_TRANSACTION)
-    const balanceIdent = await getBalance(ident.address)
+    const balanceBefore = await getBalance(faucet.address)
+    await makeTransfer(faucet, ident.address, MIN_TRANSACTION)
+    const [balanceAfter, balanceIdent] = await Promise.all([
+      getBalance(faucet.address),
+      getBalance(ident.address),
+    ])
+    expect(
+      balanceBefore.sub(balanceAfter).eq(MIN_TRANSACTION.add(GAS))
+    ).toBeTruthy()
     expect(balanceIdent.toNumber()).toBe(MIN_TRANSACTION.toNumber())
     expect(funny).toBeCalled()
   }, 15000)
@@ -44,17 +55,11 @@ describe('when there is a dev chain with a faucet', async () => {
 
 describe('When there are haves and have-nots', async () => {
   const BobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
-  const RichieRich = Identity.buildFromMnemonic(Identity.generateMnemonic())
+  const RichieRich = alice
   const StormyD = Identity.buildFromMnemonic(Identity.generateMnemonic())
 
-  beforeAll(async () => {
-    await Promise.all([
-      transferTokens(faucet, RichieRich, MIN_TRANSACTION.mul(new BN(1000))),
-    ])
-  }, 30000)
-
   it('can transfer tokens from the rich to the poor', async () => {
-    await transferTokens(RichieRich, StormyD, MIN_TRANSACTION)
+    await makeTransfer(RichieRich, StormyD.address, MIN_TRANSACTION)
     const balanceTo = await getBalance(StormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 15000)

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -7,6 +7,7 @@ import CType from '../ctype/CType'
 import ICType from '../types/CType'
 import { getOwner } from '../ctype/CType.chain'
 import getCached from '../blockchainApiConnection'
+import { Identity } from '..'
 
 describe('When there is an CtypeCreator and a verifier', async () => {
   const CtypeCreator = faucet
@@ -21,6 +22,12 @@ describe('When there is an CtypeCreator and a verifier', async () => {
       type: 'object',
     } as ICType['schema'],
   } as ICType)
+
+  it('should not be possible to create a claim type w/o tokens', async () => {
+    const BobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
+    await expect(ctype.store(BobbyBroke)).rejects.toThrowError()
+    await expect(ctype.verifyStored()).resolves.toBeFalsy()
+  }, 20000)
 
   it('should be possible to create a claim type', async () => {
     await ctype.store(CtypeCreator)

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -11,14 +11,7 @@ import Claim from '../claim/Claim'
 import RequestForAttestation from '../requestforattestation/RequestForAttestation'
 import Attestation from '../attestation/Attestation'
 import AttestedClaim from '../attestedclaim/AttestedClaim'
-import {
-  faucet,
-  alice,
-  bob,
-  DriversLicense,
-  CtypeOnChain,
-  endow,
-} from './utils'
+import { faucet, alice, bob, DriversLicense, CtypeOnChain } from './utils'
 import {
   getChildIds,
   getAttestationHashes,
@@ -26,13 +19,12 @@ import {
 } from '../delegation/Delegation.chain'
 import { decodeDelegationNode } from '../delegation/DelegationDecoder'
 
-const attester = faucet
-const UncleSam = alice
+const UncleSam = faucet
+const attester = alice
 const claimer = bob
 
 describe('when there is an account hierarchy', async () => {
   beforeAll(async () => {
-    await endow(UncleSam)
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester)
     }
@@ -65,8 +57,6 @@ describe('when there is an account hierarchy', async () => {
     let delegatedNode: DelegationNode
 
     beforeAll(async () => {
-      await endow(attester)
-
       rootNode = new DelegationRootNode(
         UUID.generate(),
         DriversLicense.hash,

--- a/src/__integrationtests__/utils.ts
+++ b/src/__integrationtests__/utils.ts
@@ -1,9 +1,7 @@
 /* eslint-disable */
 
 import BN from 'bn.js/'
-import TxStatus from '../blockchain/TxStatus'
 import Identity from '../identity/Identity'
-import { getBalance, makeTransfer } from '../balance/Balance.chain'
 import CType from '../ctype/CType'
 import ICType from '../types/CType'
 import { getOwner } from '../ctype/CType.chain'
@@ -11,31 +9,6 @@ import { getOwner } from '../ctype/CType.chain'
 export const GAS = new BN(1000000)
 export const MIN_TRANSACTION = new BN(100000000)
 export const ENDOWMENT = MIN_TRANSACTION.mul(new BN(100))
-
-export async function transferTokens(
-  from: Identity,
-  to: Identity,
-  amount: BN
-): Promise<TxStatus> {
-  const [balanceFrom, balanceTo] = await Promise.all([
-    getBalance(from.address),
-    getBalance(to.address),
-  ])
-  expect(balanceFrom.gte(amount.add(GAS))).toBeTruthy()
-  const status = await makeTransfer(from, to.address, amount)
-  const [newBalanceFrom, newBalanceTo] = await Promise.all([
-    getBalance(from.address),
-    getBalance(to.address),
-  ])
-  expect(newBalanceTo.sub(balanceTo).eq(amount)).toBeTruthy()
-  expect(balanceFrom.sub(newBalanceFrom).eq(amount.add(GAS))).toBeTruthy()
-  console.log(
-    `Successfully transferred ${amount.toNumber()} from ${from.address} to ${
-      to.address
-    }`
-  )
-  return status
-}
 
 export function NewIdentity(): Identity {
   return Identity.buildFromMnemonic(Identity.generateMnemonic())
@@ -47,14 +20,6 @@ const FaucetSeed =
 export const faucet = Identity.buildFromMnemonic(FaucetSeed)
 export const alice = Identity.buildFromURI('//Alice')
 export const bob = Identity.buildFromURI('//Bob')
-
-export async function endow(receiver: Identity) {
-  const balance = await getBalance(receiver.address)
-  if (balance.eq(new BN(0))) {
-    await makeTransfer(faucet, receiver.address, ENDOWMENT)
-  }
-  return receiver
-}
 
 export async function CtypeOnChain(ctype: CType): Promise<boolean> {
   return getOwner(ctype.hash)


### PR DESCRIPTION
## NO TICKET; re/ KILTprotocol/ticket#308

Refactorings on the assumption that Alice and Bob are endowed identities on the dev chain, thus eliminating the need to transfer money to them when two token holding identities are required for a test.

## How to test:
run integration tests with a mashnet dev node that incorporates the changes introduced by https://github.com/KILTprotocol/mashnet-node/pull/79 

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
