### PR TITLE
test: improve coverage for BlockchainApiConnection

### DIFF
--- a/src/blockchainApiConnection/BlockchainApiConnection.spec.ts
+++ b/src/blockchainApiConnection/BlockchainApiConnection.spec.ts
@@ -1,0 +1,36 @@
+import Blockchain from '../blockchain'
+import getCached, { clearCache } from './BlockchainApiConnection'
+
+const DEVNET_WS_ADDRESS = 'ws://full-nodes.devnet.kilt.io:9944/'
+
+let blockchain: Blockchain | undefined
+beforeAll(async () => {
+  blockchain = await getCached(DEVNET_WS_ADDRESS)
+})
+
+async function timeboxCache(): Promise<number> {
+  const start = new Date().getTime()
+  await getCached(DEVNET_WS_ADDRESS)
+  return new Date().getTime() - start
+}
+
+describe('BlockchainApiConnection', () => {
+  // disable spam from polkadot logger for this test
+  global.console.log = jest.fn()
+  it('Should connect to testnet', async () => {
+    expect(blockchain).toBeDefined()
+    expect(blockchain).toBeInstanceOf(Blockchain)
+    expect(blockchain?.ready).resolves.toBeTruthy()
+  })
+  it('Should clear cache', async () => {
+    // cache already exists
+    await expect(timeboxCache()).resolves.toBeLessThan(10)
+    clearCache()
+    // has to build new connection
+    await expect(timeboxCache()).resolves.toBeGreaterThan(100)
+  })
+})
+
+afterAll(() => {
+  if (typeof blockchain !== 'undefined') blockchain.api.disconnect()
+})

--- a/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -15,7 +15,7 @@ import Blockchain from '../blockchain/Blockchain'
 export const DEFAULT_WS_ADDRESS =
   process.env.DEFAULT_WS_ADDRESS || 'ws://127.0.0.1:9944'
 
-let instance: Promise<Blockchain> | null
+let instance: Blockchain | null
 
 const CUSTOM_TYPES: RegistryTypes = {
   DelegationNodeId: 'Hash',
@@ -30,6 +30,12 @@ const CUSTOM_TYPES: RegistryTypes = {
   Index: 'u64',
 }
 
+/**
+ * Connects to the specified node.
+ *
+ * @param host The host to connect with.
+ * @returns A [[Blockchain]] API instance on which we can query data or submit transactions.
+ */
 export async function buildConnection(
   host: string = DEFAULT_WS_ADDRESS
 ): Promise<Blockchain> {
@@ -43,15 +49,24 @@ export async function buildConnection(
   return bc
 }
 
+/**
+ * Connect to a node or return an already established connection.
+ *
+ * @param host The host to connect with.
+ * @returns A [[Blockchain]] API instance on which we can query data or submit transactions.
+ */
 export async function getCached(
   host: string = DEFAULT_WS_ADDRESS
 ): Promise<Blockchain> {
   if (!instance) {
-    instance = buildConnection(host)
+    instance = await buildConnection(host)
   }
   return instance
 }
 
+/**
+ * Remove the cached connection.
+ */
 export function clearCache(): void {
   instance = null
 }


### PR DESCRIPTION
## related to KILTProtocol/ticket#606
- improves coverage for `BlockchainApiConnection` by connecting to testnet

## How to test:
```
yarn jest BlockchainApiConnection
```

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
