### PR TITLE
feat: required fields in ctype wrapper schema

### DIFF
--- a/src/ctype/CTypeSchema.ts
+++ b/src/ctype/CTypeSchema.ts
@@ -16,12 +16,11 @@ export const CTypeModel = {
     $schema: {
       type: 'string',
       format: 'uri',
-      default: 'http://kilt-protocol.org/draft-01/ctype#',
-      enum: ['http://kilt-protocol.org/draft-01/ctype#'],
+      const: 'http://kilt-protocol.org/draft-01/ctype#',
     },
     type: {
       type: 'string',
-      enum: ['object'],
+      const: 'object',
     },
     properties: {
       type: 'object',
@@ -54,6 +53,7 @@ export const CTypeWrapperModel = {
     schema: {
       type: 'object',
       properties: CTypeModel.properties,
+      required: CTypeModel.required,
     },
     owner: { type: ['string', 'null'] },
     hash: {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#204
This PR gets the required fields from the ctype schema and adds it in the schema section of the wrapper schema. Before that, some fields were not marked as required.

## How to test:
- Tests should run
- Making a ctype and using it to make a claim in demo-client has to be possible
  - To test, cherry-pick this commit onto sdk master branch and use it in the demo-client

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
