### PR TITLE
test: appropriate mocking hash type

### DIFF
--- a/src/actor/Attester.spec.ts
+++ b/src/actor/Attester.spec.ts
@@ -1,7 +1,7 @@
 import Bool from '@polkadot/types/primitive/Bool'
 import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 import { Tuple, Option } from '@polkadot/types/codec'
-import { Text } from '@polkadot/types'
+import { Text, H256 } from '@polkadot/types'
 import * as gabi from '@kiltprotocol/portablegabi'
 import {
   AttesterIdentity,
@@ -53,8 +53,8 @@ describe('Attester', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Text, AccountId, Text, Bool],
-          ['0xdead', attester.getAddress(), undefined, false]
+          [H256, AccountId, Text, Bool],
+          [cType.hash, attester.getAddress(), undefined, false]
         )
       )
     )
@@ -112,8 +112,8 @@ describe('Attester', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Text, AccountId, Text, Bool],
-          ['0xdead', attester.getAddress(), undefined, false]
+          [H256, AccountId, Text, Bool],
+          [cType.hash, attester.getAddress(), undefined, false]
         )
       )
     )

--- a/src/actor/Claimer.spec.ts
+++ b/src/actor/Claimer.spec.ts
@@ -1,7 +1,7 @@
 import Bool from '@polkadot/types/primitive/Bool'
 import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 import { Tuple, Option } from '@polkadot/types/codec'
-import { Text } from '@polkadot/types'
+import { Text, H256 } from '@polkadot/types'
 import AttesterIdentity from '../identity/AttesterIdentity'
 import Identity from '../identity/Identity'
 import constants from '../test/constants'
@@ -25,7 +25,7 @@ describe('Claimer', () => {
   let attester: AttesterIdentity
   let claimer: Identity
   let verifier: Identity
-
+  let cType: CType
   let claim: IClaim
   let credentialPE: Credential
 
@@ -49,7 +49,7 @@ describe('Claimer', () => {
       type: 'object',
     }
 
-    const cType = CType.fromSchema(rawCType, claimer.getAddress())
+    cType = CType.fromSchema(rawCType, claimer.getAddress())
 
     claim = {
       cTypeHash: cType.hash,
@@ -66,8 +66,8 @@ describe('Claimer', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Text, AccountId, Text, Bool],
-          ['0xdead', attester.getAddress(), undefined, false]
+          [H256, AccountId, Text, Bool],
+          [cType.hash, attester.getAddress(), undefined, false]
         )
       )
     )
@@ -140,8 +140,8 @@ describe('Claimer', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Text, AccountId, Text, Bool],
-          ['0xdead', attester.getAddress(), undefined, false]
+          [H256, AccountId, Text, Bool],
+          [cType.hash, attester.getAddress(), undefined, false]
         )
       )
     )
@@ -215,8 +215,8 @@ describe('Claimer', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Text, AccountId, Text, Bool],
-          ['0xdead', attester.getAddress(), undefined, false]
+          [H256, AccountId, Text, Bool],
+          [cType.hash, attester.getAddress(), undefined, false]
         )
       )
     )

--- a/src/actor/Verifier.spec.ts
+++ b/src/actor/Verifier.spec.ts
@@ -1,7 +1,7 @@
 import Bool from '@polkadot/types/primitive/Bool'
 import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 import { Tuple, Option } from '@polkadot/types/codec'
-import { Text } from '@polkadot/types'
+import { Text, H256 } from '@polkadot/types'
 import {
   Verifier,
   Attester,
@@ -66,8 +66,8 @@ describe('Verifier', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Text, AccountId, Text, Bool],
-          ['0xdead', attester.getAddress(), undefined, false]
+          [H256, AccountId, Text, Bool],
+          [cType.hash, attester.getAddress(), undefined, false]
         )
       )
     )

--- a/src/attestation/Attestation.spec.ts
+++ b/src/attestation/Attestation.spec.ts
@@ -1,4 +1,4 @@
-import { Text, Data } from '@polkadot/types'
+import { Text, H256 } from '@polkadot/types'
 import Bool from '@polkadot/types/primitive/Bool'
 import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 import { Tuple, Option } from '@polkadot/types/codec'
