### PR TITLE
feat: option for disabling gabi

### DIFF
--- a/src/actor/Claimer.spec.ts
+++ b/src/actor/Claimer.spec.ts
@@ -16,7 +16,11 @@ import {
 } from '../errorhandling/SDKErrors'
 import AttesterIdentity from '../identity/AttesterIdentity'
 import Identity from '../identity/Identity'
-import Message, { MessageBodyType } from '../messaging/Message'
+import Message, {
+  MessageBodyType,
+  IRequestClaimsForCTypes,
+  ISubmitClaimsForCTypesPublic,
+} from '../messaging/Message'
 import constants from '../test/constants'
 import { ClaimerAttestationSession } from './Claimer'
 
@@ -301,6 +305,33 @@ describe('Claimer', () => {
       MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
     )
     expect(Array.isArray(presentation.body.content))
+  })
+  it('create public presentation from request without peRequest', async () => {
+    const body: IRequestClaimsForCTypes = {
+      type: MessageBodyType.REQUEST_CLAIMS_FOR_CTYPES,
+      content: {
+        allowPE: false,
+        ctypes: ['this is a ctype hash'],
+      },
+    }
+    const request = new Message(body, verifier, claimer.getPublicIdentity())
+
+    const presentation = await Claimer.createPresentation(
+      claimer,
+      request,
+      verifier.getPublicIdentity(),
+      [credentialPE],
+      [attester.getPublicIdentity()],
+      false
+    )
+    expect(presentation.body.type).toEqual(
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+    )
+    expect(Array.isArray(presentation.body.content))
+    const { content } = presentation.body as ISubmitClaimsForCTypesPublic
+    expect(Object.keys(content[0].request.claim.contents)).toEqual(
+      Object.keys(content[0].request.claimHashTree)
+    )
   })
   describe('Negative tests', () => {
     describe('create presentation', () => {

--- a/src/actor/Claimer.ts
+++ b/src/actor/Claimer.ts
@@ -5,6 +5,7 @@ import {
   ERROR_MESSAGE_TYPE,
   ERROR_PE_CREDENTIAL_MISSING,
   ERROR_PE_MISMATCH,
+  ERROR_IDENTITY_NOT_PE_ENABLED,
 } from '../errorhandling/SDKErrors'
 import Identity from '../identity/Identity'
 import PublicAttesterIdentity from '../identity/PublicAttesterIdentity'
@@ -76,6 +77,9 @@ export async function createPresentation(
     const peCreds = credentials.map((c) => c.privacyCredential)
     if (!noNulls(peCreds)) {
       throw ERROR_PE_CREDENTIAL_MISSING()
+    }
+    if (!identity.claimer) {
+      throw ERROR_IDENTITY_NOT_PE_ENABLED()
     }
     const gabiPresentation = await identity.claimer.buildCombinedPresentation({
       credentials: peCreds,

--- a/src/credential/Credential.ts
+++ b/src/credential/Credential.ts
@@ -17,6 +17,7 @@ import Identity from '../identity/Identity'
 import IAttestation from '../types/Attestation'
 import ICredential from '../types/Credential'
 import IRequestForAttestation from '../types/RequestForAttestation'
+import { ERROR_IDENTITY_NOT_PE_ENABLED } from '../errorhandling/SDKErrors'
 
 export default class Credential {
   /**
@@ -55,6 +56,9 @@ export default class Credential {
     let privacyCredential: gabi.Credential | null = null
 
     if (session !== null && attestationPE !== null) {
+      if (!claimer.claimer) {
+        throw ERROR_IDENTITY_NOT_PE_ENABLED()
+      }
       privacyCredential = await claimer.claimer.buildCredential({
         claimerSession: session,
         attestation: attestationPE,

--- a/src/errorhandling/SDKErrors.ts
+++ b/src/errorhandling/SDKErrors.ts
@@ -9,6 +9,7 @@
 import { NonceHash } from '../types/RequestForAttestation'
 
 export enum ErrorCode {
+  // Data is missing
   ERROR_CTYPE_HASH_NOT_PROVIDED = 10001,
   ERROR_CLAIM_HASH_NOT_PROVIDED = 10002,
   ERROR_CLAIM_HASHTREE_NOT_PROVIDED = 10003,
@@ -23,7 +24,9 @@ export enum ErrorCode {
   ERROR_PE_CREDENTIAL_MISSING = 10012,
   ERROR_CTYPE_ID_NOT_MATCHING = 10013,
   ERROR_PE_VERIFICATION = 10014,
+  ERROR_IDENTITY_NOT_PE_ENABLED = 10014,
 
+  // Data type is wrong or malformed
   ERROR_ADDRESS_TYPE = 20001,
   ERROR_HASH_TYPE = 20002,
   ERROR_HASH_MALFORMED = 20003,
@@ -43,6 +46,7 @@ export enum ErrorCode {
   ERROR_ROOT_NODE_QUERY = 20017,
   ERROR_INVALID_DID_PREFIX = 20018,
 
+  // Data is invalid
   ERROR_ADDRESS_INVALID = 30001,
   ERROR_NONCE_HASH_INVALID = 30002,
   ERROR_LEGITIMATIONS_UNVERIFIABLE = 30003,
@@ -55,6 +59,7 @@ export enum ErrorCode {
   ERROR_ROOT_HASH_UNVERIFIABLE = 30010,
   ERROR_NESTED_CLAIM_UNVERIFIABLE = 30011,
 
+  // Compression / Decompressions
   ERROR_DECOMPRESSION_ARRAY = 40001,
   ERROR_COMPRESS_OBJECT = 40002,
   ERROR_DECODING_MESSAGE = 40003,
@@ -423,6 +428,14 @@ export const ERROR_IDENTITY_MISMATCH: (
     'Addresses expected to be equal mismatched'
   )
 }
+
+export const ERROR_IDENTITY_NOT_PE_ENABLED: () => SDKError = () => {
+  return new SDKError(
+    ErrorCode.ERROR_IDENTITY_NOT_PE_ENABLED,
+    'Identity is not privacy enhaced'
+  )
+}
+
 export const ERROR_ROOT_HASH_UNVERIFIABLE: () => SDKError = () => {
   return new SDKError(
     ErrorCode.ERROR_ROOT_HASH_UNVERIFIABLE,

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -55,7 +55,7 @@ export default class AttesterIdentity extends Identity {
    */
   public static async buildFromIdentity(
     identity: Identity,
-    options: Options = { peEnabled: true }
+    options: Options = {}
   ): Promise<AttesterIdentity> {
     if (!identity.claimer) {
       throw ERROR_IDENTITY_NOT_PE_ENABLED()
@@ -104,10 +104,10 @@ export default class AttesterIdentity extends Identity {
    */
   public static async buildFromMnemonic(
     phraseArg?: string,
-    options: Options = { peEnabled: true }
+    options: Options = {}
   ): Promise<AttesterIdentity> {
     return this.buildFromIdentity(
-      await Identity.buildFromMnemonic(phraseArg, options),
+      await Identity.buildFromMnemonic(phraseArg, { peEnabled: true }),
       options
     )
   }
@@ -127,10 +127,10 @@ export default class AttesterIdentity extends Identity {
    */
   public static async buildFromSeedString(
     seedArg: string,
-    options: Options = { peEnabled: true }
+    options: Options = {}
   ): Promise<AttesterIdentity> {
     return this.buildFromIdentity(
-      await Identity.buildFromSeedString(seedArg, options),
+      await Identity.buildFromSeedString(seedArg, { peEnabled: true }),
       options
     )
   }
@@ -153,10 +153,10 @@ export default class AttesterIdentity extends Identity {
    */
   public static async buildFromSeed(
     seed: Uint8Array,
-    options: Options = { peEnabled: true }
+    options: Options = {}
   ): Promise<AttesterIdentity> {
     return this.buildFromIdentity(
-      await Identity.buildFromSeed(seed, options),
+      await Identity.buildFromSeed(seed, { peEnabled: true }),
       options
     )
   }
@@ -173,10 +173,10 @@ export default class AttesterIdentity extends Identity {
    */
   public static async buildFromURI(
     uri: string,
-    options: Options = { peEnabled: true }
+    options: Options = {}
   ): Promise<AttesterIdentity> {
     return this.buildFromIdentity(
-      await Identity.buildFromURI(uri, options),
+      await Identity.buildFromURI(uri, { peEnabled: true }),
       options
     )
   }

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -60,6 +60,10 @@ function fillRight(
   return paddedSeed
 }
 
+export type IdentityBuildOptions = {
+  peEnabled: boolean
+}
+
 export default class Identity {
   private static ADDITIONAL_ENTROPY_FOR_HASHING = new Uint8Array([1, 2, 3])
 
@@ -80,6 +84,8 @@ export default class Identity {
    * [STATIC] Builds an identity object from a mnemonic string.
    *
    * @param phraseArg - [BIP39](https://www.npmjs.com/package/bip39) Mnemonic word phrase (Secret phrase).
+   * @param options The option object.
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
    * @throws When phraseArg contains fewer than 12 correctly separated mnemonic words.
    * @throws When the phraseArg could not be validated.
    * @throws [[ERROR_MNEMONIC_PHRASE_MALFORMED]], [[ERROR_MNEMONIC_PHRASE_INVALID]].
@@ -92,7 +98,10 @@ export default class Identity {
    * await Identity.buildFromMnemonic(mnemonic);
    * ```
    */
-  public static async buildFromMnemonic(phraseArg?: string): Promise<Identity> {
+  public static async buildFromMnemonic(
+    phraseArg?: string,
+    options: IdentityBuildOptions = { peEnabled: true }
+  ): Promise<Identity> {
     let phrase = phraseArg
     if (phrase) {
       if (phrase.trim().split(/\s+/g).length < 12) {
@@ -108,13 +117,15 @@ export default class Identity {
     }
 
     const seed = mnemonicToMiniSecret(phrase)
-    return Identity.buildFromSeed(seed)
+    return Identity.buildFromSeed(seed, options)
   }
 
   /**
    * [STATIC] Builds an [[Identity]], generated from a seed hex string.
    *
    * @param seedArg - Seed as hex string (Starting with 0x).
+   * @param options The option object.
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
    * @returns  An [[Identity]].
    * @example ```javascript
    * const seed =
@@ -122,15 +133,20 @@ export default class Identity {
    * await Identity.buildFromSeedString(seed);
    * ```
    */
-  public static async buildFromSeedString(seedArg: string): Promise<Identity> {
+  public static async buildFromSeedString(
+    seedArg: string,
+    options: IdentityBuildOptions = { peEnabled: true }
+  ): Promise<Identity> {
     const asU8a = hexToU8a(seedArg)
-    return Identity.buildFromSeed(asU8a)
+    return Identity.buildFromSeed(asU8a, options)
   }
 
   /**
    * [STATIC] Builds a new [[Identity]], generated from a seed (Secret Seed).
    *
    * @param seed - A seed as an Uint8Array with 24 arbitrary numbers.
+   * @param options The option object.
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
    * @returns An [[Identity]].
    * @example ```javascript
    * // prettier-ignore
@@ -142,13 +158,19 @@ export default class Identity {
    * await Identity.buildFromSeed(seed);
    * ```
    */
-  public static async buildFromSeed(seed: Uint8Array): Promise<Identity> {
+  public static async buildFromSeed(
+    seed: Uint8Array,
+    options: IdentityBuildOptions = { peEnabled: true }
+  ): Promise<Identity> {
     const keyring = new Keyring({ type: 'ed25519' })
     const keyringPair = keyring.addFromSeed(seed)
 
     // pad seed if needed for claimer
     const paddedSeed = fillRight(seed, 0, MIN_SEED_LENGTH)
-    const claimer = await Claimer.buildFromSeed(paddedSeed)
+    let claimer = null
+    if (options.peEnabled) {
+      claimer = await Claimer.buildFromSeed(paddedSeed)
+    }
 
     return new Identity(seed, keyringPair, claimer)
   }
@@ -157,18 +179,26 @@ export default class Identity {
    * [STATIC] Builds a new [[Identity]], generated from a uniform resource identifier (URIs).
    *
    * @param uri - Standard identifiers.
+   * @param options The option object.
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
    * @returns  An [[Identity]].
    * @example ```javascript
    * Identity.buildFromURI('//Bob');
    * ```
    */
-  public static async buildFromURI(uri: string): Promise<Identity> {
+  public static async buildFromURI(
+    uri: string,
+    options: IdentityBuildOptions = { peEnabled: true }
+  ): Promise<Identity> {
     const keyring = new Keyring({ type: 'ed25519' })
     const derived = keyring.createFromUri(uri)
     const seed = u8aUtil.u8aToU8a(uri)
 
-    const paddedSeed = fillRight(seed, 0, MIN_SEED_LENGTH)
-    const claimer = await Claimer.buildFromSeed(paddedSeed)
+    let claimer = null
+    if (options.peEnabled) {
+      const paddedSeed = fillRight(seed, 0, MIN_SEED_LENGTH)
+      claimer = await Claimer.buildFromSeed(paddedSeed)
+    }
 
     return new Identity(seed, derived, claimer)
   }
@@ -176,7 +206,7 @@ export default class Identity {
   public readonly seed: Uint8Array
   public readonly seedAsHex: string
   public readonly signPublicKeyAsHex: string
-  public readonly claimer: Claimer
+  public readonly claimer: Claimer | null
   public readonly signKeyringPair: KeyringPair
   public readonly boxKeyPair: BoxKeyPair
   public serviceAddress?: string
@@ -184,7 +214,7 @@ export default class Identity {
   protected constructor(
     seed: Uint8Array,
     signKeyringPair: KeyringPair,
-    claimer: Claimer
+    claimer: Claimer | null
   ) {
     // NB: use different secret keys for each key pair in order to avoid
     // compromising both key pairs at the same time if one key becomes public

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -61,7 +61,7 @@ function fillRight(
 }
 
 export type IdentityBuildOptions = {
-  peEnabled: boolean
+  peEnabled?: boolean
 }
 
 export default class Identity {
@@ -100,7 +100,7 @@ export default class Identity {
    */
   public static async buildFromMnemonic(
     phraseArg?: string,
-    options: IdentityBuildOptions = { peEnabled: true }
+    { peEnabled = true }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     let phrase = phraseArg
     if (phrase) {
@@ -117,7 +117,7 @@ export default class Identity {
     }
 
     const seed = mnemonicToMiniSecret(phrase)
-    return Identity.buildFromSeed(seed, options)
+    return Identity.buildFromSeed(seed, { peEnabled })
   }
 
   /**
@@ -135,10 +135,10 @@ export default class Identity {
    */
   public static async buildFromSeedString(
     seedArg: string,
-    options: IdentityBuildOptions = { peEnabled: true }
+    { peEnabled = true }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     const asU8a = hexToU8a(seedArg)
-    return Identity.buildFromSeed(asU8a, options)
+    return Identity.buildFromSeed(asU8a, { peEnabled })
   }
 
   /**
@@ -160,7 +160,7 @@ export default class Identity {
    */
   public static async buildFromSeed(
     seed: Uint8Array,
-    options: IdentityBuildOptions = { peEnabled: true }
+    { peEnabled = true }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     const keyring = new Keyring({ type: 'ed25519' })
     const keyringPair = keyring.addFromSeed(seed)
@@ -168,7 +168,7 @@ export default class Identity {
     // pad seed if needed for claimer
     const paddedSeed = fillRight(seed, 0, MIN_SEED_LENGTH)
     let claimer = null
-    if (options.peEnabled) {
+    if (peEnabled) {
       claimer = await Claimer.buildFromSeed(paddedSeed)
     }
 
@@ -188,14 +188,14 @@ export default class Identity {
    */
   public static async buildFromURI(
     uri: string,
-    options: IdentityBuildOptions = { peEnabled: true }
+    { peEnabled = true }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     const keyring = new Keyring({ type: 'ed25519' })
     const derived = keyring.createFromUri(uri)
     const seed = u8aUtil.u8aToU8a(uri)
 
     let claimer = null
-    if (options.peEnabled) {
+    if (peEnabled) {
       const paddedSeed = fillRight(seed, 0, MIN_SEED_LENGTH)
       claimer = await Claimer.buildFromSeed(paddedSeed)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export * from './types/Attestation'
 export { default as IAttestedClaim } from './types/AttestedClaim'
 export { default as IClaim } from './types/Claim'
 export { default as ICredential } from './types/Credential'
-export { default as ICType } from './types/CType'
+export { default as ICType, CTypeSchemaWithoutId } from './types/CType'
 export { default as ICTypeMetadata } from './types/CTypeMetadata'
 export {
   IDelegationBaseNode,

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -337,7 +337,7 @@ export interface IRejectAttestationForClaim extends IMessageBodyBase {
 export interface IRequestClaimsForCTypes extends IMessageBodyBase {
   content: {
     ctypes: Array<ICType['hash'] | null>
-    peRequest: CombinedPresentationRequest
+    peRequest?: CombinedPresentationRequest
     allowPE: boolean
   }
   type: MessageBodyType.REQUEST_CLAIMS_FOR_CTYPES

--- a/src/requestforattestation/RequestForAttestation.ts
+++ b/src/requestforattestation/RequestForAttestation.ts
@@ -154,6 +154,9 @@ export default class RequestForAttestation implements IRequestForAttestation {
       if (typeof delegationId !== 'undefined') {
         rawClaim.delegationId = delegationId
       }
+      if (!identity.claimer) {
+        throw SDKErrors.ERROR_IDENTITY_NOT_PE_ENABLED()
+      }
       const peSessionMessage = await identity.claimer.requestAttestation({
         claim: rawClaim,
         startAttestationMsg: initiateAttestationMsg.content,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#634
This PR adds options to methods to disable calls to portablegabi, so that the wasm file is not loaded.

## How to test:
- Tests should run

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
