### PR TITLE
refactor: messaging

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -90,14 +90,11 @@ const message = new Kilt.Message(messageBody, claimer, attester)
 // The message can be encrypted as follows
 const encrypted = message.encrypt()
 
-// Check the validity of the message
-Message.ensureHashAndSignature(encrypted, claimer.address)
-// When the Attester receives the message, she can decrypt it
+// When the Attester receives the message, she can decrypt it.
+// During decryption, both the validity (Message.ensureHashAndSignature(encrypted, claimer.address))
+// as well as the validity of the message (Message.ensureOwnerIsSender(decrypted))
+// are automatically checked.
 const decrypted = Message.decrypt(encrypted, attester)
-
-// And make sure, that the sender is the owner of the identity.
-// This prevents claimers to use attested claims of another claimer.
-Message.ensureOwnerIsSender(decrypted)
 
 if (decrypted.body.type === MessageBodyType.REQUEST_ATTESTATION_FOR_CLAIM) {
   // const extractedRequestForAttestation: IRequestForAttestation =

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -88,12 +88,12 @@ const messageBody: IRequestAttestationForClaim = {
 }
 const message = new Kilt.Message(messageBody, claimer, attester)
 // The message can be encrypted as follows
-const encrypted = message.getEncryptedMessage()
+const encrypted = message.encrypt()
 
 // Check the validity of the message
 Message.ensureHashAndSignature(encrypted, claimer.address)
 // When the Attester receives the message, she can decrypt it
-const decrypted = Message.createFromEncryptedMessage(encrypted, attester)
+const decrypted = Message.decrypt(encrypted, attester)
 
 // And make sure, that the sender is the owner of the identity.
 // This prevents claimers to use attested claims of another claimer.

--- a/src/messaging/Message.spec.ts
+++ b/src/messaging/Message.spec.ts
@@ -29,9 +29,9 @@ describe('Messaging', () => {
       identityAlice,
       identityBob.getPublicIdentity()
     )
-    const encryptedMessage: IEncryptedMessage = message.getEncryptedMessage()
+    const encryptedMessage: IEncryptedMessage = message.encrypt()
 
-    const decryptedMessage: IMessage = Message.createFromEncryptedMessage(
+    const decryptedMessage: IMessage = Message.decrypt(
       encryptedMessage,
       identityBob
     )
@@ -44,7 +44,7 @@ describe('Messaging', () => {
     ) as IEncryptedMessage
     encryptedMessageWrongHash.hash = '0x00000000'
     expect(() =>
-      Message.createFromEncryptedMessage(encryptedMessageWrongHash, identityBob)
+      Message.decrypt(encryptedMessageWrongHash, identityBob)
     ).toThrowError(new Error('Hash of message not correct'))
 
     const encryptedMessageWrongSignature: IEncryptedMessage = JSON.parse(
@@ -56,10 +56,7 @@ describe('Messaging', () => {
     )
     encryptedMessageWrongSignature.signature += '1234'
     expect(() =>
-      Message.createFromEncryptedMessage(
-        encryptedMessageWrongSignature,
-        identityBob
-      )
+      Message.decrypt(encryptedMessageWrongSignature, identityBob)
     ).toThrowError(new Error('Signature of message not correct'))
 
     const encryptedMessageWrongContent: IEncryptedMessage = JSON.parse(
@@ -76,10 +73,7 @@ describe('Messaging', () => {
       hashStrWrongContent
     )
     expect(() =>
-      Message.createFromEncryptedMessage(
-        encryptedMessageWrongContent,
-        identityBob
-      )
+      Message.decrypt(encryptedMessageWrongContent, identityBob)
     ).toThrowError(new Error('Error decoding message'))
 
     const encryptedWrongBody: EncryptedAsymmetricString = identityAlice.encryptAsymmetricAsStr(
@@ -101,7 +95,7 @@ describe('Messaging', () => {
       senderBoxPublicKey: encryptedMessage.senderBoxPublicKey,
     } as IEncryptedMessage
     expect(() =>
-      Message.createFromEncryptedMessage(encryptedMessageWrongBody, identityBob)
+      Message.decrypt(encryptedMessageWrongBody, identityBob)
     ).toThrowError(new Error('Error parsing message body'))
   })
 

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -44,16 +44,16 @@ export interface IMessage {
 }
 
 export interface IEncryptedMessage {
-  messageId?: string
-  receivedAt?: number
   message: string
-  nonce: string
   createdAt: number
-  hash: string
-  signature: string
   receiverAddress: IPublicIdentity['address']
   senderAddress: IPublicIdentity['address']
   senderBoxPublicKey: IPublicIdentity['boxPublicKeyAsHex']
+  messageId?: string
+  receivedAt?: number
+  nonce: string
+  hash: string
+  signature: string
 }
 
 export enum MessageBodyType {
@@ -130,7 +130,7 @@ export default class Message implements IMessage {
     }
   }
 
-  public static createFromEncryptedMessage(
+  public static decrypt(
     encrypted: IEncryptedMessage,
     receiver: Identity
   ): IMessage {
@@ -200,7 +200,7 @@ export default class Message implements IMessage {
   private hash: string
   private signature: string
 
-  public getEncryptedMessage(): IEncryptedMessage {
+  public encrypt(): IEncryptedMessage {
     return {
       messageId: this.messageId,
       receivedAt: this.receivedAt,

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -1,7 +1,8 @@
 /**
  * KILT participants can communicate via a 1:1 messaging system.
  *
- * All messages are **encrypted** with the encryption keys of the involved identities. Every time an actor sends data about an [[Identity]], they have to sign the message to prove access to the corresponding private key.
+ * All messages are **encrypted** with the encryption keys of the involved identities.
+ * Every time an actor sends data about an [[Identity]], they have to sign the message to prove access to the corresponding private key.
  *
  * The [[Message]] class exposes methods to construct and verify messages.
  *
@@ -28,8 +29,14 @@ import ITerms from '../types/Terms'
 import { IQuoteAgreement } from '../types/Quote'
 
 /**
- * InReplyTo - should store the id of the parent message
- * references - should store the references or the in-reply-to of the parent-message followed by the message-id of the parent-message.
+ * - `body` - The body of the message, see [[MessageBody]].
+ * - `createdAt` - The timestamp of the message construction.
+ * - `receiverAddress` - The public SS58 address of the receiver.
+ * - `senderAddress` - The public SS58 address of the sender.
+ * - `senderBoxPublicKex` - The public encryption key of the sender.
+ * - `messageId` - The message id.
+ * - `inReplyTo` - The id of the parent-message.
+ * - `references` - The references or the in-reply-to of the parent-message followed by the message-id of the parent-message.
  */
 export interface IMessage {
   body: MessageBody
@@ -43,6 +50,14 @@ export interface IMessage {
   references?: Array<IMessage['messageId']>
 }
 
+/**
+ * Removes the [[MessageBody]], parent-id and references from the [[Message]] and adds
+ * four new fields: message, nonce, hash and signature.
+ * - `message` - The encrypted body of the message.
+ * - `nonce` - The encryption nonce.
+ * - `hash` - The hash of the concatenation of message + nonce + createdAt.
+ * - `signature` - The sender's signature on the hash.
+ */
 export type IEncryptedMessage = Pick<
   IMessage,
   | 'createdAt'
@@ -79,6 +94,14 @@ export enum MessageBodyType {
 }
 
 export default class Message implements IMessage {
+  /**
+   * Verifies that the sender of a [[Message]] is also the owner of it, e.g. the owner's and sender's public keys match.
+   *
+   * @param message The [[Message]] object which needs to be decrypted.
+   * @param message.body The body of the [[Message]] which depends on the [[MessageBodyType]].
+   * @param message.senderAddress The sender's public SS58 address of the [[Message]].
+   *
+   */
   public static ensureOwnerIsSender({ body, senderAddress }: IMessage): void {
     switch (body.type) {
       case MessageBodyType.REQUEST_ATTESTATION_FOR_CLAIM:
@@ -114,6 +137,18 @@ export default class Message implements IMessage {
     }
   }
 
+  /**
+   * Verifies that neither the hash of [[Message]] nor the sender's signature on the hash have been tampered with.
+   *
+   * @param encrypted The encrypted [[Message]] object which needs to be decrypted.
+   * @param encrypted.message The encrypted body of the [[Message]] which depends on the [[MessageBodyType]].
+   * @param encrypted.nonce The encryption nonce.
+   * @param encrypted.createdAt The timestamp of the message construction.
+   * @param encrypted.hash The hash of the concatenation of message + nonce + createdAt.
+   * @param encrypted.signature The sender's signature on the hash.
+   * @param senderAddress The sender's public SS58 address of the [[Message]].
+   *
+   */
   public static ensureHashAndSignature(
     { message, nonce, createdAt, hash, signature }: IEncryptedMessage,
     senderAddress: IMessage['senderAddress']
@@ -126,6 +161,15 @@ export default class Message implements IMessage {
     }
   }
 
+  /**
+   * Symmetrically decrypts the result of [[Message.encrypt]].
+   *
+   * Uses [[Message.ensureHashAndSignature]] and [[Message.ensureOwnerIsSender]] internally.
+   *
+   * @param encrypted The encrypted message.
+   * @param receiver The [[Identity]] of the receiver.
+   * @returns The original [[Message]].
+   */
   public static decrypt(
     encrypted: IEncryptedMessage,
     receiver: Identity
@@ -168,6 +212,13 @@ export default class Message implements IMessage {
   public senderAddress: IMessage['senderAddress']
   public senderBoxPublicKey: IMessage['senderBoxPublicKey']
 
+  /**
+   * Constructs a message which should be encrypted with [[Message.encrypt]] before sending to the receiver.
+   *
+   * @param body The body of the message.
+   * @param sender The [[Identity]] of the sender.
+   * @param receiver The [[PublicIdentity]] of the receiver.
+   */
   public constructor(
     body: MessageBody,
     sender: Identity,
@@ -196,6 +247,11 @@ export default class Message implements IMessage {
   private hash: string
   private signature: string
 
+  /**
+   * Encrypts the [[Message]] symmetrically as a string. This can be reversed with [[Message.decrypt]].
+   *
+   * @returns The encrypted version of the original [[Message]], see [[IEncryptedMessage]].
+   */
   public encrypt(): IEncryptedMessage {
     return {
       messageId: this.messageId,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#502
- `message.**getEncryptedMessage**` -> `message.**encrypt**`
- `Kilt.Message.**createFromEncryptedMessage**` -> `Kilt.Message.**decrypt**`
- include `Kilt.Message.ensureHashAndSignature` and `Kilt.Message.ensureOwnerIsSender` in `decrypt`
  - add destructuring to parameters to emphasize what properties are needed from `Kilt.Message` 
- refactor `IEncryptedMessage` to "extend" `IMessage` without "hardcoding" the properties seperately
- add documentation
- add testing for errors of `ensureHashAndSignature` and `ensureOwnerIsSender`

## How to test:
```
yarn test Message
```

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
