### PR TITLE
Doc: Add @throws #369

### DIFF
--- a/src/attestation/Attestation.ts
+++ b/src/attestation/Attestation.ts
@@ -152,7 +152,7 @@ export default class Attestation implements IAttestation {
   }
 
   /**
-   * [ASYNC] Queries an attestation from the chain and checks its validity.
+   * [STATIC] [ASYNC] Queries an attestation from the chain and checks its validity.
    *
    * @param claimHash - The hash of the claim that corresponds to the attestation to check. Defaults to the claimHash for the attestation onto which "verify" is called.
    * @returns A promise containing whether the attestation is valid.

--- a/src/attestation/Attestation.utils.ts
+++ b/src/attestation/Attestation.utils.ts
@@ -40,6 +40,7 @@ export function compress(attestation: IAttestation): CompressedAttestation {
  *  Decompresses an [[Attestation]] from storage and/or message into an object.
  *
  * @param attestation A compressed [[Attestation]] array that is reverted back into an object.
+ * @throws When [[attestation]] is not an Array or it's length is unequal 5.
  *
  * @returns An object that has the same properties as an [[Attestation]].
  */

--- a/src/attestedclaim/AttestedClaim.utils.ts
+++ b/src/attestedclaim/AttestedClaim.utils.ts
@@ -43,6 +43,7 @@ export function compress(
  *  Decompresses an [[AttestedClaim]] array from storage and/or message into an object.
  *
  * @param attestedClaim A compressed [[Attestation]] and [[RequestForAttestation]] array that is reverted back into an object.
+ * @throws When [[attestedClaim]] is not an Array or it's length is unequal 2.
  *
  * @returns An object that has the same properties as an [[AttestedClaim]].
  */

--- a/src/claim/Claim.ts
+++ b/src/claim/Claim.ts
@@ -26,6 +26,15 @@ function verifyClaim(
 }
 
 export default class Claim implements IClaim {
+  /**
+   * Instantiates a new Claim from the given [[IClaim]] and [[schema]].
+   *
+   * @param claimInput IClaim to instantiate the new claim from.
+   * @param cTypeSchema ICType['schema'] to verify claimInput's contents.
+   * @throws When claimInput's contents could not be verified with the provided cTypeSchema.
+   *
+   * @returns An instantiated Claim.
+   */
   public static fromClaim(
     claimInput: IClaim,
     cTypeSchema: ICType['schema']
@@ -38,6 +47,16 @@ export default class Claim implements IClaim {
     return new Claim(claimInput)
   }
 
+  /**
+   * Instantiates a new Claim from the given [[ICType]], IClaim['contents'] and IPublicIdentity['address'].
+   *
+   * @param ctypeInput [[ICType]] for which the Claim will be built.
+   * @param claimContents IClaim['contents'] to be used as the pure contents of the instantiated Claim.
+   * @param claimOwner IPublicIdentity['address'] to be used as the Claim owner.
+   * @throws When claimInput's contents could not be verified with the schema of the provided ctypeInput.
+   *
+   * @returns An instantiated Claim.
+   */
   public static fromCTypeAndClaimContents(
     ctypeInput: ICType,
     claimContents: IClaim['contents'],

--- a/src/claim/Claim.utils.ts
+++ b/src/claim/Claim.utils.ts
@@ -40,7 +40,7 @@ export function compress(claim: IClaim): CompressedClaim {
 export function decompress(claim: CompressedClaim): IClaim {
   if (!Array.isArray(claim) || claim.length !== 3) {
     throw new Error(
-      "Compressed Claim isn't an Array or has all the required data types"
+      `Compressed Claim isn't an Array or has all the required data types`
     )
   }
   return {

--- a/src/claim/Claim.utils.ts
+++ b/src/claim/Claim.utils.ts
@@ -33,6 +33,7 @@ export function compress(claim: IClaim): CompressedClaim {
  *  Decompresses the [[Claim]] from storage and/or message.
  *
  * @param claim A compressed [[Claim]] array that is reverted back into an object.
+ * @throws When [[claim]] is not an Array or it's length is unequal 3.
  *
  * @returns An object that has the same properties as the [[Claim]].
  */

--- a/src/claim/Claim.utils.ts
+++ b/src/claim/Claim.utils.ts
@@ -33,8 +33,7 @@ export function compress(claim: IClaim): CompressedClaim {
  *  Decompresses the [[Claim]] from storage and/or message.
  *
  * @param claim A compressed [[Claim]] array that is reverted back into an object.
- * @throws When [[claim]] is not an Array or it's length is unequal 3.
- *
+ * @throws When [[Claim]] is not an Array or it's length is unequal 3.
  * @returns An object that has the same properties as the [[Claim]].
  */
 export function decompress(claim: CompressedClaim): IClaim {

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -36,6 +36,15 @@ export function verifySchema(object: object, schema: object): boolean {
   return verifySchemaWithErrors(object, schema)
 }
 
+/**
+ *  Verifies the Structure of the provided IClaim['contents'] with ICType['schema'].
+ *
+ * @param claimContents IClaim['contents'] to be verified against the schema.
+ * @param schema ICType['schema'] to be verified against the [CTypeModel].
+ * @throws When schema does not correspond to the CTypeModel.
+ *
+ * @returns Boolean whether both claimContents and schema could be verified.
+ */
 export function verifyClaimStructure(
   claimContents: IClaim['contents'],
   schema: ICType['schema']
@@ -54,6 +63,7 @@ export function getHashForSchema(schema: ICType['schema']): string {
  *  Compresses a [[CType]] schema for storage and/or messaging.
  *
  * @param cTypeSchema A [[CType]] schema object that will be sorted and stripped for messaging or storage.
+ * @throws When any of the four properties of the cTypeSchema are missing.
  *
  * @returns An ordered array of a [[CType]] schema.
  */
@@ -85,6 +95,7 @@ export function compressSchema(
  *  Decompresses a schema of a [[CType]] from storage and/or message.
  *
  * @param cTypeSchema A compressed [[CType]] schema array that is reverted back into an object.
+ * @throws When either the cTypeSchema is not an Array or it's length is not equal to the defined length of 4.
  *
  * @returns An object that has the same properties as a [[CType]] schema.
  */
@@ -136,6 +147,7 @@ export function compress(cType: ICType): CompressedCType {
  *  Decompresses a [[CType]] from storage and/or message.
  *
  * @param cType A compressed [[CType]] array that is reverted back into an object.
+ * @throws When either the cType is not an Array or it's length is not equal to the defined length of 3.
  *
  * @returns An object that has the same properties as a [[CType]].
  */

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -63,7 +63,7 @@ export function getHashForSchema(schema: ICType['schema']): string {
  *  Compresses a [[CType]] schema for storage and/or messaging.
  *
  * @param cTypeSchema A [[CType]] schema object that will be sorted and stripped for messaging or storage.
- * @throws When any of the four properties of the cTypeSchema are missing.
+ * @throws When any of the four required properties of the cTypeSchema are missing.
  *
  * @returns An ordered array of a [[CType]] schema.
  */

--- a/src/ctype/CTypeMetadata.ts
+++ b/src/ctype/CTypeMetadata.ts
@@ -12,6 +12,13 @@ export default class CTypeMetadata implements ICTypeMetadata {
   public ctypeHash: ICTypeMetadata['ctypeHash']
   public metadata: ICTypeMetadata['metadata']
 
+  /**
+   *  Instantiates a new CTypeMetadata.
+   *
+   * @param metadata [[ICTypeMetadata]] that is to be instantiated.
+   * @throws When metadata is not verifiable with the MetadataModel.
+   * @returns The verified and instantiated CTypeMetadata.
+   */
   public constructor(metadata: ICTypeMetadata) {
     if (!CTypeUtils.verifySchema(metadata, MetadataModel)) {
       throw new Error('CTypeMetadata does not correspond to schema')

--- a/src/delegation/DelegationNode.ts
+++ b/src/delegation/DelegationNode.ts
@@ -27,7 +27,7 @@ const log = factory.getLogger('DelegationNode')
 export default class DelegationNode extends DelegationBaseNode
   implements IDelegationNode {
   /**
-   * Queries the delegation node with [delegationId].
+   * [STATIC] Queries the delegation node with [delegationId].
    *
    * @param delegationId The unique identifier of the desired delegation.
    * @returns Promise containing the [[DelegationNode]] or [null].
@@ -104,6 +104,7 @@ export default class DelegationNode extends DelegationBaseNode
   /**
    * Fetches the root of this delegation node.
    *
+   * @throws When the rootId could not be queried.
    * @returns Promise containing the [[DelegationRootNode]] of this delegation node.
    */
   public async getRoot(): Promise<DelegationRootNode> {

--- a/src/delegation/DelegationRootNode.ts
+++ b/src/delegation/DelegationRootNode.ts
@@ -23,7 +23,7 @@ const log = factory.getLogger('DelegationRootNode')
 export default class DelegationRootNode extends DelegationBaseNode
   implements IDelegationRootNode {
   /**
-   * Queries the delegation root with [delegationId].
+   * [STATIC] Queries the delegation root with [delegationId].
    *
    * @param delegationId Unique identifier of the delegation root.
    * @returns Promise containing [[DelegationRootNode]] or [null].

--- a/src/did/Did.ts
+++ b/src/did/Did.ts
@@ -105,7 +105,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Builds a [[Did]] object from the given [[Identity]].
+   * [STATIC] Builds a [[Did]] object from the given [[Identity]].
    *
    * @param identity The identity used to build the [[Did]] object.
    * @param documentStore The storage location of the associated DID Document; usually a URL.
@@ -122,7 +122,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Stores the [[Did]] object on-chain.
+   * [ASYNC] Stores the [[Did]] object on-chain.
    *
    * @param identity The identity used to store the [[Did]] object on-chain.
    * @returns A promise containing the [[SubmittableResult]] (transaction status).
@@ -133,7 +133,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Queries the [[Did]] object from the chain using the [identifier].
+   * [STATIC] Queries the [[Did]] object from the chain using the [identifier].
    *
    * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
    * @returns A promise containing the [[Did]] or [null].
@@ -143,7 +143,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Queries the [[Did]] object from the chain using the [address].
+   * [STATIC] Queries the [[Did]] object from the chain using the [address].
    *
    * @param address The address associated to this [[Did]].
    * @returns A promise containing the [[Did]] or [null].
@@ -153,7 +153,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Removes the [[Did]] object attached to a given [[Identity]] from the chain.
+   * [STATIC] Removes the [[Did]] object attached to a given [[Identity]] from the chain.
    *
    * @param identity The identity for which to delete the [[Did]].
    * @returns A promise containing the [[SubmittableResult]] (transaction status).
@@ -164,7 +164,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Gets the complete KILT DID from an [address] (in KILT, the method-specific ID is an address). Reverse of [[getAddressFromIdentifier]].
+   * [STATIC] Gets the complete KILT DID from an [address] (in KILT, the method-specific ID is an address). Reverse of [[getAddressFromIdentifier]].
    *
    * @param address An address, e.g. "5CtPYoDuQQF...".
    * @returns The associated KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
@@ -176,7 +176,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Gets the [address] from a complete KILT DID (in KILT, the method-specific ID is an address). Reverse of [[getIdentifierFromAddress]].
+   * [STATIC] Gets the [address] from a complete KILT DID (in KILT, the method-specific ID is an address). Reverse of [[getIdentifierFromAddress]].
    *
    * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".
    * @returns The associated address, e.g. "5CtPYoDuQQF...".
@@ -188,7 +188,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Signs (the hash of) a DID Document.
+   * [STATIC] Signs (the hash of) a DID Document.
    *
    * @param didDocument A DID Document, e.g. Created via [[createDefaultDidDocument]].
    * @param identity [[Identity]] representing the DID subject for this DID Document, and used for signature.
@@ -202,7 +202,7 @@ export default class Did implements IDid {
   }
 
   /**
-   * Verifies the signature of a DID Document, to check whether the data has been tampered with.
+   * [STATIC] Verifies the signature of a DID Document, to check whether the data has been tampered with.
    *
    * @param didDocument A signed DID Document.
    * @param identifier A KILT DID identifier, e.g. "did:kilt:5CtPYoDuQQF...".

--- a/src/did/Did.utils.ts
+++ b/src/did/Did.utils.ts
@@ -47,6 +47,14 @@ export function getIdentifierFromAddress(
   return IDENTIFIER_PREFIX + address
 }
 
+/**
+ * Fetches the root of this delegation node.
+ *
+ * @param identifier IDid identifier to derive it's address from.
+ * @throws When the identifier is not prefixed with the defined Kilt IDENTIFIER_PREFIX.
+ *
+ * @returns The Address derived from the IDid Identifier.
+ */
 export function getAddressFromIdentifier(
   identifier: IDid['identifier']
 ): IPublicIdentity['address'] {
@@ -96,9 +104,19 @@ export function createDefaultDidDocument(
   }
 }
 
+/**
+ * Verifies the signature of a [[IDidDocumentSigned]].
+ *
+ * @param didDocument [[IDidDocumentSigned]] to verify it's signature.
+ * @param identifier IDid identifier to match the IDidDocumentSigned id and to verify the signature with.
+ * @throws When didDocument and it's signature as well as the identifier are missing.
+ * @throws When identifier does not match didDocument's id.
+ *
+ * @returns The Address derived from the IDid Identifier.
+ */
 export function verifyDidDocumentSignature(
   didDocument: IDidDocumentSigned,
-  identifier: string
+  identifier: IDid['identifier']
 ): boolean {
   if (!didDocument || !didDocument.signature || !identifier) {
     throw new Error(

--- a/src/errorhandling/ErrorHandler.ts
+++ b/src/errorhandling/ErrorHandler.ts
@@ -22,7 +22,7 @@ export class ErrorHandler {
   private static readonly ERROR_MODULE_NAME = 'error'
 
   /**
-   * Checks if there is `SystemEvent.ExtrinsicFailed` in the list of
+   * [STATIC] Checks if there is `SystemEvent.ExtrinsicFailed` in the list of
    * transaction events within the given `extrinsicResult`.
    *
    * @param extrinsicResult The result of a submission.
@@ -80,7 +80,7 @@ export class ErrorHandler {
   }
 
   /**
-   * Derive the module index from the metadata module descriptor.
+   * [STATIC] Derive the module index from the metadata module descriptor.
    *
    * @param apiPromise The api promise object from polkadot/api.
    * @returns The error module index.

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -74,7 +74,6 @@ export default class Identity extends PublicIdentity {
     if (phrase) {
       if (phrase.trim().split(/\s+/g).length < 12) {
         // https://www.npmjs.com/package/bip39
-        // Actually only checks whether the phrase is too short.
         throw Error(`Phrase '${phrase}' too short or malformed`)
       }
     } else {

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -57,6 +57,9 @@ export default class Identity extends PublicIdentity {
    * [STATIC] Builds an identity object from a mnemonic string.
    *
    * @param phraseArg - [[BIP39]](https://www.npmjs.com/package/bip39) Mnemonic word phrase (Secret phrase).
+   * @throws When phraseArg contains fewer than 12 correctly separated mnemonic words.
+   * @throws When the phraseArg could not be validated.
+   *
    * @returns An [[Identity]].
    *
    * @example ```javascript
@@ -71,6 +74,7 @@ export default class Identity extends PublicIdentity {
     if (phrase) {
       if (phrase.trim().split(/\s+/g).length < 12) {
         // https://www.npmjs.com/package/bip39
+        // Actually only checks whether the phrase is too short.
         throw Error(`Phrase '${phrase}' too long or malformed`)
       }
     } else {

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -75,7 +75,7 @@ export default class Identity extends PublicIdentity {
       if (phrase.trim().split(/\s+/g).length < 12) {
         // https://www.npmjs.com/package/bip39
         // Actually only checks whether the phrase is too short.
-        throw Error(`Phrase '${phrase}' too long or malformed`)
+        throw Error(`Phrase '${phrase}' too short or malformed`)
       }
     } else {
       phrase = generate()

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -142,23 +142,22 @@ export default class Message implements IMessage {
    * [STATIC] Verifies that neither the hash of [[Message]] nor the sender's signature on the hash have been tampered with.
    *
    * @param encrypted The encrypted [[Message]] object which needs to be decrypted.
-   * @param encrypted.message The encrypted body of the [[Message]] which depends on the [[MessageBodyType]].
-   * @param encrypted.nonce The encryption nonce.
-   * @param encrypted.createdAt The timestamp of the message construction.
-   * @param encrypted.hash The hash of the concatenation of message + nonce + createdAt.
-   * @param encrypted.signature The sender's signature on the hash.
    * @param senderAddress The sender's public SS58 address of the [[Message]].
    * @throws When either the hash or the signature could not be verified against the calculations.
    *
    */
   public static ensureHashAndSignature(
-    { message, nonce, createdAt, hash, signature }: IEncryptedMessage,
+    encrypted: IEncryptedMessage,
     senderAddress: IMessage['senderAddress']
   ): void {
-    if (Crypto.hashStr(message + nonce + createdAt) !== hash) {
+    if (
+      Crypto.hashStr(
+        encrypted.message + encrypted.nonce + encrypted.createdAt
+      ) !== encrypted.hash
+    ) {
       throw new Error('Hash of message not correct')
     }
-    if (!Crypto.verify(hash, signature, senderAddress)) {
+    if (!Crypto.verify(encrypted.hash, encrypted.signature, senderAddress)) {
       throw new Error('Signature of message not correct')
     }
   }

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -95,7 +95,7 @@ export enum MessageBodyType {
 
 export default class Message implements IMessage {
   /**
-   * [STATIC] Verifies that the sender of a [[Message]] is also the owner of it, e.g. the owner's and sender's public keys match.
+   * [STATIC] Verifies that the sender of a [[Message]] is also the owner of it, e.g the owner's and sender's public keys match.
    *
    * @param message The [[Message]] object which needs to be decrypted.
    * @param message.body The body of the [[Message]] which depends on the [[MessageBodyType]].

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -95,11 +95,12 @@ export enum MessageBodyType {
 
 export default class Message implements IMessage {
   /**
-   * Verifies that the sender of a [[Message]] is also the owner of it, e.g. the owner's and sender's public keys match.
+   * [STATIC] Verifies that the sender of a [[Message]] is also the owner of it, e.g. the owner's and sender's public keys match.
    *
    * @param message The [[Message]] object which needs to be decrypted.
    * @param message.body The body of the [[Message]] which depends on the [[MessageBodyType]].
    * @param message.senderAddress The sender's public SS58 address of the [[Message]].
+   * @throws When the sender does not match the owner of the in the Message supplied Object.
    *
    */
   public static ensureOwnerIsSender({ body, senderAddress }: IMessage): void {
@@ -138,7 +139,7 @@ export default class Message implements IMessage {
   }
 
   /**
-   * Verifies that neither the hash of [[Message]] nor the sender's signature on the hash have been tampered with.
+   * [STATIC] Verifies that neither the hash of [[Message]] nor the sender's signature on the hash have been tampered with.
    *
    * @param encrypted The encrypted [[Message]] object which needs to be decrypted.
    * @param encrypted.message The encrypted body of the [[Message]] which depends on the [[MessageBodyType]].
@@ -147,6 +148,7 @@ export default class Message implements IMessage {
    * @param encrypted.hash The hash of the concatenation of message + nonce + createdAt.
    * @param encrypted.signature The sender's signature on the hash.
    * @param senderAddress The sender's public SS58 address of the [[Message]].
+   * @throws When either the hash or the signature could not be verified against the calculations.
    *
    */
   public static ensureHashAndSignature(
@@ -162,12 +164,14 @@ export default class Message implements IMessage {
   }
 
   /**
-   * Symmetrically decrypts the result of [[Message.encrypt]].
+   * [STATIC] Symmetrically decrypts the result of [[Message.encrypt]].
    *
    * Uses [[Message.ensureHashAndSignature]] and [[Message.ensureOwnerIsSender]] internally.
    *
    * @param encrypted The encrypted message.
    * @param receiver The [[Identity]] of the receiver.
+   * @throws When decryption of the encrypted returns false.
+   * @throws When the decoded message could not be parsed.
    * @returns The original [[Message]].
    */
   public static decrypt(

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -169,7 +169,7 @@ export default class Message implements IMessage {
    *
    * @param encrypted The encrypted message.
    * @param receiver The [[Identity]] of the receiver.
-   * @throws When decryption of the encrypted returns false.
+   * @throws When encrypted message couldn't be decrypted.
    * @throws When the decoded message could not be parsed.
    * @returns The original [[Message]].
    */

--- a/src/quote/Quote.ts
+++ b/src/quote/Quote.ts
@@ -53,6 +53,8 @@ export function validateQuoteSchema(
  * Builds a [[Quote]] object, from a simple object with the same properties.
  *
  * @param deserializedQuote The object which is used to create the attester signed [[Quote]] object.
+ * @throws When the deserializedQuote's signature could not be verified.
+ * @throws When the derived basicQuote can not be validated with the QuoteSchema.
  *
  * @returns A [[Quote]] object signed by an Attester.
  */
@@ -108,6 +110,7 @@ export function createAttesterSignature(
  *
  * @param quoteInput A [[Quote]] object.
  * @param identity [[Identity]] used to sign the object.
+ * @throws When the derived quoteInput can not be validated with the QuoteSchema.
  *
  * @returns A [[Quote]] object ready to be signed via [[createAttesterSignature]].
  */
@@ -128,6 +131,7 @@ export function fromQuoteDataAndIdentity(
  * @param claimerIdentity [[Identity]] of the Claimer in order to sign.
  * @param attesterSignedQuote A [[Quote]] object signed by an Attester.
  * @param requestRootHash A root hash of the entire object.
+ * @throws When the attesterSignedQuote's signature could not be verified.
  *
  * @returns A [[Quote]] agreement signed by both the Attester and Claimer.
  */

--- a/src/quote/Quote.utils.ts
+++ b/src/quote/Quote.utils.ts
@@ -19,6 +19,7 @@ import {
  *  Compresses the cost from a [[Quote]] object.
  *
  * @param cost A cost object that will be sorted and stripped into a [[Quote]].
+ * @throws When cost is missing any property defined in [[ICostBreakdown]].
  *
  * @returns An ordered array of a cost.
  */
@@ -40,6 +41,7 @@ export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
  *  Decompresses the cost from storage and/or message.
  *
  * @param cost A compressed cost array that is reverted back into an object.
+ * @throws When cost is not an Array and it's length does not equal the defined length of 3.
  *
  * @returns An object that has the same properties as a cost.
  */
@@ -57,6 +59,7 @@ export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
  *  Compresses a [[Quote]] for storage and/or messaging.
  *
  * @param quote An [[Quote]] object that will be sorted and stripped for messaging or storage.
+ * @throws When quote is missing any property defined in [[IQuote]].
  *
  * @returns An ordered array of an [[Quote]].
  */
@@ -92,6 +95,7 @@ export function compressQuote(quote: IQuote): CompressedQuote {
  *  Decompresses an [[Quote]] from storage and/or message.
  *
  * @param quote A compressed [[Quote]] array that is reverted back into an object.
+ * @throws When quote is not an Array and it's length does not equal the defined length of 6.
  *
  * @returns An object that has the same properties as an [[Quote]].
  */

--- a/src/quote/Quote.utils.ts
+++ b/src/quote/Quote.utils.ts
@@ -49,7 +49,7 @@ export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
 export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
   if (!Array.isArray(cost) || cost.length !== 3) {
     throw new Error(
-      "Compressed cost isn't an Array or has all the required data types"
+      `Compressed cost isn't an Array or has all the required data types`
     )
   }
   return { gross: cost[0], net: cost[1], tax: cost[2] }
@@ -96,14 +96,13 @@ export function compressQuote(quote: IQuote): CompressedQuote {
  *
  * @param quote A compressed [[Quote]] array that is reverted back into an object.
  * @throws When quote is not an Array and it's length does not equal the defined length of 6.
- *
  * @returns An object that has the same properties as an [[Quote]].
  */
 
 export function decompressQuote(quote: CompressedQuote): IQuote {
   if (!Array.isArray(quote) || quote.length !== 6) {
     throw new Error(
-      "Compressed quote isn't an Array or has all the required data types"
+      `Compressed quote isn't an Array or has all the required data types`
     )
   }
   return {
@@ -170,7 +169,7 @@ export function decompressAttesterSignedQuote(
 ): IQuoteAttesterSigned {
   if (!Array.isArray(attesterSignedQuote) || attesterSignedQuote.length !== 7) {
     throw new Error(
-      "Compressed quote isn't an Array or has all the required data types"
+      `Compressed attesterSignedQuote isn't an Array or has all the required data types`
     )
   }
   return {
@@ -240,7 +239,7 @@ export function decompressQuoteAgreement(
 ): IQuoteAgreement {
   if (!Array.isArray(quoteAgreement) || quoteAgreement.length !== 9) {
     throw new Error(
-      "Compressed quoteAgreement isn't an Array or has all the required data types"
+      `Compressed quoteAgreement isn't an Array or has all the required data types`
     )
   }
   return {

--- a/src/quote/Quote.utils.ts
+++ b/src/quote/Quote.utils.ts
@@ -229,13 +229,8 @@ export function compressQuoteAgreement(
 /**
  *  Decompresses a [[Quote]] Agreement from storage and/or message.
  *
-<<<<<<< HEAD
  * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into an object.
-=======
- * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into object.
- * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into object.
  * @throws When quoteAgreement is not an Array and it's length does not equal the defined length of 9.
->>>>>>> docs: added throws
  *
  * @returns An object that has the same properties as a [[Quote]] Agreement.
  */

--- a/src/quote/Quote.utils.ts
+++ b/src/quote/Quote.utils.ts
@@ -120,6 +120,7 @@ export function decompressQuote(quote: CompressedQuote): IQuote {
  *  Compresses an attester signed [[Quote]] for storage and/or messaging.
  *
  * @param attesterSignedQuote An attester signed [[Quote]] object that will be sorted and stripped for messaging or storage.
+ * @throws When attesterSignedQuote is missing any property defined in [[IQuoteAttesterSigned]].
  *
  * @returns An ordered array of an attester signed [[Quote]].
  */
@@ -159,6 +160,7 @@ export function compressAttesterSignedQuote(
  *  Decompresses an attester signed [[Quote]] from storage and/or message.
  *
  * @param attesterSignedQuote A compressed attester signed [[Quote]] array that is reverted back into an object.
+ * @throws When attesterSignedQuote is not an Array and it's length does not equal the defined length of 7.
  *
  * @returns An object that has the same properties as an attester signed [[Quote]].
  */
@@ -186,6 +188,7 @@ export function decompressAttesterSignedQuote(
  *  Compresses a [[Quote]] Agreement for storage and/or messaging.
  *
  * @param quoteAgreement A [[Quote]] Agreement object that will be sorted and stripped for messaging or storage.
+ * @throws When quoteAgreement is missing any property defined in [[IQuoteAgreement]].
  *
  * @returns An ordered array of a [[Quote]] Agreement.
  */
@@ -226,7 +229,13 @@ export function compressQuoteAgreement(
 /**
  *  Decompresses a [[Quote]] Agreement from storage and/or message.
  *
+<<<<<<< HEAD
  * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into an object.
+=======
+ * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into object.
+ * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into object.
+ * @throws When quoteAgreement is not an Array and it's length does not equal the defined length of 9.
+>>>>>>> docs: added throws
  *
  * @returns An object that has the same properties as a [[Quote]] Agreement.
  */

--- a/src/requestforattestation/RequestForAttestation.ts
+++ b/src/requestforattestation/RequestForAttestation.ts
@@ -94,6 +94,7 @@ export default class RequestForAttestation implements IRequestForAttestation {
    * @param identity - The Claimer's [Identity].
    * @param legitimationsInput - Array of [AttestedClaim] objects of the Attester which the Claimer requests to include into the attestation as legitimations.
    * @param delegationIdInput - The id of the DelegationNode of the Attester, which should be used in the attestation.
+   * @throws When claimInput's owner address does not match the supplied identity's address.
    * @returns  A new [[RequestForAttestation]] object.
    * @example ```javascript
    * const requestForAttestation = RequestForAttestation.fromClaimAndIdentity(
@@ -237,6 +238,8 @@ export default class RequestForAttestation implements IRequestForAttestation {
    * Verifies the data of the [[RequestForAttestation]] object; used to check that the data was not tampered with, by checking the data against hashes.
    *
    * @returns Whether the data is valid.
+   * @throws When any key of the claim contents could not be found in the claimHashTree.
+   * @throws When either the rootHash or the signature are not verifiable.
    * @example ```javascript
    * const reqForAtt = RequestForAttestation.fromClaimAndIdentity(
    *   claim,

--- a/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/src/requestforattestation/RequestForAttestation.utils.ts
@@ -42,6 +42,7 @@ export function errorCheck(
  *  Compresses an nonce and hash from a [[NonceHashTree]] or [[RequestForAttestation]] properties.
  *
  * @param nonceHash A hash or a hash and nonce object that will be sorted and stripped for messaging or storage.
+ * @throws When the nonceHash is missing it's hash (existence of nonce is ignored).
  *
  * @returns An object compressing of a hash or a hash and nonce.
  */
@@ -176,6 +177,7 @@ export function compress(
  *  Decompresses a [[RequestForAttestation]] from storage and/or message.
  *
  * @param reqForAtt A compressed [[RequestForAttestation]] array that is reverted back into an object.
+ * @throws When reqForAtt is not an Array and it's length is not equal to the defined length of 8.
  *
  * @returns An object that has the same properties as a [[RequestForAttestation]].
  */


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/369
Improves the jsdoc coverage and adds @throw tags to all functions that throw errors, this branch is based on lw-154-constructor-checks, as this adds a lot of Error throwing functions.

Please provide feedback for the added documentation and request away!

Should the throw tags only represent the Errors the function explicitly throws or should we add the called functions thrown Errors too, especially in the case of our own verify functions, called mostly to check objects? @tjwelde 

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
