### PR TITLE
fix: ctype compress accepts nulled owner

### DIFF
--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,3 +1,4 @@
+import { checkAddress } from '@polkadot/util-crypto'
 import CType from './CType'
 import Identity from '../identity/Identity'
 import Crypto from '../crypto'
@@ -103,6 +104,8 @@ describe('CType', () => {
     }).toThrow()
   })
   it('compresses and decompresses the ctype object', () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    console.log(checkAddress(claimCtype.owner!, 42)[0])
     expect(CTypeUtils.compressSchema(rawCType)).toEqual(compressedCType[2])
 
     expect(CTypeUtils.compress(claimCtype)).toEqual(compressedCType)

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,4 +1,3 @@
-import { checkAddress } from '@polkadot/util-crypto'
 import CType from './CType'
 import Identity from '../identity/Identity'
 import Crypto from '../crypto'

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -104,8 +104,6 @@ describe('CType', () => {
     }).toThrow()
   })
   it('compresses and decompresses the ctype object', () => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    console.log(checkAddress(claimCtype.owner!, 42)[0])
     expect(CTypeUtils.compressSchema(rawCType)).toEqual(compressedCType[2])
 
     expect(CTypeUtils.compress(claimCtype)).toEqual(compressedCType)

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -107,7 +107,11 @@ export function decompressSchema(
  */
 
 export function compress(cType: ICType): CompressedCType {
-  if (!cType.hash || !cType.owner || !cType.schema) {
+  if (
+    !cType.hash || typeof cType.owner === 'string'
+      ? true
+      : cType.owner === null || !cType.schema
+  ) {
     throw new Error(
       `Property Not Provided while building cType: ${JSON.stringify(
         cType,

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -111,8 +111,8 @@ export function compress(cType: ICType): CompressedCType {
   if (
     !cType.hash ||
     (typeof cType.owner === 'string'
-      ? checkAddress(cType.owner, 42)[0]
-      : cType.owner === null) ||
+      ? !checkAddress(cType.owner, 42)[0]
+      : !(cType.owner === null)) ||
     !cType.schema
   ) {
     throw new Error(

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -6,6 +6,7 @@
 
 import Ajv from 'ajv'
 import * as jsonabc from 'jsonabc'
+import { checkAddress } from '@polkadot/util-crypto'
 import { CTypeModel } from './CTypeSchema'
 import ICType, { CompressedCTypeSchema, CompressedCType } from '../types/CType'
 import Crypto from '../crypto'
@@ -108,9 +109,11 @@ export function decompressSchema(
 
 export function compress(cType: ICType): CompressedCType {
   if (
-    !cType.hash || typeof cType.owner === 'string'
-      ? true
-      : cType.owner === null || !cType.schema
+    !cType.hash ||
+    (typeof cType.owner === 'string'
+      ? checkAddress(cType.owner, 42)[0]
+      : cType.owner === null) ||
+    !cType.schema
   ) {
     throw new Error(
       `Property Not Provided while building cType: ${JSON.stringify(


### PR DESCRIPTION
## fixes [KILTProtocol/ticket#312](https://github.com/KILTprotocol/ticket/issues/397)

Currently compress throws an Error when given a ctype with owner set to null, even though `CType['owner']` is of union type `IPublicIdentity['address'] | null`

It should instead check, if the owner is a valid address or null

checking with checkAddress from '@polkadot/util-crypto' and prefix 42




## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
