### PR TITLE
fix: pe-verification error parameter

### DIFF
--- a/src/errorhandling/SDKErrors.ts
+++ b/src/errorhandling/SDKErrors.ts
@@ -517,9 +517,7 @@ export const ERROR_UNKNOWN: () => SDKError = () => {
 export const ERROR_PE_VERIFICATION: (
   accFailure: boolean,
   keyFailure: boolean
-) => SDKError = (
-  ...[accFailure, keyFailure]: Parameters<typeof ERROR_PE_VERIFICATION>
-) => {
+) => SDKError = (accFailure: boolean, keyFailure: boolean) => {
   return new SDKError(
     ErrorCode.ERROR_PE_VERIFICATION,
     `Received privacy enhanced presentation with insufficient data. 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#631

The Demo-client complains and does not compile with the way we destructure the parameter array.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
