### PR TITLE
Fix ExtrinsicError array of length 3101

### DIFF
--- a/src/errorhandling/ExtrinsicError.spec.ts
+++ b/src/errorhandling/ExtrinsicError.spec.ts
@@ -1,0 +1,30 @@
+import {
+  ErrorCode,
+  errorsByCode,
+  errorForCode,
+  ExtrinsicError,
+} from './ExtrinsicError'
+
+describe('ExtrinsicError', () => {
+  // get all error codes from ErrorCode enum
+  // Object.keys() returns both the integers as well as the strings
+  const errorCodes: number[] = Object.keys(ErrorCode).reduce(
+    (codes: number[], value: string) => {
+      // either an integer error code or NaN
+      const num = Number.parseInt(value, 10)
+      // check for NaN case
+      if (Number.isInteger(num)) {
+        return [...codes, num]
+      }
+      return codes
+    },
+    []
+  )
+  it('checks whether errorsByCode includes all errors', () => {
+    expect(Object.keys(errorsByCode).length).toBe(errorCodes.length)
+  })
+  it.each(errorCodes)('should return error for code %s', errorCode => {
+    expect(errorForCode(errorCode)).toBeDefined()
+    expect(errorForCode(errorCode)).toBeInstanceOf(ExtrinsicError)
+  })
+})

--- a/src/errorhandling/ExtrinsicError.ts
+++ b/src/errorhandling/ExtrinsicError.ts
@@ -50,7 +50,7 @@ export const ERROR_CTYPE_ALREADY_EXISTS: ExtrinsicError = new ExtrinsicError(
   ErrorCode.ERROR_CTYPE_ALREADY_EXISTS,
   'CTYPE already exists'
 )
-export const ERROR_ALEADY_ATTESTED: ExtrinsicError = new ExtrinsicError(
+export const ERROR_ALREADY_ATTESTED: ExtrinsicError = new ExtrinsicError(
   ErrorCode.ERROR_ALREADY_ATTESTED,
   'already attested'
 )
@@ -128,12 +128,16 @@ export const ERROR_UNKNOWN: ExtrinsicError = new ExtrinsicError(
   'an unknown error ocurred'
 )
 
-const errorsByCode: ExtrinsicError[] = []
+/**
+ * A dictionary in which each key is an error code of an [[ExtrinsicError]] and the value the corresponding error.
+ */
+export const errorsByCode: { [code: number]: ExtrinsicError } = {}
+
+  // fill dictionary
 ;[
   ERROR_CTYPE_NOT_FOUND,
   ERROR_CTYPE_ALREADY_EXISTS,
-
-  ERROR_ALEADY_ATTESTED,
+  ERROR_ALREADY_ATTESTED,
   ERROR_ERROR_ALREADY_REVOKED,
   ERROR_ATTESTATION_NOT_FOUND,
   ERROR_DELEGATION_REVOKED,
@@ -158,6 +162,15 @@ const errorsByCode: ExtrinsicError[] = []
   errorsByCode[value.errorCode] = value
 })
 
-export function errorForCode(errorCode: number): ExtrinsicError {
+/**
+ * Maps an error code to its corresponding [[ExtrinsicError]].
+ *
+ * @param errorCode A number which can be mapped to an [[ExtrinsicError]].
+ *
+ * @returns The [[ExtrinsicError]] for the committed key.
+ */
+export function errorForCode(
+  errorCode: keyof typeof errorsByCode
+): ExtrinsicError {
   return errorsByCode[errorCode]
 }


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/500
- `errorsByCode` in [ExtrinsicError.ts](https://github.com/KILTprotocol/sdk-js/blob/0c219d9ea268fecd1a4d926e2621d55a5f267dec/src/errorhandling/ExtrinsicError.ts#L131) was an array of length 3101 ([Playground Link](https://www.typescriptlang.org/play/?ssl=151&ssc=1&pln=1&pc=1#))
- changed `errorsByCode` to be an object
- fixed typo in former ExtrinsicError `ERROR_AL(R)EADY_ATTESTED`
- added documentation to `errorsByCode` and `errorForCode`
- added jest tests which check whether
  - all ExtrinsicErrors are inside `errorsForCode`
  - `errorForCode` returns an ExtrinsicError for each `errorCode`

## How to test:
```bash
yarn test ExtrinsicError
```

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
