### PR TITLE
feat: better blockchain api mocking

### DIFF
--- a/src/blockchain/Mocktest.spec.ts
+++ b/src/blockchain/Mocktest.spec.ts
@@ -1,33 +1,67 @@
 import BN from 'bn.js'
+import { Tuple, Option, U8a, Text } from '@polkadot/types'
 import { Identity } from '..'
 import { makeTransfer } from '../balance/Balance.chain'
 import getCached from '../blockchainApiConnection/BlockchainApiConnection'
+import { queryByAddress } from '../did/Did.chain'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
-it('succeeds', async () => {
-  require('../blockchainApiConnection/BlockchainApiConnection').__setDefaultResult(
-    true
-  )
-  const alice = Identity.buildFromURI('//Alice')
-  const amount = new BN(1000)
-  const blockchain = await getCached()
-  const transfer = blockchain.api.tx.balances.transfer(alice.address, amount)
-  const result = await blockchain.submitTx(alice, transfer)
-  expect(result).toMatchObject({ isFinalized: true })
+describe('tx mocks', () => {
+  it('tx succeeds', async () => {
+    require('../blockchainApiConnection/BlockchainApiConnection').__setDefaultResult(
+      true
+    )
+    const alice = Identity.buildFromURI('//Alice')
+    const amount = new BN(1000)
+    const blockchain = await getCached()
+    const transfer = blockchain.api.tx.balances.transfer(alice.address, amount)
+    const result = await blockchain.submitTx(alice, transfer)
+    expect(result).toMatchObject({ isFinalized: true })
+  })
+
+  it('tx succeeds then fails', async () => {
+    require('../blockchainApiConnection/BlockchainApiConnection').__queueResults(
+      [true, false]
+    )
+    const alice = Identity.buildFromURI('//Alice')
+    const amount = new BN(1000)
+    await expect(
+      makeTransfer(alice, alice.address, amount)
+    ).resolves.toMatchObject({
+      isFinalized: true,
+    })
+    await expect(makeTransfer(alice, alice.address, amount)).rejects.toThrow(
+      'Transaction failed'
+    )
+  })
 })
 
-it('succeeds then fails', async () => {
-  require('../blockchainApiConnection/BlockchainApiConnection').__queueResults([
-    true,
-    false,
-  ])
-  const alice = Identity.buildFromURI('//Alice')
-  const amount = new BN(1000)
-  expect(makeTransfer(alice, alice.address, amount)).resolves.toMatchObject({
-    isFinalized: true,
+describe('mock query result', () => {
+  beforeAll(async () => {
+    require('../blockchainApiConnection/BlockchainApiConnection').__mocked_api.query.did.dIDs.mockReturnValue(
+      new Option(
+        Tuple,
+        new Tuple(
+          // (publicBoxKey, publicSigningKey, documentStore?)
+          [Text, Text, U8a],
+          ['0x987', '0x123', '0x687474703a2f2f6d794449442e6b696c742e696f']
+        )
+      )
+    )
+    // would also work:
+    // ```ts
+    // const bc: any = await getCached()
+    // bc.api.query.did.dIDs.mockReturnValue(...)
+    // ```
   })
-  expect(makeTransfer(alice, alice.address, amount)).rejects.toThrow(
-    'Transaction failed'
-  )
+
+  it('works', async () => {
+    await expect(queryByAddress('0xwertzui')).resolves.toMatchObject({
+      documentStore: 'http://myDID.kilt.io',
+      identifier: 'did:kilt:0xwertzui',
+      publicBoxKey: '0x123',
+      publicSigningKey: '0x987',
+    })
+  })
 })

--- a/src/blockchain/Mocktest.spec.ts
+++ b/src/blockchain/Mocktest.spec.ts
@@ -1,0 +1,33 @@
+import BN from 'bn.js'
+import { Identity } from '..'
+import { makeTransfer } from '../balance/Balance.chain'
+import getCached from '../blockchainApiConnection/BlockchainApiConnection'
+
+jest.mock('../blockchainApiConnection/BlockchainApiConnection')
+
+it('succeeds', async () => {
+  require('../blockchainApiConnection/BlockchainApiConnection').__setDefaultResult(
+    true
+  )
+  const alice = Identity.buildFromURI('//Alice')
+  const amount = new BN(1000)
+  const blockchain = await getCached()
+  const transfer = blockchain.api.tx.balances.transfer(alice.address, amount)
+  const result = await blockchain.submitTx(alice, transfer)
+  expect(result).toMatchObject({ isFinalized: true })
+})
+
+it('succeeds then fails', async () => {
+  require('../blockchainApiConnection/BlockchainApiConnection').__queueResults([
+    true,
+    false,
+  ])
+  const alice = Identity.buildFromURI('//Alice')
+  const amount = new BN(1000)
+  expect(makeTransfer(alice, alice.address, amount)).resolves.toMatchObject({
+    isFinalized: true,
+  })
+  expect(makeTransfer(alice, alice.address, amount)).rejects.toThrow(
+    'Transaction failed'
+  )
+})

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -5,12 +5,140 @@
 /**
  * Dummy comment needed for correct doc display, do not remove
  */
-import Blockchain from '../../blockchain/Blockchain'
+import Blockchain, { IBlockchainApi } from '../../blockchain/Blockchain'
+import { ApiPromise, SubmittableResult } from '@polkadot/api'
+import { Option, Tuple, Vec, Text } from '@polkadot/types'
+import BN from 'bn.js'
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
+import { ExtrinsicStatus } from '@polkadot/types/interfaces'
 
-jest.mock('../../blockchain/Blockchain')
+const BlockchainApiConnection = jest.requireActual('../BlockchainApiConnection')
 
-export async function getCached() {
-  return Promise.resolve(Blockchain)
+BlockchainApiConnection.getCached = getCached
+BlockchainApiConnection.__queueResults = __queueResults
+BlockchainApiConnection.__setDefaultResult = __setDefaultResult
+
+module.exports = BlockchainApiConnection
+module.exports.default = BlockchainApiConnection.getCached
+
+async function getCached(
+  _: string = BlockchainApiConnection.DEFAULT_WS_ADDRESS
+): Promise<IBlockchainApi> {
+  if (!BlockchainApiConnection.instance) {
+    BlockchainApiConnection.instance = Promise.resolve(
+      new Blockchain(mocked_api as ApiPromise)
+    )
+  }
+  return BlockchainApiConnection.instance
 }
 
-export default getCached
+const TxresultsQueue: SubmittableResult[] = []
+let defaultTxResult: SubmittableResult = __makeSubmittableResult(true)
+
+class MockSubmittableExtrinsic {
+  result: SubmittableResult
+  method: string = 'mock tx'
+
+  constructor(result: SubmittableResult) {
+    this.result = result
+  }
+
+  public sign(_a: any, _b: any, _c: any) {
+    return this
+  }
+
+  public send(callable: Function) {
+    if (callable) {
+      callable(this.result)
+    }
+  }
+}
+
+function __getMockSubmittableExtrinsic(): SubmittableExtrinsic {
+  const result: SubmittableResult = TxresultsQueue.shift() || defaultTxResult
+  return (new MockSubmittableExtrinsic(result) as any) as SubmittableExtrinsic
+}
+
+function __makeSubmittableResult(success: boolean): SubmittableResult {
+  const status: ExtrinsicStatus = {
+    type: success ? 'Finalized' : 'Invalid',
+    isFinalized: success,
+    isDropped: false,
+    isInvalid: !success,
+    isUsurped: false,
+    isFuture: false,
+    isReady: true,
+  } as any
+
+  return new SubmittableResult({
+    status,
+  })
+}
+
+function __queueResults(results: boolean[]) {
+  results.forEach(success => {
+    TxresultsQueue.push(__makeSubmittableResult(success))
+  })
+}
+
+function __setDefaultResult(success: boolean) {
+  defaultTxResult = __makeSubmittableResult(success)
+}
+
+const mocked_api: any = {
+  tx: {
+    attestation: {
+      add: jest.fn((claimHash, _cTypeHash) => {
+        return __getMockSubmittableExtrinsic()
+      }),
+    },
+    balances: {
+      transfer: jest.fn(() => __getMockSubmittableExtrinsic()),
+    },
+    ctype: {
+      add: jest.fn((hash, signature) => {
+        return __getMockSubmittableExtrinsic()
+      }),
+    },
+    delegation: {
+      createRoot: jest.fn((rootId, _ctypeHash) => {
+        return __getMockSubmittableExtrinsic()
+      }),
+      revokeRoot: jest.fn(rootId => {
+        return __getMockSubmittableExtrinsic()
+      }),
+      revokeDelegation: jest.fn(delegationId => {
+        return __getMockSubmittableExtrinsic()
+      }),
+    },
+    did: {
+      add: jest.fn((sign_key, box_key, doc_ref) => {
+        return __getMockSubmittableExtrinsic()
+      }),
+      remove: jest.fn(() => {
+        return __getMockSubmittableExtrinsic()
+      }),
+    },
+  },
+  query: {
+    system: { accountNonce: jest.fn(() => new Text('12345')) },
+    attestation: {
+      delegatedAttestations: jest.fn(),
+      attestations: jest.fn(),
+    },
+    balances: {
+      freeBalance: jest.fn((account: string) => new BN(0)),
+    },
+    ctype: {
+      cTYPEs: jest.fn(hash => true),
+    },
+    delegation: {
+      root: jest.fn((rootId: string) => new Option(Tuple, null)),
+      delegations: jest.fn((delegationId: string) => new Option(Tuple, null)),
+      children: jest.fn((id: string) => new Vec(Text, [])),
+    },
+    did: {
+      dIDs: jest.fn(id => new Option(Tuple, null)),
+    },
+  },
+}

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -14,19 +14,12 @@ import { ExtrinsicStatus } from '@polkadot/types/interfaces'
 
 const BlockchainApiConnection = jest.requireActual('../BlockchainApiConnection')
 
-BlockchainApiConnection.getCached = getCached
-BlockchainApiConnection.__queueResults = __queueResults
-BlockchainApiConnection.__setDefaultResult = __setDefaultResult
-
-module.exports = BlockchainApiConnection
-module.exports.default = BlockchainApiConnection.getCached
-
 async function getCached(
   _: string = BlockchainApiConnection.DEFAULT_WS_ADDRESS
 ): Promise<IBlockchainApi> {
   if (!BlockchainApiConnection.instance) {
     BlockchainApiConnection.instance = Promise.resolve(
-      new Blockchain(mocked_api as ApiPromise)
+      new Blockchain(__mocked_api as ApiPromise)
     )
   }
   return BlockchainApiConnection.instance
@@ -85,7 +78,7 @@ function __setDefaultResult(success: boolean) {
   defaultTxResult = __makeSubmittableResult(success)
 }
 
-const mocked_api: any = {
+const __mocked_api: any = {
   tx: {
     attestation: {
       add: jest.fn((claimHash, _cTypeHash) => {
@@ -133,12 +126,20 @@ const mocked_api: any = {
       cTYPEs: jest.fn(hash => true),
     },
     delegation: {
-      root: jest.fn((rootId: string) => new Option(Tuple, null)),
-      delegations: jest.fn((delegationId: string) => new Option(Tuple, null)),
+      root: jest.fn((rootId: string) => new Option(Tuple)),
+      delegations: jest.fn((delegationId: string) => new Option(Tuple)),
       children: jest.fn((id: string) => new Vec(Text, [])),
     },
     did: {
-      dIDs: jest.fn(id => new Option(Tuple, null)),
+      dIDs: jest.fn(id => new Option(Tuple)),
     },
   },
 }
+
+BlockchainApiConnection.getCached = getCached
+BlockchainApiConnection.__queueResults = __queueResults
+BlockchainApiConnection.__setDefaultResult = __setDefaultResult
+BlockchainApiConnection.__mocked_api = __mocked_api
+
+module.exports = BlockchainApiConnection
+module.exports.default = BlockchainApiConnection.getCached


### PR DESCRIPTION
## NO-TICKET
This is a suggestion for better mocking of the blockchain api connection. Instead of mocking the entire `Blockchain` module, we would be able to mock only api calls, thus allowing us to use the original functions on the module. We would also only mock `getCached` on the `BlockchainApiConnection` module to inject our mocked API and retain originals of the remaining functions. 
Currently only the spec file I included is written to use this correctly, others will fail. Let me know what you think, if you like what you see I could proceed to refactor our existing tests.

## How to test:
run the dedicated spec file with `yarn jest Mocktest` and play around with the tests included in `Mocktest.spec.ts` 

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
