### PR TITLE
Feat: Debug mode and modify logLevel

### DIFF
--- a/src/config/ConfigLog.spec.ts
+++ b/src/config/ConfigLog.spec.ts
@@ -1,0 +1,25 @@
+import { LogLevel, Logger } from 'typescript-logging'
+import { factory, modifyLogLevel } from './ConfigLog'
+
+describe('Log COnfiguration', () => {
+  let testLogger: Logger
+  beforeEach(() => {
+    testLogger = factory.getLogger('testLogger')
+  })
+  it('Tests the default Log Level', () => {
+    if (process.env.DEBUG === 'true') {
+      expect(testLogger.getLogLevel()).toEqual(LogLevel.Debug)
+    } else expect(testLogger.getLogLevel()).toEqual(LogLevel.Error)
+  })
+  it('modifies the Log Level of all Loggers to the desired Level', () => {
+    const initialLevel = testLogger.getLogLevel()
+    modifyLogLevel(LogLevel.Info)
+    expect(testLogger.getLogLevel()).toEqual(LogLevel.Info)
+    expect(factory.getLogger('test1').getLogLevel()).toEqual(LogLevel.Info)
+
+    modifyLogLevel(-100)
+    expect(testLogger.getLogLevel()).toEqual(0)
+    modifyLogLevel(initialLevel)
+    expect(testLogger.getLogLevel()).toEqual(initialLevel)
+  })
+})

--- a/src/config/ConfigLog.ts
+++ b/src/config/ConfigLog.ts
@@ -11,6 +11,8 @@ import {
   LoggerFactoryOptions,
   LogGroupRule,
   LogLevel,
+  getLogControl,
+  LogGroupControlSettings,
 } from 'typescript-logging'
 
 // Create options instance and specify 2 LogGroupRules:
@@ -33,19 +35,16 @@ export const factory = LFService.createNamedLoggerFactory(
 )
 
 export function modifyLogLevel(level: number): void {
+  const control = getLogControl()
+  control.listFactories()
   let actualLevel
   if (level < 0) {
     actualLevel = 0
   } else if (level > 5) {
     actualLevel = 5
   } else actualLevel = level
-  factory.configure(
-    new LoggerFactoryOptions().addLogGroupRule(
-      new LogGroupRule(new RegExp('.+'), actualLevel)
-    )
-  )
-  // eslint-disable-next-line no-console
-  console.log(`changed logging level to ${actualLevel}`)
-  // eslint-disable-next-line no-console
-  console.log(factory.getLogger('test').getLogLevel())
+  control.getLoggerFactoryControl(0).change({
+    group: 'all',
+    logLevel: LogLevel[actualLevel],
+  } as LogGroupControlSettings)
 }

--- a/src/config/ConfigLog.ts
+++ b/src/config/ConfigLog.ts
@@ -36,7 +36,7 @@ export const factory = LFService.createNamedLoggerFactory(
 /**
  *  Changes all existing Loggers of our default Factory with id 0 to the intended Level.
  *
- * @param level The intended LogLevel.
+ * @param level The intended LogLevel. LogLevel has a range of 0 to 5.
  */
 export function modifyLogLevel(level: LogLevel): void {
   let actualLevel

--- a/src/config/ConfigLog.ts
+++ b/src/config/ConfigLog.ts
@@ -17,9 +17,13 @@ import {
 // * One for any logger with a name starting with model, to log on debug
 // * The second one for anything else to log on info
 const options = new LoggerFactoryOptions().addLogGroupRule(
-  new LogGroupRule(new RegExp('.+'), LogLevel.Debug)
+  new LogGroupRule(
+    new RegExp('.+'),
+    process.env.DEBUG && process.env.DEBUG === 'true'
+      ? LogLevel.Debug
+      : LogLevel.Error
+  )
 )
-
 // Create a named loggerfactory and pass in the options and export the factory.
 // Named is since version 0.2.+ (it's recommended for future usage)
 // eslint-disable-next-line import/prefer-default-export
@@ -27,3 +31,21 @@ export const factory = LFService.createNamedLoggerFactory(
   'LoggerFactory',
   options
 )
+
+export function modifyLogLevel(level: number): void {
+  let actualLevel
+  if (level < 0) {
+    actualLevel = 0
+  } else if (level > 5) {
+    actualLevel = 5
+  } else actualLevel = level
+  factory.configure(
+    new LoggerFactoryOptions().addLogGroupRule(
+      new LogGroupRule(new RegExp('.+'), actualLevel)
+    )
+  )
+  // eslint-disable-next-line no-console
+  console.log(`changed logging level to ${actualLevel}`)
+  // eslint-disable-next-line no-console
+  console.log(factory.getLogger('test').getLogLevel())
+}

--- a/src/config/ConfigLog.ts
+++ b/src/config/ConfigLog.ts
@@ -15,9 +15,8 @@ import {
   LogGroupControlSettings,
 } from 'typescript-logging'
 
-// Create options instance and specify 2 LogGroupRules:
-// * One for any logger with a name starting with model, to log on debug
-// * The second one for anything else to log on info
+// Create options instance and specify 1 LogGroupRule:
+// * LogLevel Error on default, env DEBUG = 'true' changes Level to Debug.
 const options = new LoggerFactoryOptions().addLogGroupRule(
   new LogGroupRule(
     new RegExp('.+'),
@@ -34,17 +33,22 @@ export const factory = LFService.createNamedLoggerFactory(
   options
 )
 
-export function modifyLogLevel(level: number): void {
-  const control = getLogControl()
-  control.listFactories()
+/**
+ *  Changes all existing Loggers of our default Factory with id 0 to the intended Level.
+ *
+ * @param level The intended LogLevel.
+ */
+export function modifyLogLevel(level: LogLevel): void {
   let actualLevel
   if (level < 0) {
     actualLevel = 0
   } else if (level > 5) {
     actualLevel = 5
   } else actualLevel = level
-  control.getLoggerFactoryControl(0).change({
-    group: 'all',
-    logLevel: LogLevel[actualLevel],
-  } as LogGroupControlSettings)
+  getLogControl()
+    .getLoggerFactoryControl(0)
+    .change({
+      group: 'all',
+      logLevel: LogLevel[actualLevel],
+    } as LogGroupControlSettings)
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#496


Changes the default logLevel from Debug to Error, with the option to enable Debug mode with env variable DEBUG.

Adds new exported function to change the logLevel of all factories to the specified level.

## How to test:

start with or without DEBUG env set to true, call modifyLogLevel, see many logs or not.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
