### PR TITLE
WIP: replace transaction status constants with substrate SDK status checks

### DIFF
--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js/'
 import Identity from '../identity/Identity'
 // import partial from 'lodash/partial'
 import { listenToBalanceChanges, makeTransfer } from './Balance.chain'
+import TxStatus from '../blockchain/TxStatus'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -38,7 +39,8 @@ describe('Balance', () => {
     const alice = Identity.buildFromURI('//Alice')
     const bob = Identity.buildFromURI('//Bob')
 
-    const hash = await makeTransfer(alice, bob.address, new BN(100))
-    expect(hash).toBe('123')
+    const status = await makeTransfer(alice, bob.address, new BN(100))
+    expect(status).toBeInstanceOf(TxStatus)
+    expect(status.isFinalized).toBeTruthy()
   })
 })

--- a/src/blockchain/TxStatus.ts
+++ b/src/blockchain/TxStatus.ts
@@ -1,14 +1,38 @@
+import { ExtrinsicStatus } from '@polkadot/types/interfaces'
+
 /**
  * @packageDocumentation
  * @module TxStatus
  */
 
 export default class TxStatus {
-  public type: string
   public payload: any
+  readonly type: ExtrinsicStatus['type']
+  readonly isFuture: boolean
+  readonly isReady: boolean
+  readonly isFinalized: boolean
+  readonly isUsurped: boolean
+  readonly isBroadcast: boolean
+  readonly isDropped: boolean
+  readonly isInvalid: boolean
 
-  public constructor(type: string, payload?: any) {
-    this.type = type
+  public constructor(status: ExtrinsicStatus, payload?: any) {
     this.payload = payload
+    this.type = status.type
+    this.isFuture = status.isFuture
+    this.isReady = status.isReady
+    this.isFinalized = status.isFinalized
+    this.isUsurped = status.isUsurped
+    this.isBroadcast = status.isBroadcast
+    this.isDropped = status.isDropped
+    this.isInvalid = status.isInvalid
+  }
+
+  get isCompleted(): boolean {
+    return this.isError || this.isFinalized
+  }
+
+  get isError(): boolean {
+    return this.isDropped || this.isInvalid || this.isUsurped
   }
 }

--- a/src/blockchain/TxStatus.ts
+++ b/src/blockchain/TxStatus.ts
@@ -1,12 +1,11 @@
-import { ExtrinsicStatus } from '@polkadot/types/interfaces'
-
 /**
  * @packageDocumentation
  * @module TxStatus
  */
+import { ExtrinsicStatus } from '@polkadot/types/interfaces'
 
-export default class TxStatus {
-  public payload: any
+export default class TxStatus implements Partial<ExtrinsicStatus> {
+  public payload: string | object | undefined
   readonly type: ExtrinsicStatus['type']
   readonly isFuture: boolean
   readonly isReady: boolean
@@ -16,16 +15,19 @@ export default class TxStatus {
   readonly isDropped: boolean
   readonly isInvalid: boolean
 
-  public constructor(status: ExtrinsicStatus, payload?: any) {
+  public constructor(
+    status: Partial<ExtrinsicStatus>,
+    payload?: string | object
+  ) {
     this.payload = payload
-    this.type = status.type
-    this.isFuture = status.isFuture
-    this.isReady = status.isReady
-    this.isFinalized = status.isFinalized
-    this.isUsurped = status.isUsurped
-    this.isBroadcast = status.isBroadcast
-    this.isDropped = status.isDropped
-    this.isInvalid = status.isInvalid
+    this.type = status.type ? status.type : ''
+    this.isFuture = !!status.isFuture
+    this.isReady = !!status.isReady
+    this.isFinalized = !!status.isFinalized
+    this.isUsurped = !!status.isUsurped
+    this.isBroadcast = !!status.isBroadcast
+    this.isDropped = !!status.isDropped
+    this.isInvalid = !!status.isInvalid
   }
 
   get isCompleted(): boolean {

--- a/src/blockchain/__mocks__/Blockchain.ts
+++ b/src/blockchain/__mocks__/Blockchain.ts
@@ -1,3 +1,5 @@
+import TxStatus from '../TxStatus'
+
 /**
  * @module Blockchain
  * @ignore
@@ -8,6 +10,7 @@
  */
 const blockchain: any = {
   __mockResultHash: '',
+  __mockTxStatus: {payload: undefined, type: 'Finalized', isFinalized: true, isError: false, isDropped: false, isInvalid: false, isUsurped: false},
   __mockTxDelegationRoot: jest.fn(),
   __mockQueryDelegationRoot: jest.fn(),
   __mockQueryDelegationDelegation: jest.fn(),
@@ -88,7 +91,7 @@ const blockchain: any = {
   listenToBalanceChanges: jest.fn(),
   makeTransfer: jest.fn(),
   submitTx: jest.fn((identity, tx) => {
-    return Promise.resolve(blockchain.__mockResultHash)
+    return Promise.resolve(new TxStatus(blockchain.__mockTxStatus))
   }),
   getNonce: jest.fn(),
 }

--- a/src/blockchain/alternateTxStatus.ts
+++ b/src/blockchain/alternateTxStatus.ts
@@ -1,0 +1,39 @@
+/**
+ * @packageDocumentation
+ * @module AlternateTxStatus
+ */
+import { SubmittableResult } from '@polkadot/api'
+import { ExtrinsicStatus } from '@polkadot/types/interfaces'
+
+export default class TxStatus extends SubmittableResult {
+  public payload: string | object | undefined
+
+  public constructor(status: ExtrinsicStatus, payload?: string | object) {
+    super({ status })
+    this.payload = payload
+  }
+
+  get type(): ExtrinsicStatus['type'] {
+    return this.status.type
+  }
+
+  get isFuture(): boolean {
+    return this.status.isFuture
+  }
+
+  get isReady(): boolean {
+    return this.status.isReady
+  }
+
+  get isUsurped(): boolean {
+    return this.status.isUsurped
+  }
+
+  get isDropped(): boolean {
+    return this.status.isDropped
+  }
+
+  get isInvalid(): boolean {
+    return this.status.isInvalid
+  }
+}

--- a/src/const/TxStatus.ts
+++ b/src/const/TxStatus.ts
@@ -1,9 +1,0 @@
-/**
- * @packageDocumentation
- * @ignore
- */
-
-export const FINALIZED = 'Finalized'
-export const INVALID = 'Invalid'
-export const DROPPED = 'Dropped'
-export const OK = 'Ok'

--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -1,7 +1,0 @@
-/**
- * @packageDocumentation
- * @ignore
- */
-import * as TxStatus from './TxStatus'
-
-export default TxStatus

--- a/src/ctype/CType.chain.ts
+++ b/src/ctype/CType.chain.ts
@@ -4,7 +4,6 @@
  */
 
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
-import { FINALIZED } from '../const/TxStatus'
 import { QueryResult } from '../blockchain/Blockchain'
 import { getCached } from '../blockchainApiConnection'
 import TxStatus from '../blockchain/TxStatus'
@@ -23,7 +22,7 @@ export async function store(
   log.debug(() => `Create tx for 'ctype.add'`)
   const tx: SubmittableExtrinsic = await blockchain.api.tx.ctype.add(ctype.hash)
   const txStatus: TxStatus = await blockchain.submitTx(identity, tx)
-  if (txStatus.type === FINALIZED) {
+  if (txStatus.isFinalized) {
     txStatus.payload = {
       ...ctype,
       owner: identity.address,

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -2,9 +2,7 @@ import CType from './CType'
 import Identity from '../identity/Identity'
 import Crypto from '../crypto'
 import ICType from '../types/CType'
-import TxStatus from '../blockchain/TxStatus'
 import Claim from '../claim/Claim'
-import { FINALIZED } from '../const/TxStatus'
 import requestForAttestation from '../requestforattestation/RequestForAttestation'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
@@ -64,11 +62,9 @@ describe('CType', () => {
       owner: identityAlice.address,
     }
 
-    const resultTxStatus = new TxStatus(FINALIZED, Crypto.hashStr('987654'))
-    require('../blockchain/Blockchain').default.__mockResultHash = resultTxStatus
-
     const result = await ctype.store(identityAlice)
-    expect(result.type).toEqual(resultTxStatus.type)
+    expect(result.isFinalized).toBeTruthy()
+    expect(result.isCompleted).toBeTruthy()
     expect(result.payload).toMatchObject(resultCtype)
   })
   it('verifies the claim structure', () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -3,7 +3,6 @@ import { Did } from '..'
 import { IDid } from './Did'
 import Identity from '../identity/Identity'
 import { getIdentifierFromAddress } from './Did.utils'
-import { OK } from '../const/TxStatus'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -32,9 +31,6 @@ describe('DID', () => {
       return Promise.resolve(tuple)
     }
   )
-  require('../blockchain/Blockchain').default.submitTx = jest.fn(() => {
-    return Promise.resolve({ status: OK })
-  })
 
   it('query by address with documentStore', async () => {
     const did = await Did.queryByAddress('withDocumentStore')
@@ -78,7 +74,7 @@ describe('DID', () => {
   it('store did', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
-    expect(await did.store(alice)).toEqual({ status: OK })
+    await expect(did.store(alice)).resolves.toHaveProperty('isFinalized', true)
   })
 
   it('creates default did document', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import DelegationRootNode from './delegation/DelegationRootNode'
 import Did, { IDid } from './did/Did'
 import * as Quote from './quote/Quote'
 import Message from './messaging/Message'
-import * as Constants from './const'
 
 export { default as Blockchain, IBlockchainApi } from './blockchain/Blockchain'
 export { default as TxStatus } from './blockchain/TxStatus'
@@ -76,7 +75,6 @@ export {
   Did,
   IDid,
   Message,
-  Constants,
   Quote,
 }
 


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/384
Proposal to replace transaction status constants with properties from Substrate's `ExtrinsicStatus`. See ticket.
Draft contains two possible ways of implementing this; either by implementing `ExtrinsicStatus` or by extending `SubmittableResult`.
The latter seems less hacky, but instances of the former are far easier to create, thus making for better usability. 
I'd appreciate your feedback here.

## How to test:
We'll worry about this later

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
