### PR TITLE
refactor: check for ctype registrations seperately

### DIFF
--- a/src/ctype/CType.ts
+++ b/src/ctype/CType.ts
@@ -104,14 +104,25 @@ export default class CType implements ICType {
   }
 
   /**
-   * [ASYNC] Check whether the current owner of [[CType]] matches the one stored on the blockchain.
-   * - If the [[CType]] has no owner property, it checks whether the [[CType]] hash is known on-chain.
-   * - Else it checks whether the [[CType]] hash is known on-chain AND the owner matches the one stored on the chain.
+   * [ASYNC] Check whether the [[CType]]'s hash has been registered to the blockchain.
    *
-   * @returns Whether the owner of this [[CType]] matches the one stored on the blockchain.
+   * @returns Whether the [[CType]] hash is registered to the blockchain.
    */
   public async verifyStored(): Promise<boolean> {
     return CTypeUtils.verifyStored(this)
+  }
+
+  /**
+   * [ASYNC] Check whether the current owner of [[CType]] matches the one stored on the blockchain. Returns true iff:
+   * - The [[CType]] is registered on-chain
+   * - The owner property of the [[CType]] matches the registered owner
+   * If the owner property is not set this method will always return false because the blockchain always stores the
+   * submitter as owner.
+   *
+   * @returns Whether the owner of this [[CType]] matches the one stored on the blockchain.
+   */
+  public async verifyOwner(): Promise<boolean> {
+    return CTypeUtils.verifyOwner(this)
   }
 
   /**

--- a/src/ctype/CType.utils.ts
+++ b/src/ctype/CType.utils.ts
@@ -62,8 +62,12 @@ export function verifyClaimStructure(
 }
 
 export async function verifyStored(ctype: ICType): Promise<boolean> {
-  const actualOwner = await getOwner(ctype.hash)
-  return ctype.owner ? actualOwner === ctype.owner : actualOwner !== null
+  return typeof (await getOwner(ctype.hash)) === 'string'
+}
+
+export async function verifyOwner(ctype: ICType): Promise<boolean> {
+  const owner = await getOwner(ctype.hash)
+  return owner ? owner === ctype.owner : false
 }
 
 type schemaPropsForHashing = {
@@ -254,6 +258,7 @@ export default {
   verifySchema,
   verifySchemaWithErrors,
   verifyStored,
+  verifyOwner,
   getHashForSchema,
   getIdForSchema,
   validateNestedSchemas,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#630
This adds a method to check whether a CType's owner property is equal to the owner registered to chain. It also changes the `verifyStored` method to check only whether the ctype is registered to chain without checking the owner. 

## How to test:
...

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
