### PR TITLE
use next nonce rpc

### DIFF
--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -124,6 +124,6 @@ export default class Blockchain implements IBlockchainApi {
   }
 
   public async getNonce(accountAddress: string): Promise<Index> {
-    return (await this.api.query.system.account(accountAddress)).nonce
+    return this.api.rpc.system.accountNextIndex(accountAddress)
   }
 }

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -51,6 +51,7 @@ import {
   AccountData,
   AccountInfo,
   ExtrinsicStatus,
+  Index
 } from '@polkadot/types/interfaces'
 import U64 from '@polkadot/types/primitive/U64'
 import BN from 'bn.js'
@@ -154,6 +155,9 @@ const __mocked_api: any = {
       chain: jest.fn(),
       name: jest.fn(),
       version: jest.fn(),
+      accountNextIndex: jest.fn(
+        async (): Promise<Index> => TYPE_REGISTRY.createType('Index', 0)
+      ),
     },
     chain: { subscribeNewHeads: jest.fn() },
   },

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -46,15 +46,8 @@
 
 import { ApiPromise, SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
-import AccountIndex from '@polkadot/types/generic/AccountIndex'
-import {
-  AccountData,
-  AccountInfo,
-  ExtrinsicStatus,
-  Index
-} from '@polkadot/types/interfaces'
+import { AccountInfo, ExtrinsicStatus, Index } from '@polkadot/types/interfaces'
 import U64 from '@polkadot/types/primitive/U64'
-import BN from 'bn.js'
 import Blockchain from '../../blockchain/Blockchain'
 import IPublicIdentity from '../../types/PublicIdentity'
 import TYPE_REGISTRY, { mockChainQueryReturn } from './BlockchainQuery'
@@ -210,20 +203,8 @@ const __mocked_api: any = {
       // default return value decodes to BN(0)
       // default return value decodes to AccountInfo with all entries holding BN(0)
       account: jest.fn(
-        async (
-          address: IPublicIdentity['address'],
-          cb
-        ): Promise<AccountInfo> => {
-          return {
-            data: {
-              free: new BN(0),
-              reserved: new BN(0),
-              miscFrozen: new BN(0),
-              feeFrozen: new BN(0),
-            } as AccountData,
-            nonce: new AccountIndex(TYPE_REGISTRY, 0),
-          } as AccountInfo
-        }
+        async (address: IPublicIdentity['address'], cb): Promise<AccountInfo> =>
+          TYPE_REGISTRY.createType('AccountInfo')
       ),
     },
     attestation: {

--- a/src/identity/Identity.ts
+++ b/src/identity/Identity.ts
@@ -430,7 +430,7 @@ export default class Identity {
    * @example ```javascript
    * const alice = Identity.buildFromMnemonic('car dog ...');
    * const tx = await blockchain.api.tx.ctype.add(ctype.hash);
-   * const { nonce } = await blockchain.api.query.system.account(alice.address);
+   * const nonce = await blockchain.api.rpc.system.accountNextIndex(alice.address);
    * alice.signSubmittableExtrinsic(tx, nonce.toHex());
    * ```
    */


### PR DESCRIPTION
## fixes KILTProtocol/ticket#593
Gets the account nonce via `api.rpc.system.accountNextIndex(accountAddress)` instead as part of `api.query.system.account(accountAddress)`. Using this recently added rpc module will ensure that transactions in the transaction pool will be taken into account when computing the next nonce.
Unfortunately firing two transactions with very little time in between will still result in an error if the first transaction has not yet been added to the transaction pool.

## How to test:
This snippet, pasted into two separate files, will now pass even if both tests are run simultaneously: 
```js
import { Identity, Balance } from './index'
import BN from 'bn.js'

it('makes a transaction', async () => {
  const alice = await Identity.buildFromURI('//Alice')
  const bob = await Identity.buildFromMnemonic(Identity.generateMnemonic())
  return Balance.makeTransfer(alice, bob.address, new BN(1000))
}, 30000)
``` 

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
