### PR TITLE
feat: gabi opt-in, rename public to classic & require mnemonic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,7 +88,7 @@
         "jsdoc/check-tag-names": [
           "warn",
           {
-            "definedTags": ["group"]
+            "definedTags": ["group", "packageDocumentation"]
           }
         ],
         "@typescript-eslint/no-var-requires": "off"

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -93,7 +93,8 @@ async function setup(): Promise<{
   // How to generate an Identity
   // const mnemonic = Kilt.Identity.generateMnemonic()
   const claimer = await Kilt.Identity.buildFromMnemonic(
-    'wish rather clinic rather connect culture frown like quote effort cart faculty'
+    'wish rather clinic rather connect culture frown like quote effort cart faculty',
+    { peEnabled: true }
   )
   // const address = claimer.getAddress()
 

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -231,7 +231,9 @@ async function doVerification(
     )
   )
   const verifierMnemonic = Identity.generateMnemonic()
-  const verifier = await Kilt.Identity.buildFromMnemonic(verifierMnemonic)
+  const verifier = await Kilt.Identity.buildFromMnemonic(verifierMnemonic, {
+    peEnabled: true,
+  })
   // ------------------------- Verifier ----------------------------------------
   const { session, message: request } = await Kilt.Verifier.newRequestBuilder()
     .requestPresentationForCtype({

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -230,7 +230,8 @@ async function doVerification(
       ' VERIFICATION '
     )
   )
-  const verifier = await Kilt.Identity.buildFromMnemonic()
+  const verifierMnemonic = Identity.generateMnemonic()
+  const verifier = await Kilt.Identity.buildFromMnemonic(verifierMnemonic)
   // ------------------------- Verifier ----------------------------------------
   const { session, message: request } = await Kilt.Verifier.newRequestBuilder()
     .requestPresentationForCtype({

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -476,9 +476,9 @@ const { session: verifierSession } = await Kilt.Verifier.newRequestBuilder()
 Now the claimer can send a message to the verifier including the attested claim:
 
 ```typescript
-const messageBodyForVerifier: ISubmitClaimsForCTypesPublic = {
+const messageBodyForVerifier: ISubmitClaimsForCTypesClassic = {
   content: [myAttestedClaim],
-  type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+  type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
 }
 const messageForVerifier = new Kilt.Message(
   messageBodyForVerifier,

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -5,6 +5,7 @@ import Kilt, {
   MessageBodyType,
   ISubmitAttestationForClaim,
   ISubmitClaimsForCTypesClassic,
+  Identity,
 } from '../src'
 import { DEFAULT_WS_ADDRESS } from '../src/blockchainApiConnection'
 
@@ -141,7 +142,8 @@ async function main(): Promise<void> {
       console.log(myAttestedClaim)
 
       /* As in the attestation, you need a second identity to act as the verifier: */
-      const verifier = await Kilt.Identity.buildFromMnemonic()
+      const verifierMnemonic = Identity.generateMnemonic()
+      const verifier = await Kilt.Identity.buildFromMnemonic(verifierMnemonic)
 
       /* 6.1.1. Without privacy enhancement */
       const {

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -4,7 +4,7 @@ import Kilt, {
   Message,
   MessageBodyType,
   ISubmitAttestationForClaim,
-  ISubmitClaimsForCTypesPublic,
+  ISubmitClaimsForCTypesClassic,
 } from '../src'
 import { DEFAULT_WS_ADDRESS } from '../src/blockchainApiConnection'
 
@@ -159,9 +159,9 @@ async function main(): Promise<void> {
         )
 
       /* Now the claimer can send a message to verifier including the attested claim: */
-      const messageBodyForVerifier: ISubmitClaimsForCTypesPublic = {
+      const messageBodyForVerifier: ISubmitClaimsForCTypesClassic = {
         content: [myAttestedClaim],
-        type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+        type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
       }
       const messageForVerifier = new Kilt.Message(
         messageBodyForVerifier,

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -124,7 +124,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
 
-    const bobbyBroke = await Identity.buildFromMnemonic()
+    const bobbyBroke = await Identity.buildFromMnemonic(
+      Identity.generateMnemonic()
+    )
 
     await expect(attestation.store(bobbyBroke)).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(

--- a/src/__integrationtests__/AttestationPE.spec.ts
+++ b/src/__integrationtests__/AttestationPE.spec.ts
@@ -16,7 +16,7 @@ import Credential from '../credential'
 import Identity, { AttesterIdentity } from '../identity'
 import constants from '../test/constants'
 import { IRevocationHandle } from '../types/Attestation'
-import { CtypeOnChain, DriversLicense, FaucetSeed, wannabeBob } from './utils'
+import { CtypeOnChain, DriversLicense, FaucetSeed } from './utils'
 
 let blockchain: IBlockchainApi | undefined
 beforeAll(async () => {
@@ -34,14 +34,14 @@ describe('Privacy enhanced claim, attestation, verification process', () => {
 
   beforeAll(async () => {
     // set up actors
-    claimer = await wannabeBob
+    claimer = await Identity.buildFromURI('//Bob', { peEnabled: true })
     attester = await AttesterIdentity.buildFromMnemonic(FaucetSeed, {
       key: {
         publicKey: constants.PUBLIC_KEY.toString(),
         privateKey: constants.PRIVATE_KEY.toString(),
       },
     })
-    verifier = await Identity.buildFromMnemonic()
+    verifier = await Identity.buildFromMnemonic(undefined, { peEnabled: true })
 
     // update accumulator (empty for fresh chain)
     accumulator = await Attester.buildAccumulator(attester)

--- a/src/__integrationtests__/AttestationPE.spec.ts
+++ b/src/__integrationtests__/AttestationPE.spec.ts
@@ -41,7 +41,9 @@ describe('Privacy enhanced claim, attestation, verification process', () => {
         privateKey: constants.PRIVATE_KEY.toString(),
       },
     })
-    verifier = await Identity.buildFromMnemonic(undefined, { peEnabled: true })
+    verifier = await Identity.buildFromMnemonic(Identity.generateMnemonic(), {
+      peEnabled: true,
+    })
 
     // update accumulator (empty for fresh chain)
     accumulator = await Attester.buildAccumulator(attester)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -55,14 +55,16 @@ describe('when there is a dev chain with a faucet', () => {
 
   it('getBalance should return 0 for new identity', async () => {
     return expect(
-      getBalance((await Identity.buildFromMnemonic()).getAddress()).then((n) =>
-        n.toNumber()
-      )
+      getBalance(
+        (
+          await Identity.buildFromMnemonic(Identity.generateMnemonic())
+        ).getAddress()
+      ).then((n) => n.toNumber())
     ).resolves.toEqual(0)
   })
 
   it('should be able to faucet coins to a new identity', async () => {
-    const ident = await Identity.buildFromMnemonic()
+    const ident = await Identity.buildFromMnemonic(Identity.generateMnemonic())
     const funny = jest.fn()
     listenToBalanceChanges(ident.getAddress(), funny)
     const balanceBefore = await getBalance(faucet.getAddress())
@@ -86,10 +88,10 @@ describe('When there are haves and have-nots', () => {
   let faucet: Identity
 
   beforeAll(async () => {
-    bobbyBroke = await Identity.buildFromMnemonic()
+    bobbyBroke = await Identity.buildFromMnemonic(Identity.generateMnemonic())
     richieRich = await wannabeAlice
     faucet = await wannabeFaucet
-    stormyD = await Identity.buildFromMnemonic()
+    stormyD = await Identity.buildFromMnemonic(Identity.generateMnemonic())
   })
 
   it('can transfer tokens from the rich to the poor', async () => {

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -41,7 +41,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type w/o tokens', async () => {
     const ctype = makeCType()
-    const bobbyBroke = await Identity.buildFromMnemonic()
+    const bobbyBroke = await Identity.buildFromMnemonic(
+      Identity.generateMnemonic()
+    )
     await expect(ctype.store(bobbyBroke)).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)

--- a/src/__integrationtests__/Did.spec.ts
+++ b/src/__integrationtests__/Did.spec.ts
@@ -18,7 +18,7 @@ describe('querying DIDs that do not exist', () => {
   let ident: Identity
 
   beforeAll(async () => {
-    ident = await Identity.buildFromMnemonic()
+    ident = await Identity.buildFromMnemonic(Identity.generateMnemonic())
   })
 
   it('queryByAddress', async () => {

--- a/src/actor/Attester.spec.ts
+++ b/src/actor/Attester.spec.ts
@@ -37,7 +37,7 @@ describe('Attester', () => {
       },
     })
 
-    claimer = await Identity.buildFromURI('//Bob')
+    claimer = await Identity.buildFromURI('//Bob', { peEnabled: true })
 
     rawCType = {
       $id: 'kilt:ctype:0x1',

--- a/src/actor/Claimer.spec.ts
+++ b/src/actor/Claimer.spec.ts
@@ -47,7 +47,9 @@ describe('Claimer', () => {
     })
 
     claimer = await Identity.buildFromURI('//Bob', { peEnabled: true })
-    verifier = await Identity.buildFromMnemonic(undefined, { peEnabled: true })
+    verifier = await Identity.buildFromMnemonic(Identity.generateMnemonic(), {
+      peEnabled: true,
+    })
 
     const rawCType: ICType['schema'] = {
       $id: 'kilt:ctype:0x1',

--- a/src/actor/Claimer.spec.ts
+++ b/src/actor/Claimer.spec.ts
@@ -21,7 +21,7 @@ import Identity from '../identity/Identity'
 import Message, {
   MessageBodyType,
   IRequestClaimsForCTypes,
-  ISubmitClaimsForCTypesPublic,
+  ISubmitClaimsForCTypesClassic,
 } from '../messaging/Message'
 import constants from '../test/constants'
 import { ClaimerAttestationSession } from './Claimer'
@@ -304,7 +304,7 @@ describe('Claimer', () => {
       false
     )
     expect(presentation.body.type).toEqual(
-      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC
     )
     expect(Array.isArray(presentation.body.content)).toBe(true)
   })
@@ -327,10 +327,10 @@ describe('Claimer', () => {
       false
     )
     expect(presentation.body.type).toEqual(
-      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC
     )
     expect(Array.isArray(presentation.body.content)).toBe(true)
-    const { content } = presentation.body as ISubmitClaimsForCTypesPublic
+    const { content } = presentation.body as ISubmitClaimsForCTypesClassic
     expect(Object.keys(content[0].request.claim.contents)).toEqual(
       Object.keys(content[0].request.claimHashTree)
     )

--- a/src/actor/Claimer.spec.ts
+++ b/src/actor/Claimer.spec.ts
@@ -46,8 +46,8 @@ describe('Claimer', () => {
       },
     })
 
-    claimer = await Identity.buildFromURI('//Bob')
-    verifier = await Identity.buildFromMnemonic()
+    claimer = await Identity.buildFromURI('//Bob', { peEnabled: true })
+    verifier = await Identity.buildFromMnemonic(undefined, { peEnabled: true })
 
     const rawCType: ICType['schema'] = {
       $id: 'kilt:ctype:0x1',

--- a/src/actor/Claimer.ts
+++ b/src/actor/Claimer.ts
@@ -126,7 +126,7 @@ export async function createPresentation(
 
   return new Message(
     {
-      type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+      type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
       content: attestedClaims,
     },
     identity,

--- a/src/actor/Verifier.spec.ts
+++ b/src/actor/Verifier.spec.ts
@@ -40,8 +40,8 @@ describe('Verifier', () => {
       },
     })
 
-    claimer = await Identity.buildFromURI('//bob')
-    verifier = await Identity.buildFromMnemonic()
+    claimer = await Identity.buildFromURI('//bob', { peEnabled: true })
+    verifier = await Identity.buildFromMnemonic(undefined, { peEnabled: true })
 
     const rawCType: ICType['schema'] = {
       $id: 'kilt:ctype:0x1',

--- a/src/actor/Verifier.spec.ts
+++ b/src/actor/Verifier.spec.ts
@@ -260,7 +260,7 @@ describe('Verifier', () => {
       ...{
         // set public type and remove attestedClaims
         body: {
-          type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+          type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
           content: [],
         },
       },
@@ -337,7 +337,7 @@ describe('Verifier', () => {
     ).rejects.toThrowError(
       ERROR_MESSAGE_TYPE(
         MessageBodyType.SUBMIT_TERMS,
-        MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+        MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
         MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PE
       )
     )
@@ -394,7 +394,7 @@ describe('Verifier', () => {
       false
     )
     expect(presentation.body.type).toEqual(
-      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC
     )
     expect(Array.isArray(presentation.body.content)).toBeTruthy()
 
@@ -426,11 +426,12 @@ describe('Verifier', () => {
       false
     )
     expect(presentation.body.type).toEqual(
-      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC
     )
     expect(Array.isArray(presentation.body.content)).toBeTruthy()
     if (
-      presentation.body.type === MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+      presentation.body.type ===
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC
     ) {
       delete presentation.body.content[0].request.claim.contents.name
       const { verified: ok, claims } = await Verifier.verifyPresentation(

--- a/src/actor/Verifier.spec.ts
+++ b/src/actor/Verifier.spec.ts
@@ -41,7 +41,9 @@ describe('Verifier', () => {
     })
 
     claimer = await Identity.buildFromURI('//bob', { peEnabled: true })
-    verifier = await Identity.buildFromMnemonic(undefined, { peEnabled: true })
+    verifier = await Identity.buildFromMnemonic(Identity.generateMnemonic(), {
+      peEnabled: true,
+    })
 
     const rawCType: ICType['schema'] = {
       $id: 'kilt:ctype:0x1',

--- a/src/actor/Verifier.ts
+++ b/src/actor/Verifier.ts
@@ -238,7 +238,7 @@ export async function verifyPresentation(
   claims: Array<Partial<IRequestForAttestation | IAttestedClaim>>
 }> {
   // If we got a public presentation, check that the attestation is valid
-  if (message.body.type === MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC) {
+  if (message.body.type === MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC) {
     const attestedClaims = message.body.content.map(
       AttestedClaim.fromAttestedClaim
     )
@@ -272,7 +272,7 @@ export async function verifyPresentation(
   } else {
     throw ERROR_MESSAGE_TYPE(
       message.body.type,
-      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+      MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
       MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PE
     )
   }

--- a/src/credential/Credential.spec.ts
+++ b/src/credential/Credential.spec.ts
@@ -16,13 +16,16 @@ describe('Credential', () => {
   let attestation: Attestation
 
   beforeAll(async () => {
-    attester = await AttesterIdentity.buildFromMnemonic(undefined, {
-      key: {
-        publicKey: constants.PUBLIC_KEY.toString(),
-        privateKey: constants.PRIVATE_KEY.toString(),
-      },
-    })
-    claimer = await Identity.buildFromMnemonic()
+    attester = await AttesterIdentity.buildFromMnemonic(
+      Identity.generateMnemonic(),
+      {
+        key: {
+          publicKey: constants.PUBLIC_KEY.toString(),
+          privateKey: constants.PRIVATE_KEY.toString(),
+        },
+      }
+    )
+    claimer = await Identity.buildFromMnemonic(Identity.generateMnemonic())
 
     const rawCType: ICType['schema'] = {
       $id: 'kilt:ctype:0x1',

--- a/src/crypto/Crypto.spec.ts
+++ b/src/crypto/Crypto.spec.ts
@@ -10,8 +10,8 @@ describe('Crypto', () => {
   let message: Uint8Array
 
   beforeAll(async () => {
-    alice = await Identity.buildFromMnemonic()
-    bob = await Identity.buildFromMnemonic()
+    alice = await Identity.buildFromMnemonic(Identity.generateMnemonic())
+    bob = await Identity.buildFromMnemonic(Identity.generateMnemonic())
 
     messageStr = 'This is a test'
     message = new Uint8Array(string.stringToU8a(messageStr))

--- a/src/identity/AttesterIdentity.spec.ts
+++ b/src/identity/AttesterIdentity.spec.ts
@@ -41,7 +41,7 @@ describe('AttesterIdentity', () => {
       type: 'object',
       title: 'title',
     }
-    claimer = await Identity.buildFromURI('//Bob')
+    claimer = await Identity.buildFromURI('//Bob', { peEnabled: true })
     cType = CType.fromSchema(rawCType, claimer.getAddress())
     attester = await AttesterIdentity.buildFromMnemonic(mnemonic, {
       key: {
@@ -113,7 +113,9 @@ describe('AttesterIdentity', () => {
   })
 
   it('should build the same from plain identity', async () => {
-    const plainId = await Identity.buildFromMnemonic(mnemonic)
+    const plainId = await Identity.buildFromMnemonic(mnemonic, {
+      peEnabled: true,
+    })
     const newAttester = await AttesterIdentity.buildFromIdentity(plainId, {
       key: {
         publicKey: constants.PUBLIC_KEY.toString(),

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -103,7 +103,7 @@ export default class AttesterIdentity extends Identity {
    * ```
    */
   public static async buildFromMnemonic(
-    phraseArg?: string,
+    phraseArg: string,
     options: Options = {}
   ): Promise<AttesterIdentity> {
     return this.buildFromIdentity(

--- a/src/identity/Identity.spec.ts
+++ b/src/identity/Identity.spec.ts
@@ -27,8 +27,8 @@ describe('Identity', () => {
   })
 
   it('should create different identities with random phrases', async () => {
-    const alice = await Identity.buildFromMnemonic()
-    const bob = await Identity.buildFromMnemonic()
+    const alice = await Identity.buildFromMnemonic(Identity.generateMnemonic())
+    const bob = await Identity.buildFromMnemonic(Identity.generateMnemonic())
 
     expect(alice.signPublicKeyAsHex).not.toBeFalsy()
     expect(alice.boxKeyPair.publicKey).not.toBeFalsy()
@@ -61,7 +61,7 @@ describe('Identity', () => {
   })
 
   it('should have different keys for signing and boxing', async () => {
-    const alice = await Identity.buildFromMnemonic()
+    const alice = await Identity.buildFromMnemonic(Identity.generateMnemonic())
     expect(coToUInt8(alice.signPublicKeyAsHex)).not.toEqual(
       alice.boxKeyPair.publicKey
     )
@@ -82,19 +82,22 @@ describe('Identity', () => {
   })
 
   it('should have different keys for signing and boxing', async () => {
-    const alice = await Identity.buildFromMnemonic()
+    const alice = await Identity.buildFromMnemonic(Identity.generateMnemonic())
     expect(coToUInt8(alice.signPublicKeyAsHex)).not.toEqual(
       alice.boxKeyPair.publicKey
     )
   })
 
   it('should initiate attestation with gabi keys (PE)', async () => {
-    const alice = await AttesterIdentity.buildFromMnemonic(undefined, {
-      key: {
-        publicKey: constants.PUBLIC_KEY.toString(),
-        privateKey: constants.PRIVATE_KEY.toString(),
-      },
-    })
+    const alice = await AttesterIdentity.buildFromMnemonic(
+      Identity.generateMnemonic(),
+      {
+        key: {
+          publicKey: constants.PUBLIC_KEY.toString(),
+          privateKey: constants.PRIVATE_KEY.toString(),
+        },
+      }
+    )
 
     const msgSession = await alice.initiateAttestation()
     expect(msgSession.session).toBeDefined()

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -85,7 +85,7 @@ export default class Identity {
    *
    * @param phraseArg - [BIP39](https://www.npmjs.com/package/bip39) Mnemonic word phrase (Secret phrase).
    * @param options The option object.
-   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: false).
    * @throws When phraseArg contains fewer than 12 correctly separated mnemonic words.
    * @throws When the phraseArg could not be validated.
    * @throws [[ERROR_MNEMONIC_PHRASE_MALFORMED]], [[ERROR_MNEMONIC_PHRASE_INVALID]].
@@ -100,7 +100,7 @@ export default class Identity {
    */
   public static async buildFromMnemonic(
     phraseArg?: string,
-    { peEnabled = true }: IdentityBuildOptions = {}
+    { peEnabled = false }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     let phrase = phraseArg
     if (phrase) {
@@ -125,7 +125,7 @@ export default class Identity {
    *
    * @param seedArg - Seed as hex string (Starting with 0x).
    * @param options The option object.
-   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: false).
    * @returns  An [[Identity]].
    * @example ```javascript
    * const seed =
@@ -135,7 +135,7 @@ export default class Identity {
    */
   public static async buildFromSeedString(
     seedArg: string,
-    { peEnabled = true }: IdentityBuildOptions = {}
+    { peEnabled = false }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     const asU8a = hexToU8a(seedArg)
     return Identity.buildFromSeed(asU8a, { peEnabled })
@@ -146,7 +146,7 @@ export default class Identity {
    *
    * @param seed - A seed as an Uint8Array with 24 arbitrary numbers.
    * @param options The option object.
-   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: false).
    * @returns An [[Identity]].
    * @example ```javascript
    * // prettier-ignore
@@ -160,7 +160,7 @@ export default class Identity {
    */
   public static async buildFromSeed(
     seed: Uint8Array,
-    { peEnabled = true }: IdentityBuildOptions = {}
+    { peEnabled = false }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     const keyring = new Keyring({ type: 'ed25519' })
     const keyringPair = keyring.addFromSeed(seed)
@@ -180,7 +180,7 @@ export default class Identity {
    *
    * @param uri - Standard identifiers.
    * @param options The option object.
-   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: true).
+   * @param options.peEnabled - If the identity should be privacy enhanced, or not (default: false).
    * @returns  An [[Identity]].
    * @example ```javascript
    * Identity.buildFromURI('//Bob');
@@ -188,7 +188,7 @@ export default class Identity {
    */
   public static async buildFromURI(
     uri: string,
-    { peEnabled = true }: IdentityBuildOptions = {}
+    { peEnabled = false }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     const keyring = new Keyring({ type: 'ed25519' })
     const derived = keyring.createFromUri(uri)

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -99,7 +99,7 @@ export default class Identity {
    * ```
    */
   public static async buildFromMnemonic(
-    phraseArg?: string,
+    phraseArg: string,
     { peEnabled = false }: IdentityBuildOptions = {}
   ): Promise<Identity> {
     let phrase = phraseArg
@@ -239,7 +239,8 @@ export default class Identity {
    *
    * @returns The [[PublicIdentity]], corresponding to the [[Identity]].
    * @example ```javascript
-   * const alice = await Kilt.Identity.buildFromMnemonic();
+   * const mnemonic = Identity.generateMnemonic();
+   * const alice = await Kilt.Identity.buildFromMnemonic(mnemonic);
    * alice.getPublicIdentity();
    * ```
    */
@@ -275,7 +276,8 @@ export default class Identity {
    * @param cryptoInput - The data to be signed.
    * @returns The signed data.
    * @example  ```javascript
-   * const alice = await Identity.buildFromMnemonic();
+   * const mnemonic = Identity.generateMnemonic();
+   * const alice = await Identity.buildFromMnemonic(mnemonic);
    * const data = 'This is a test';
    * alice.sign(data);
    * // (output) Uint8Array [

--- a/src/messaging/Message.spec.ts
+++ b/src/messaging/Message.spec.ts
@@ -211,7 +211,7 @@ describe('Messaging', () => {
 
     const submitClaimsForCTypeBody: ISubmitClaimsForCTypes = {
       content: [attestedClaim],
-      type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC,
+      type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC,
     }
 
     Message.ensureOwnerIsSender(

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -94,7 +94,7 @@ export enum MessageBodyType {
   REJECT_ATTESTATION_FOR_CLAIM = 'reject-attestation-for-claim',
 
   REQUEST_CLAIMS_FOR_CTYPES = 'request-claims-for-ctypes',
-  SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC = 'submit-claims-for-ctypes-public',
+  SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC = 'submit-claims-for-ctypes-classic',
   SUBMIT_CLAIMS_FOR_CTYPES_PE = 'submit-claims-for-ctypes-pe',
   ACCEPT_CLAIMS_FOR_CTYPES = 'accept-claims-for-ctypes',
   REJECT_CLAIMS_FOR_CTYPES = 'reject-claims-for-ctypes',
@@ -113,7 +113,7 @@ export default class Message implements IMessage {
    * @param message.body The body of the [[Message]] which depends on the [[MessageBodyType]].
    * @param message.senderAddress The sender's public SS58 address of the [[Message]].
    * @throws When the sender does not match the owner of the in the Message supplied Object.
-   * @throws [[SUBMIT_ATTESTATION_FOR_CLAIM]], [[SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC]], [[ERROR_IDENTITY_MISMATCH]].
+   * @throws [[SUBMIT_ATTESTATION_FOR_CLAIM]], [[SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC]], [[ERROR_IDENTITY_MISMATCH]].
    *
    */
   public static ensureOwnerIsSender({ body, senderAddress }: IMessage): void {
@@ -137,9 +137,9 @@ export default class Message implements IMessage {
           }
         }
         break
-      case MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC:
+      case MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC:
         {
-          const submitClaimsForCtype = body
+          const submitClaimsForCtype: ISubmitClaimsForCTypesClassic = body
           submitClaimsForCtype.content.forEach((claim) => {
             if (claim.request.claim.owner !== senderAddress) {
               throw SDKErrors.ERROR_IDENTITY_MISMATCH('Claims', 'Sender')
@@ -344,12 +344,12 @@ export interface IRequestClaimsForCTypes extends IMessageBodyBase {
 }
 
 export type ISubmitClaimsForCTypes =
-  | ISubmitClaimsForCTypesPublic
+  | ISubmitClaimsForCTypesClassic
   | ISubmitClaimsForCTypesPE
 
-export interface ISubmitClaimsForCTypesPublic extends IMessageBodyBase {
+export interface ISubmitClaimsForCTypesClassic extends IMessageBodyBase {
   content: IAttestedClaim[]
-  type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC
+  type: MessageBodyType.SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC
 }
 
 export interface ISubmitClaimsForCTypesPE extends IMessageBodyBase {
@@ -419,7 +419,7 @@ export type MessageBody =
   | IRejectAttestationForClaim
   //
   | IRequestClaimsForCTypes
-  | ISubmitClaimsForCTypesPublic
+  | ISubmitClaimsForCTypesClassic
   | ISubmitClaimsForCTypesPE
   | IAcceptClaimsForCTypes
   | IRejectClaimsForCTypes

--- a/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/src/requestforattestation/RequestForAttestation.spec.ts
@@ -193,13 +193,16 @@ describe('RequestForAttestation', () => {
   })
 
   it('verify request for attestation (PE)', async () => {
+    const identityBobWithPE = await Identity.buildFromURI('//Bob', {
+      peEnabled: true,
+    })
     const [
       request,
       claimerSession,
       attester,
       attesterSession,
     ] = await buildRequestForAttestationPE(
-      identityBob,
+      identityBobWithPE,
       {
         a: 'a',
         b: 'b',


### PR DESCRIPTION
## fixes KILTProtocol/ticket#644
This PR makes portablgabi opt-in and renames `SUBMIT_CLAIMS_FOR_CTYPES_PUBLIC` to `SUBMIT_CLAIMS_FOR_CTYPES_CLASSIC`

## How to test:
- Tests should run succesfully

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
