### PR TITLE
refactor: chain stats return string types

### DIFF
--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -36,7 +36,7 @@ describe('handling attestations that do not exist', () => {
   }, 30_000)
 })
 
-describe('When there is an attester, claimer and ctype drivers license', async () => {
+describe('When there is an attester, claimer and ctype drivers license', () => {
   beforeAll(async () => {
     const ctypeExists = await CtypeOnChain(DriversLicense)
     // console.log(`ctype exists: ${ctypeExists}`)
@@ -154,7 +154,7 @@ describe('When there is an attester, claimer and ctype drivers license', async (
     )
   }, 60_000)
 
-  describe('when there is an attested claim on-chain', async () => {
+  describe('when there is an attested claim on-chain', () => {
     let AttClaim: AttestedClaim
 
     beforeAll(async () => {
@@ -202,7 +202,7 @@ describe('When there is an attester, claimer and ctype drivers license', async (
     }, 15000)
   })
 
-  describe('when there is another Ctype that works as a legitimation', async () => {
+  describe('when there is another Ctype that works as a legitimation', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(UncleSam)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -12,7 +12,7 @@ import {
 import { GAS, MIN_TRANSACTION, faucet, bob, alice, NewIdentity } from './utils'
 import getCached from '../blockchainApiConnection'
 
-describe('when there is a dev chain with a faucet', async () => {
+describe('when there is a dev chain with a faucet', () => {
   it('should have enough coins available on the faucet', async () => {
     const balance = await getBalance(faucet.address)
     expect(balance.gt(new BN(100000000))).toBeTruthy()
@@ -53,7 +53,7 @@ describe('when there is a dev chain with a faucet', async () => {
   }, 15000)
 })
 
-describe('When there are haves and have-nots', async () => {
+describe('When there are haves and have-nots', () => {
   const BobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
   const RichieRich = alice
   const StormyD = Identity.buildFromMnemonic(Identity.generateMnemonic())

--- a/src/__integrationtests__/ChainConnectivity.spec.ts
+++ b/src/__integrationtests__/ChainConnectivity.spec.ts
@@ -3,20 +3,14 @@
  */
 
 import { Header } from '@polkadot/types/interfaces/types'
-import { Struct, Text } from '@polkadot/types'
 import { getCached } from '../blockchainApiConnection'
 
-describe('Blockchain', async () => {
+describe('Blockchain', () => {
   it('should get stats', async () => {
     const blockchainSingleton = await getCached()
     const stats = await blockchainSingleton.getStats()
 
-    expect(
-      new Struct(
-        { chain: Text, nodeName: Text, nodeVersion: Text },
-        stats
-      ).toJSON()
-    ).toMatchObject({
+    expect(stats).toMatchObject({
       chain: 'Development',
       nodeName: 'substrate-node',
       nodeVersion: expect.stringMatching(/.+\..+\..+/),

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -9,7 +9,7 @@ import { getOwner } from '../ctype/CType.chain'
 import getCached from '../blockchainApiConnection'
 import { Identity } from '..'
 
-describe('When there is an CtypeCreator and a verifier', async () => {
+describe('When there is an CtypeCreator and a verifier', () => {
   const CtypeCreator = faucet
 
   const ctype = CType.fromCType({

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -23,7 +23,7 @@ const UncleSam = faucet
 const attester = alice
 const claimer = bob
 
-describe('when there is an account hierarchy', async () => {
+describe('when there is an account hierarchy', () => {
   beforeAll(async () => {
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester)
@@ -52,7 +52,7 @@ describe('when there is an account hierarchy', async () => {
     ])
   }, 30000)
 
-  describe('and attestation rights have been delegated', async () => {
+  describe('and attestation rights have been delegated', () => {
     let rootNode: DelegationRootNode
     let delegatedNode: DelegationNode
 

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -1,0 +1,37 @@
+import { Text } from '@polkadot/types'
+import getCached from '../blockchainApiConnection/BlockchainApiConnection'
+
+jest.mock('../blockchainApiConnection/BlockchainApiConnection')
+
+describe('queries', () => {
+  beforeAll(() => {
+    const api = require('../blockchainApiConnection/BlockchainApiConnection')
+      .__mocked_api
+    api.rpc.system.version.mockResolvedValue(new Text('1.0.0'))
+    api.rpc.system.chain.mockResolvedValue(new Text('mockchain'))
+    api.rpc.system.name.mockResolvedValue(new Text('substrate-node'))
+
+    api.rpc.chain.subscribeNewHeads = jest.fn(async listener => {
+      listener('mockHead')
+      return jest.fn()
+    })
+  })
+
+  it('should get stats', async () => {
+    const blockchain = await getCached()
+
+    await expect(blockchain.getStats()).resolves.toMatchObject({
+      chain: 'mockchain',
+      nodeName: 'substrate-node',
+      nodeVersion: '1.0.0',
+    })
+  })
+
+  it('should listen to blocks', async () => {
+    const listener = jest.fn()
+    const blockchain = await getCached()
+    const unsubscribe = await blockchain.listenToBlocks(listener)
+    expect(listener).toBeCalledWith('mockHead')
+    expect(unsubscribe()).toBeUndefined()
+  })
+})

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -22,9 +22,9 @@ const log = LoggerFactory.getLogger('Blockchain')
 export type QueryResult = Codec | undefined | null
 
 export type Stats = {
-  chain: Codec
-  nodeName: Codec
-  nodeVersion: Codec
+  chain: string
+  nodeName: string
+  nodeVersion: string
 }
 
 export interface IBlockchainApi {
@@ -62,12 +62,12 @@ export default class Blockchain implements IBlockchainApi {
   private errorHandler: ErrorHandler
 
   public async getStats(): Promise<Stats> {
-    const [chain, nodeName, nodeVersion] = await Promise.all([
+    const encoded = await Promise.all([
       this.api.rpc.system.chain(),
       this.api.rpc.system.name(),
       this.api.rpc.system.version(),
     ])
-
+    const [chain, nodeName, nodeVersion] = encoded.map(el => el.toString())
     return { chain, nodeName, nodeVersion }
   }
 

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -12,6 +12,7 @@ import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Header } from '@polkadot/types/interfaces/types'
 import { Codec, AnyJson } from '@polkadot/types/types'
+import { Text } from '@polkadot/types'
 import { ErrorHandler } from '../errorhandling/ErrorHandler'
 import { factory as LoggerFactory } from '../config/ConfigLog'
 import { ERROR_UNKNOWN, ExtrinsicError } from '../errorhandling/ExtrinsicError'
@@ -62,7 +63,7 @@ export default class Blockchain implements IBlockchainApi {
   private errorHandler: ErrorHandler
 
   public async getStats(): Promise<Stats> {
-    const encoded = await Promise.all([
+    const encoded: Text[] = await Promise.all([
       this.api.rpc.system.chain(),
       this.api.rpc.system.name(),
       this.api.rpc.system.version(),

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -55,8 +55,7 @@ import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 
 const BlockchainApiConnection = jest.requireActual('../BlockchainApiConnection')
 
-async function getCached(
-): Promise<IBlockchainApi> {
+async function getCached(): Promise<IBlockchainApi> {
   if (!BlockchainApiConnection.instance) {
     BlockchainApiConnection.instance = Promise.resolve(
       new Blockchain(__mocked_api as ApiPromise)
@@ -119,6 +118,14 @@ function __setDefaultResult(success: boolean) {
 }
 
 const __mocked_api: any = {
+  rpc: {
+    system: {
+      chain: jest.fn(),
+      name: jest.fn(),
+      version: jest.fn(),
+    },
+    chain: { subscribeNewHeads: jest.fn() },
+  },
   tx: {
     attestation: {
       add: jest.fn((claimHash, _cTypeHash) => {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#310
Returns a map of strings instead of Codec types from `getStats()`.
Adds unit tests to verify this behaviour in the future. 

## How to test:
(new) unit tests and integration tests should cover it.  

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
