### PR TITLE
chore: changed return type of connect function

### DIFF
--- a/src/kilt/Kilt.ts
+++ b/src/kilt/Kilt.ts
@@ -9,10 +9,10 @@
  * @preferred
  */
 
-import { IBlockchainApi } from '../blockchain/Blockchain'
+import Blockchain from '../blockchain/Blockchain'
 import { clearCache, getCached } from '../blockchainApiConnection'
 
-export function connect(host: string): Promise<IBlockchainApi> {
+export function connect(host: string): Promise<Blockchain> {
   return getCached(host)
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#608


Changes the return type of Kilt default `connect` function, as the `getCached` returns the full instance now