### PR TITLE
fix: blockchain cache returns instance

### DIFF
--- a/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -11,12 +11,12 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { RegistryTypes } from '@polkadot/types/types'
 
-import Blockchain, { IBlockchainApi } from '../blockchain/Blockchain'
+import Blockchain from '../blockchain/Blockchain'
 
 export const DEFAULT_WS_ADDRESS =
   process.env.DEFAULT_WS_ADDRESS || 'ws://127.0.0.1:9944'
 
-let instance: Promise<IBlockchainApi> | null
+let instance: Promise<Blockchain> | null
 
 const CUSTOM_TYPES: RegistryTypes = {
   DelegationNodeId: 'Hash',
@@ -28,7 +28,7 @@ const CUSTOM_TYPES: RegistryTypes = {
 
 export async function buildConnection(
   host: string = DEFAULT_WS_ADDRESS
-): Promise<IBlockchainApi> {
+): Promise<Blockchain> {
   const provider = new WsProvider(host)
   const api: ApiPromise = await ApiPromise.create({
     provider,
@@ -39,7 +39,7 @@ export async function buildConnection(
 
 export async function getCached(
   host: string = DEFAULT_WS_ADDRESS
-): Promise<IBlockchainApi> {
+): Promise<Blockchain> {
   if (!instance) {
     instance = buildConnection(host)
   }

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -45,7 +45,7 @@
  *
  */
 
-import Blockchain, { IBlockchainApi } from '../../blockchain/Blockchain'
+import Blockchain from '../../blockchain/Blockchain'
 import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { Option, Tuple, Vec, H256, u64, u128 } from '@polkadot/types'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
@@ -54,7 +54,7 @@ import AccountId from '@polkadot/types/primitive/Generic/AccountId'
 
 const BlockchainApiConnection = jest.requireActual('../BlockchainApiConnection')
 
-async function getCached(): Promise<IBlockchainApi> {
+async function getCached(): Promise<Blockchain> {
   if (!BlockchainApiConnection.instance) {
     BlockchainApiConnection.instance = Promise.resolve(
       new Blockchain(__mocked_api as ApiPromise)


### PR DESCRIPTION
## fixes KILTProtocol/ticket#584

The Blockchain connection can be retrieved from cache and is stored in the variable instance.
The Code creates full instances but returns Interface only, I changed the retrun type to better represent the code behaviour.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
