### PR TITLE
feat: copy jsonabc into project

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+src/util/jsonabc.js
+src/util/jsonabc.d.ts

--- a/package.json
+++ b/package.json
@@ -83,10 +83,8 @@
     "@polkadot/types-known": "^1.23.1",
     "@polkadot/util": "^2.17.1",
     "@polkadot/util-crypto": "^2.17.1",
-    "@types/jsonabc": "^2.3.1",
     "ajv": "^6.12.2",
     "bn.js": "^5.1.2",
-    "jsonabc": "^2.3.1",
     "typescript-logging": "^0.6.4",
     "uuid": "^8.1.0"
   },

--- a/src/claim/Claim.utils.ts
+++ b/src/claim/Claim.utils.ts
@@ -4,7 +4,7 @@
  * @preferred
  */
 
-import * as jsonabc from 'jsonabc'
+import jsonabc from '../util/jsonabc'
 import * as SDKErrors from '../errorhandling/SDKErrors'
 import IClaim, { CompressedClaim } from '../types/Claim'
 import { validateAddress, validateHash } from '../util/DataUtils'

--- a/src/crypto/Crypto.ts
+++ b/src/crypto/Crypto.ts
@@ -22,8 +22,8 @@ import { signatureVerify } from '@polkadot/util-crypto'
 import blake2AsU8a from '@polkadot/util-crypto/blake2/asU8a'
 import naclDecrypt from '@polkadot/util-crypto/nacl/decrypt'
 import naclEncrypt from '@polkadot/util-crypto/nacl/encrypt'
-import * as jsonabc from 'jsonabc'
 import nacl from 'tweetnacl'
+import jsonabc from '../util/jsonabc'
 
 export { encodeAddress, decodeAddress, u8aToHex, u8aConcat }
 

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -5,7 +5,7 @@
  */
 
 import Ajv from 'ajv'
-import * as jsonabc from 'jsonabc'
+import jsonabc from '../util/jsonabc'
 import Crypto from '../crypto'
 import * as SDKErrors from '../errorhandling/SDKErrors'
 import IClaim from '../types/Claim'

--- a/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/src/requestforattestation/RequestForAttestation.utils.ts
@@ -4,7 +4,7 @@
  * @preferred
  */
 
-import * as jsonabc from 'jsonabc'
+import jsonabc from '../util/jsonabc'
 import AttestedClaimUtils from '../attestedclaim/AttestedClaim.utils'
 import ClaimUtils from '../claim/Claim.utils'
 import * as SDKErrors from '../errorhandling/SDKErrors'

--- a/src/util/jsonabc.d.ts
+++ b/src/util/jsonabc.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for jsonabc 2.3
+// Project: http://novicelab.org/jsonabc
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+/* eslint-disable */
+
+/**
+ * Sort the JSON (clean, parse, sort, stringify).
+ * @param noArray Sort or don't sort arrays
+ */
+export function sort(inputStr: string, noArray?: boolean): string;
+
+/**
+ * Sort the JSON (clean, parse, sort, stringify).
+ * @param noArray Sort or don't sort arrays
+ */
+export function sortObj<T extends object>(input: T, noArray?: boolean): T;
+
+/** Remove trailing commas */
+export function cleanJSON(input: string): string;

--- a/src/util/jsonabc.js
+++ b/src/util/jsonabc.js
@@ -1,0 +1,93 @@
+// Taken from https://github.com/ShivrajRath/jsonabc/blob/2ccf15f967f0e44e48fb7b163aebef43c0047166/index.js
+// Copied here, because the package defines a browser compatible script, but doesn't create it,
+// which leads to it failing in react-native. See https://github.com/ShivrajRath/jsonabc/issues/18
+/* eslint-disable */
+
+
+/*!
+  JSON ABC | License: MIT.
+*/
+
+module.exports = {
+  sort: sort,
+  sortObj: sortObj,
+  cleanJSON: cleanJSON
+};
+
+// Is a value an array?
+function isArray (val) {
+  return Object.prototype.toString.call(val) === '[object Array]';
+}
+
+// Is a value an Object?
+function isPlainObject (val) {
+  return Object.prototype.toString.call(val) === '[object Object]';
+}
+
+// Sorting Logic
+function sortObj (un, noarray) {
+  noarray = noarray || false;
+
+  var or = {};
+
+  if (isArray(un)) {
+    // Sort or don't sort arrays
+    if (noarray) {
+      or = un;
+    } else {
+      or = un.sort();
+    }
+
+    or.forEach(function (v, i) {
+      or[i] = sortObj(v, noarray);
+    });
+
+    if (!noarray) {
+      or = or.sort(function (a, b) {
+        a = JSON.stringify(a);
+        b = JSON.stringify(b);
+        return a < b ? -1 : (a > b ? 1 : 0);
+      });
+    }
+  } else if (isPlainObject(un)) {
+    or = {};
+    Object.keys(un).sort(function (a, b) {
+      if (a.toLowerCase() < b.toLowerCase()) return -1;
+      if (a.toLowerCase() > b.toLowerCase()) return 1;
+      return 0;
+    }).forEach(function (key) {
+      or[key] = sortObj(un[key], noarray);
+    });
+  } else {
+    or = un;
+  }
+
+  return or;
+}
+
+// Remove trailing commas
+function cleanJSON (input) {
+  input = input.replace(/,[ \t\r\n]+}/g, '}');
+  input = input.replace(/,[ \t\r\n]+\]/g, ']');
+  return input;
+}
+
+// Sort the JSON (clean, parse, sort, stringify).
+function sort (inputStr, noarray) {
+  var output, obj, r;
+
+  if (inputStr) {
+    try {
+      inputStr = cleanJSON(inputStr);
+      obj = JSON.parse(inputStr);
+      r = sortObj(obj, noarray);
+      output = JSON.stringify(r, null, 4);
+    } catch (ex) {
+      console.error('jsonabc: Incorrect JSON object.', [], ex);
+      throw ex;
+    }
+  }
+  return output;
+}
+
+// End.

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,11 +879,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/jsonabc@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/jsonabc/-/jsonabc-2.3.1.tgz#3aa5d3f938331ef2472d3ea56c6b4c805bef6198"
-  integrity sha512-SOR8DMQQVUmk3JnNp7FU75U+vp/VcFcghvS68mUQEuq4FKDANIQ9dxDA5qEQMDahBCd5Vyhk81ywn0JbcLpZZw==
-
 "@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
@@ -3692,11 +3687,6 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-jsonabc@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/jsonabc/-/jsonabc-2.3.1.tgz#800a1bd158fb30ace2b4613f8725adfcb040bfb4"
-  integrity sha1-gAob0Vj7MKzitGE/hyWt/LBAv7Q=
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## NO-TICKET
Since we always have problems with the `jsonabc` library in react-native, I copied it directly into the project.

The problems stemmed from the library using a `browser` field in their `package.json`, but not building the library, so it leads to nothing.
In the past we built the file in our react-native projects, which is already not a good solution. To save this hassle, I just copied it here.

## How to test:
- tests should run

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