@@ -56,7 +56,7 @@ describe('Attestation', () => {
       new Option(
         Tuple,
         new Tuple(
-          [Data, AccountId, Text, Bool],
+          [H256, AccountId, Text, Bool],
           [testCType.hash, identityAlice.getAddress(), undefined, false]
         )
       )
@@ -90,7 +90,7 @@ describe('Attestation', () => {
         Tuple,
         new Tuple(
           // Attestations: claim-hash -> (ctype-hash, account, delegation-id?, revoked)
-          [Data, AccountId, Text, Bool],
+          [H256, AccountId, Text, Bool],
           [
             testCType.hash,
             identityAlice.signKeyringPair.address,

--- a/src/delegation/Delegation.spec.ts
+++ b/src/delegation/Delegation.spec.ts
@@ -1,4 +1,4 @@
-import { Text, Tuple, Vec, Option, H256, Data } from '@polkadot/types'
+import { Text, Tuple, Vec, Option, H256 } from '@polkadot/types'
 import Bool from '@polkadot/types/primitive/Bool'
 import U32 from '@polkadot/types/primitive/U32'
 import AccountId from '@polkadot/types/primitive/Generic/AccountId'
@@ -11,19 +11,20 @@ jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
 describe('Delegation', () => {
   let identityAlice: Identity
+  let ctypeHash: string
 
   beforeAll(async () => {
     identityAlice = await Identity.buildFromURI('//Alice')
 
-    const ctypeHash = Crypto.hashStr('testCtype')
+    ctypeHash = Crypto.hashStr('testCtype')
     const blockchainApi = require('../blockchainApiConnection/BlockchainApiConnection')
       .__mocked_api
 
     blockchainApi.query.attestation.delegatedAttestations.mockReturnValue(
       new Vec(
         //  (claim-hash)
-        Text,
-        ['0x123', '0x456', '0x789']
+        H256,
+        [ctypeHash, Crypto.hashStr('secondTest'), Crypto.hashStr('thirdTest')]
       )
     )
     blockchainApi.query.delegation.root.mockReturnValue(
@@ -31,7 +32,7 @@ describe('Delegation', () => {
         Tuple,
         new Tuple(
           // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-          [Data, AccountId, Bool],
+          [H256, AccountId, Bool],
           [[ctypeHash, identityAlice.getAddress(), false]]
         )
       )
@@ -118,6 +119,6 @@ describe('Delegation', () => {
   it('get attestation hashes', async () => {
     const attestationHashes = await getAttestationHashes('myDelegationId')
     expect(attestationHashes).toHaveLength(3)
-    expect(attestationHashes).toContain('0x123')
+    expect(attestationHashes).toContain(ctypeHash)
   })
 })

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -71,8 +71,8 @@ describe('Delegation', () => {
             Tuple,
             new Tuple(
               // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-              [Text, Text, Bool],
-              ['myCtypeHash', 'myAccount', false]
+              [H256, Text, Bool],
+              [ctypeHash, 'myAccount', false]
             )
           )
           return Promise.resolve(tuple)
@@ -81,8 +81,8 @@ describe('Delegation', () => {
           Tuple,
           new Tuple(
             // Root-Delegation: root-id -> (ctype-hash, account, revoked)
-            [Text, Text, Bool],
-            ['myCtypeHash', 'myAccount', true]
+            [H256, Text, Bool],
+            [ctypeHash, 'myAccount', true]
           )
         )
         return Promise.resolve(tuple)
@@ -90,19 +90,11 @@ describe('Delegation', () => {
     )
 
     expect(
-      await new DelegationRootNode(
-        'success',
-        'myCtypeHash',
-        'myAccount'
-      ).verify()
+      await new DelegationRootNode('success', ctypeHash, 'myAccount').verify()
     ).toBe(true)
 
     expect(
-      await new DelegationRootNode(
-        'failure',
-        'myCtypeHash',
-        'myAccount'
-      ).verify()
+      await new DelegationRootNode('failure', ctypeHash, 'myAccount').verify()
     ).toBe(false)
   })
 
@@ -111,7 +103,7 @@ describe('Delegation', () => {
 
     const aDelegationRootNode = new DelegationRootNode(
       'myRootId',
-      'myCtypeHash',
+      ctypeHash,
       'myAccount'
     )
     const revokeStatus = await aDelegationRootNode.revoke(identityAlice)


### PR DESCRIPTION
## fixes KILTProtocol/ticket#575

Replaced Data/Text with appropriate H256 type when mocking blockchain return values to better represent the actual chain behaviour and to prevent faulty decoding.


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
