### PR TITLE
Fix: getPublicIdentity should be instanceof PublicIdentity

### DIFF
--- a/src/identity/Identity.spec.ts
+++ b/src/identity/Identity.spec.ts
@@ -1,6 +1,7 @@
 import * as u8aUtil from '@polkadot/util/u8a'
 import Identity from './Identity'
 import { coToUInt8 } from '../crypto/Crypto'
+import { PublicIdentity } from '..'
 
 describe('Identity', () => {
   // https://polkadot.js.org/api/examples/promise/
@@ -19,7 +20,10 @@ describe('Identity', () => {
       '0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee'
     )
   })
-
+  it('should return instanceof PublicIdentity', () => {
+    const alice = Identity.buildFromURI('//Alice')
+    expect(alice.getPublicIdentity()).toBeInstanceOf(PublicIdentity)
+  })
   it('should create different identities with random phrases', () => {
     const alice = Identity.buildFromMnemonic()
     const bob = Identity.buildFromMnemonic()

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -178,7 +178,7 @@ export default class Identity extends PublicIdentity {
    */
   public getPublicIdentity(): PublicIdentity {
     const { address, boxPublicKeyAsHex } = this
-    return { address, boxPublicKeyAsHex }
+    return new PublicIdentity(address, boxPublicKeyAsHex)
   }
 
   /**

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -341,7 +341,7 @@ export default class Identity extends PublicIdentity {
    * const alice = Identity.buildFromMnemonic('car dog ...');
    * const tx = await blockchain.api.tx.ctype.add(ctype.hash);
    * const nonce = await blockchain.api.query.system.accountNonce(alice.address);
-   * alice.signSubmittableExtrinsic(tx, nonce.tohex());
+   * alice.signSubmittableExtrinsic(tx, nonce.toHex());
    * ```
    */
   public signSubmittableExtrinsic(

--- a/src/identity/PublicIdentity.ts
+++ b/src/identity/PublicIdentity.ts
@@ -175,7 +175,7 @@ export default class PublicIdentity implements IPublicIdentity {
    *
    * @param address - A public address.
    * @param boxPublicKeyAsHex - The public encryption key.
-   * @param serviceAddress - The address of the service used to retreive the DID.
+   * @param serviceAddress - The address of the service used to retrieve the DID.
    * @example ```javascript
    * const identity = new PublicIdentity(address, boxPublicKeyAsHex, serviceAddress);
    * ```


### PR DESCRIPTION
## fixes KILTProtocol/ticket#483
- fixed that `Identity.getPublicIdentity()` did not return an instance of `PublicIdentity`
- added a test
- fixed two minor documentation errors

## How to test:
```bash
yarn jest -t "should return instanceof PublicIdentity" Identity
```

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
