### PR TITLE
feat: publishing to github packages from develop

### DIFF
--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -1,0 +1,19 @@
+name: Publish package to github packages
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://npm.pkg.github.com
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - publish-github-package
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -12,7 +12,11 @@ jobs:
         with:
           node-version: 10
           registry-url: https://npm.pkg.github.com
-      - run: yarn install --frozen-lockfile
+          scope: '@kiltprotocol'
+      - run: echo $(jq '.dependencies."@kiltprotocol/portablegabi"="latest"' package.json) > package.json
+      - run: yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn build
       - run: yarn version --no-git-tag-version --prerelease --preid $(git rev-parse --short HEAD)
       - run: npm publish --tag dev

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -15,6 +15,7 @@ jobs:
           registry-url: https://npm.pkg.github.com
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: npm publish
+      - run: yarn version --no-git-tag-version --prerelease --preid $(git rev-parse --short HEAD)
+      - run: npm publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - publish-github-package
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix=""

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""


### PR DESCRIPTION
## fixes KILTProtocol/ticket#599
Builds and publishes the sdk as a npm package to the GitHub Packages repo.
These releases are versioned with the current commit id and tagged `dev`.

Possible issues:
 - [x] there is a (almost empty) `.npmrc` in this repo that may interfere with the publishing process
     - removed it after talking to Dudley, who added it
 - [x] the `package.json` mentions a target for publishing (`publishConfig`) that could potentially interfere
     - does not seem to interfere

## How to test:
By adding this branch to the triggers I have successfully triggered a release. You can find the published package in https://github.com/KILTprotocol/sdk-js/packages/286306.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
