### PR TITLE
chore: add dispatch event to workflow

### DIFF
--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -21,3 +21,10 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Repository dispatch to workshop
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: KILTprotocol/kilt-workshop-101
+          event-type: sdk-update
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "github": ${{ toJson(github) }}}'


### PR DESCRIPTION
## fixes KILTProtocol/ticket#625
- adds dispatch action to workflow after publishing the github package
- see [here](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event) for more general information
- this action can be received from the workshop and triggers the CI tests there (this is the only trigger!)
- In the workshop:
   - automatically creates an issue when the CI breaks there + links the SDK commit sha
   - see the updated KILT workshop CI [here](https://github.com/KILTprotocol/kilt-workshop-101/commit/5b73041fba422c6dcb81b9e50f453d3ea7c2c741) 

```
on:
  repository_dispatch:
    types: [sdk-update]
```

## How to test:
Can only check after we merged this PR. However, I tested this locally on a dummy repo until it worked.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
