### PR TITLE
explicit transactions & awaiting custom tx status changes

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -10,6 +10,7 @@ import Kilt, {
   IRevocationHandle,
   PublicAttesterIdentity,
 } from '../src'
+import { AWAIT_IN_BLOCK, submitTx } from '../src/blockchain/Blockchain'
 import constants from '../src/test/constants'
 
 const NODE_URL = 'ws://127.0.0.1:9944'
@@ -81,8 +82,7 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    // TODO: use submitTx to handle extrinsic errors correctly
-    await ctype.store(attester).then(tx => tx.send())
+    await ctype.store(attester).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',
@@ -195,10 +195,7 @@ async function doAttestation(
   const submitAttestationEnc = submitAttestation.encrypt()
 
   // ------------------------- CLAIMER -----------------------------------------
-  Kilt.Message.ensureHashAndSignature(
-    submitAttestationEnc,
-    attester.address
-  )
+  Kilt.Message.ensureHashAndSignature(submitAttestationEnc, attester.address)
   const submitAttestationDec = Kilt.Message.decrypt(
     submitAttestationEnc,
     claimer

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -81,7 +81,8 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store(attester)
+    // TODO: use submitTx to handle extrinsic errors correctly
+    await ctype.store(attester).then(tx => tx.send())
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -10,7 +10,7 @@ import Kilt, {
   IRevocationHandle,
   PublicAttesterIdentity,
 } from '../src'
-import { AWAIT_IN_BLOCK, submitSignedTx } from '../src/blockchain/Blockchain'
+import { IS_IN_BLOCK, submitSignedTx } from '../src/blockchain/Blockchain'
 import constants from '../src/test/constants'
 
 const NODE_URL = 'ws://127.0.0.1:9944'
@@ -82,7 +82,7 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store(attester).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+    await ctype.store(attester).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -10,7 +10,7 @@ import Kilt, {
   IRevocationHandle,
   PublicAttesterIdentity,
 } from '../src'
-import { AWAIT_IN_BLOCK, submitTx } from '../src/blockchain/Blockchain'
+import { AWAIT_IN_BLOCK, submitSignedTx } from '../src/blockchain/Blockchain'
 import constants from '../src/test/constants'
 
 const NODE_URL = 'ws://127.0.0.1:9944'
@@ -82,7 +82,7 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store(attester).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+    await ctype.store(attester).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -82,7 +82,7 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store(attester).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+    await ctype.store(attester).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -33,7 +33,7 @@ import {
   wannabeFaucet,
 } from './utils'
 
-let blockchain: IBlockchainApi
+let blockchain: IBlockchainApi | undefined
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
 })

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -12,7 +12,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
-  submitTx,
+  submitSignedTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
@@ -48,7 +48,7 @@ describe('handling attestations that do not exist', () => {
       Attestation.revoke(
         '0x012012012',
         await Identity.buildFromURI('//Alice')
-      ).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+      ).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrow()
   }, 30_000)
 })
@@ -68,7 +68,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store(attester).then((tx) =>
-        submitTx(tx, AWAIT_READY)
+        submitSignedTx(tx, AWAIT_READY)
       )
     }
   }, 60_000)
@@ -104,7 +104,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       request,
       attester.getPublicIdentity()
     )
-    await attestation.store(attester).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+    await attestation
+      .store(attester)
+      .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
       request,
@@ -138,7 +140,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
 
     await expect(
-      attestation.store(bobbyBroke).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+      attestation
+        .store(bobbyBroke)
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
       bobbyBroke,
@@ -180,7 +184,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
     await expect(
-      attestation.store(attester).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+      attestation
+        .store(attester)
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
 
@@ -203,7 +209,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
         request,
@@ -217,7 +223,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await expect(
         attClaim.attestation
           .store(attester)
-          .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+          .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
       ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
 
@@ -242,7 +248,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), claimer).then((tx) =>
-          submitTx(tx, AWAIT_IN_BLOCK)
+          submitSignedTx(tx, AWAIT_IN_BLOCK)
         )
       ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
@@ -251,7 +257,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), attester).then((tx) =>
-        submitTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, AWAIT_IN_BLOCK)
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
@@ -261,7 +267,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          submitTx(tx, AWAIT_IN_BLOCK)
+          submitSignedTx(tx, AWAIT_IN_BLOCK)
         )
       }
       await expect(
@@ -291,7 +297,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await licenseAuthorizationGranted
         .store(faucet)
-        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
         DriversLicense,
@@ -318,7 +324,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store(attester).then((tx) =>
-        submitTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, AWAIT_IN_BLOCK)
       )
       const license = await Credential.fromRequestAndAttestation(
         claimer,

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -8,7 +8,11 @@ import { IAttestedClaim, IClaim } from '..'
 import Attestation from '../attestation/Attestation'
 import { revoke } from '../attestation/Attestation.chain'
 import AttestedClaim from '../attestedclaim/AttestedClaim'
-import { IBlockchainApi } from '../blockchain/Blockchain'
+import {
+  AWAIT_IN_BLOCK,
+  AWAIT_READY,
+  IBlockchainApi,
+} from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
 import Credential from '../credential/Credential'
@@ -28,7 +32,7 @@ import {
   wannabeFaucet,
 } from './utils'
 
-let blockchain: IBlockchainApi | undefined
+let blockchain: IBlockchainApi
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
 })
@@ -40,7 +44,10 @@ describe('handling attestations that do not exist', () => {
 
   it('Attestation.revoke', async () => {
     return expect(
-      Attestation.revoke('0x012012012', await Identity.buildFromURI('//Alice'))
+      Attestation.revoke(
+        '0x012012012',
+        await Identity.buildFromURI('//Alice')
+      ).then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrow()
   }, 30_000)
 })
@@ -59,7 +66,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`ctype exists: ${ctypeExists}`)
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
-      await DriversLicense.store(attester)
+      await DriversLicense.store(attester).then((tx) =>
+        blockchain.submitTx(tx, AWAIT_READY)
+      )
     }
   }, 60_000)
 
@@ -94,8 +103,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       request,
       attester.getPublicIdentity()
     )
-    const result = await attestation.store(attester)
-    expect(result.status.type).toBe('Finalized')
+    await attestation
+      .store(attester)
+      .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
       request,
@@ -128,7 +138,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       Identity.generateMnemonic()
     )
 
-    await expect(attestation.store(bobbyBroke)).rejects.toThrow()
+    await expect(
+      attestation
+        .store(bobbyBroke)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+    ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
       bobbyBroke,
       request,
@@ -168,9 +182,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       request,
       attester.getPublicIdentity()
     )
-    await expect(attestation.store(attester)).rejects.toThrowError(
-      ERROR_CTYPE_NOT_FOUND
-    )
+    await expect(
+      attestation
+        .store(attester)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+    ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
 
   describe('when there is an attested claim on-chain', () => {
@@ -190,8 +206,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request,
         attester.getPublicIdentity()
       )
-      const result = await attestation.store(attester)
-      expect(result.status.type).toBe('Finalized')
+      await attestation
+        .store(attester)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
         request,
@@ -202,9 +219,11 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     }, 60_000)
 
     it('should not be possible to attest the same claim twice', async () => {
-      await expect(attClaim.attestation.store(attester)).rejects.toThrowError(
-        ERROR_ALREADY_ATTESTED
-      )
+      await expect(
+        attClaim.attestation
+          .store(attester)
+          .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
 
     it('should not be possible to use attestation for different claim', async () => {
@@ -226,17 +245,19 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     }, 15_000)
 
     it('should not be possible for the claimer to revoke an attestation', async () => {
-      await expect(revoke(attClaim.getHash(), claimer)).rejects.toThrowError(
-        'not permitted'
-      )
+      await expect(
+        revoke(attClaim.getHash(), claimer).then((tx) =>
+          blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        )
+      ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
     }, 45_000)
 
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
-      const result = await revoke(attClaim.getHash(), attester)
-      expect(result.status.type).toBe('Finalized')
-      expect(result.isFinalized).toBeTruthy()
+      await revoke(attClaim.getHash(), attester).then((tx) =>
+        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+      )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
   })
@@ -244,7 +265,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   describe('when there is another Ctype that works as a legitimation', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
-        await IsOfficialLicenseAuthority.store(faucet)
+        await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
+          blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        )
       }
       await expect(
         CtypeOnChain(IsOfficialLicenseAuthority)
@@ -271,8 +294,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request1,
         faucet.getPublicIdentity()
       )
-      const tx1 = await licenseAuthorizationGranted.store(faucet)
-      expect(tx1.status.isFinalized).toBeTruthy()
+      await licenseAuthorizationGranted
+        .store(faucet)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
         DriversLicense,
@@ -298,8 +322,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request2,
         attester.getPublicIdentity()
       )
-      const tx2 = await LicenseGranted.store(attester)
-      expect(tx2.status.isFinalized).toBeTruthy()
+      await LicenseGranted.store(attester).then((tx) =>
+        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+      )
       const license = await Credential.fromRequestAndAttestation(
         claimer,
         request2,

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -12,6 +12,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
+  submitTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
@@ -47,7 +48,7 @@ describe('handling attestations that do not exist', () => {
       Attestation.revoke(
         '0x012012012',
         await Identity.buildFromURI('//Alice')
-      ).then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      ).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrow()
   }, 30_000)
 })
@@ -67,7 +68,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store(attester).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_READY)
+        submitTx(tx, AWAIT_READY)
       )
     }
   }, 60_000)
@@ -103,9 +104,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       request,
       attester.getPublicIdentity()
     )
-    await attestation
-      .store(attester)
-      .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+    await attestation.store(attester).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
       request,
@@ -139,9 +138,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
 
     await expect(
-      attestation
-        .store(bobbyBroke)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      attestation.store(bobbyBroke).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
       bobbyBroke,
@@ -183,9 +180,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
     await expect(
-      attestation
-        .store(attester)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      attestation.store(attester).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
 
@@ -208,7 +203,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
         request,
@@ -222,7 +217,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await expect(
         attClaim.attestation
           .store(attester)
-          .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+          .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
       ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
 
@@ -247,7 +242,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), claimer).then((tx) =>
-          blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+          submitTx(tx, AWAIT_IN_BLOCK)
         )
       ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
@@ -256,7 +251,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), attester).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        submitTx(tx, AWAIT_IN_BLOCK)
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
@@ -266,7 +261,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+          submitTx(tx, AWAIT_IN_BLOCK)
         )
       }
       await expect(
@@ -296,7 +291,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await licenseAuthorizationGranted
         .store(faucet)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
         DriversLicense,
@@ -323,7 +318,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store(attester).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        submitTx(tx, AWAIT_IN_BLOCK)
       )
       const license = await Credential.fromRequestAndAttestation(
         claimer,

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -9,8 +9,8 @@ import Attestation from '../attestation/Attestation'
 import { revoke } from '../attestation/Attestation.chain'
 import AttestedClaim from '../attestedclaim/AttestedClaim'
 import {
-  AWAIT_IN_BLOCK,
-  AWAIT_READY,
+  IS_IN_BLOCK,
+  IS_READY,
   IBlockchainApi,
   submitSignedTx,
 } from '../blockchain/Blockchain'
@@ -48,7 +48,7 @@ describe('handling attestations that do not exist', () => {
       Attestation.revoke(
         '0x012012012',
         await Identity.buildFromURI('//Alice')
-      ).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+      ).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     ).rejects.toThrow()
   }, 30_000)
 })
@@ -68,7 +68,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store(attester).then((tx) =>
-        submitSignedTx(tx, AWAIT_READY)
+        submitSignedTx(tx, [IS_READY])
       )
     }
   }, 60_000)
@@ -106,7 +106,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
     await attestation
       .store(attester)
-      .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+      .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
       request,
@@ -142,7 +142,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     await expect(
       attestation
         .store(bobbyBroke)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
       bobbyBroke,
@@ -186,7 +186,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     await expect(
       attestation
         .store(attester)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
 
@@ -209,7 +209,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
         request,
@@ -223,7 +223,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await expect(
         attClaim.attestation
           .store(attester)
-          .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+          .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
       ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
 
@@ -248,7 +248,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), claimer).then((tx) =>
-          submitSignedTx(tx, AWAIT_IN_BLOCK)
+          submitSignedTx(tx, [IS_IN_BLOCK])
         )
       ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
@@ -257,7 +257,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), attester).then((tx) =>
-        submitSignedTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, [IS_IN_BLOCK])
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
@@ -267,7 +267,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          submitSignedTx(tx, AWAIT_IN_BLOCK)
+          submitSignedTx(tx, [IS_IN_BLOCK])
         )
       }
       await expect(
@@ -297,7 +297,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await licenseAuthorizationGranted
         .store(faucet)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
         DriversLicense,
@@ -324,7 +324,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store(attester).then((tx) =>
-        submitSignedTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, [IS_IN_BLOCK])
       )
       const license = await Credential.fromRequestAndAttestation(
         claimer,

--- a/src/__integrationtests__/Attestation.spec.ts
+++ b/src/__integrationtests__/Attestation.spec.ts
@@ -48,7 +48,7 @@ describe('handling attestations that do not exist', () => {
       Attestation.revoke(
         '0x012012012',
         await Identity.buildFromURI('//Alice')
-      ).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      ).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     ).rejects.toThrow()
   }, 30_000)
 })
@@ -68,7 +68,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store(attester).then((tx) =>
-        submitSignedTx(tx, [IS_READY])
+        submitSignedTx(tx, IS_READY)
       )
     }
   }, 60_000)
@@ -106,7 +106,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
     await attestation
       .store(attester)
-      .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     const cred = await Credential.fromRequestAndAttestation(
       claimer,
       request,
@@ -142,7 +142,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     await expect(
       attestation
         .store(bobbyBroke)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     ).rejects.toThrow()
     const cred = await Credential.fromRequestAndAttestation(
       bobbyBroke,
@@ -184,9 +184,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
     await expect(
-      attestation
-        .store(attester)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      attestation.store(attester).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     ).rejects.toThrowError(ERROR_CTYPE_NOT_FOUND)
   }, 60_000)
 
@@ -209,7 +207,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
       const cred = await Credential.fromRequestAndAttestation(
         claimer,
         request,
@@ -223,7 +221,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       await expect(
         attClaim.attestation
           .store(attester)
-          .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+          .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
       ).rejects.toThrowError(ERROR_ALREADY_ATTESTED)
     }, 15_000)
 
@@ -248,7 +246,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), claimer).then((tx) =>
-          submitSignedTx(tx, [IS_IN_BLOCK])
+          submitSignedTx(tx, IS_IN_BLOCK)
         )
       ).rejects.toThrowError('not permitted')
       await expect(attClaim.verify()).resolves.toBeTruthy()
@@ -257,7 +255,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), attester).then((tx) =>
-        submitSignedTx(tx, [IS_IN_BLOCK])
+        submitSignedTx(tx, IS_IN_BLOCK)
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 40_000)
@@ -267,7 +265,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          submitSignedTx(tx, [IS_IN_BLOCK])
+          submitSignedTx(tx, IS_IN_BLOCK)
         )
       }
       await expect(
@@ -297,7 +295,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
       await licenseAuthorizationGranted
         .store(faucet)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
       // make request including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
         DriversLicense,
@@ -324,7 +322,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store(attester).then((tx) =>
-        submitSignedTx(tx, [IS_IN_BLOCK])
+        submitSignedTx(tx, IS_IN_BLOCK)
       )
       const license = await Credential.fromRequestAndAttestation(
         claimer,

--- a/src/__integrationtests__/AttestationPE.spec.ts
+++ b/src/__integrationtests__/AttestationPE.spec.ts
@@ -11,6 +11,8 @@ import {
 import { Claim, IBlockchainApi, IClaim, Message } from '..'
 import { Attester, Claimer, Verifier } from '../actor'
 import { ClaimerAttestationSession } from '../actor/Claimer'
+import { submitSignedTx } from '../blockchain'
+import { IS_IN_BLOCK } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Credential from '../credential'
 import Identity, { AttesterIdentity } from '../identity'
@@ -51,7 +53,9 @@ describe('Privacy enhanced claim, attestation, verification process', () => {
 
     // set up claim (ctype missing on fresh chain)
     if (!(await CtypeOnChain(DriversLicense))) {
-      await DriversLicense.store(attester)
+      await DriversLicense.store(attester).then((tx) =>
+        submitSignedTx(tx, IS_IN_BLOCK)
+      )
     }
     claim = Claim.fromCTypeAndClaimContents(
       DriversLicense,

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -14,6 +14,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
+  submitTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Identity from '../identity/Identity'
@@ -70,7 +71,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
     const tx = await makeTransfer(faucet, ident.address, MIN_TRANSACTION)
-    await blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+    await submitTx(tx, AWAIT_IN_BLOCK)
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
       getBalance(ident.address),
@@ -99,7 +100,7 @@ describe('When there are haves and have-nots', () => {
       richieRich,
       stormyD.address,
       MIN_TRANSACTION
-    ).then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+    ).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     const balanceTo = await getBalance(stormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 40_000)
@@ -108,7 +109,7 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalance(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        submitTx(tx, AWAIT_IN_BLOCK)
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
@@ -123,7 +124,7 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        submitTx(tx, AWAIT_IN_BLOCK)
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -138,10 +139,10 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      blockchain.submitTx(tx, AWAIT_READY)
+      submitTx(tx, AWAIT_READY)
     )
     await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+      submitTx(tx, AWAIT_IN_BLOCK)
     )
 
     expect(listener).toBeCalledWith(
@@ -157,10 +158,10 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        submitTx(tx, AWAIT_IN_BLOCK)
       ),
       makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_IN_BLOCK)
+        submitTx(tx, AWAIT_IN_BLOCK)
       ),
     ])
     expect(listener).toBeCalledWith(faucet.address)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -71,7 +71,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
     await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
-      submitSignedTx(tx, [IS_IN_BLOCK])
+      submitSignedTx(tx, IS_IN_BLOCK)
     )
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
@@ -101,7 +101,7 @@ describe('When there are haves and have-nots', () => {
       richieRich,
       stormyD.address,
       MIN_TRANSACTION
-    ).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+    ).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     const balanceTo = await getBalance(stormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 40_000)
@@ -110,7 +110,7 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalance(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        submitSignedTx(tx, [IS_IN_BLOCK])
+        submitSignedTx(tx, IS_IN_BLOCK)
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
@@ -125,7 +125,7 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        submitSignedTx(tx, [IS_IN_BLOCK])
+        submitSignedTx(tx, IS_IN_BLOCK)
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -140,10 +140,10 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      submitSignedTx(tx, [IS_READY])
+      submitSignedTx(tx, IS_READY)
     )
     await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      submitSignedTx(tx, [IS_IN_BLOCK])
+      submitSignedTx(tx, IS_IN_BLOCK)
     )
 
     expect(listener).toBeCalledWith(
@@ -159,10 +159,10 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        submitSignedTx(tx, [IS_IN_BLOCK])
+        submitSignedTx(tx, IS_IN_BLOCK)
       ),
       makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        submitSignedTx(tx, [IS_IN_BLOCK])
+        submitSignedTx(tx, IS_IN_BLOCK)
       ),
     ])
     expect(listener).toBeCalledWith(faucet.address)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -70,8 +70,9 @@ describe('when there is a dev chain with a faucet', () => {
     const funny = jest.fn()
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
-    const tx = await makeTransfer(faucet, ident.address, MIN_TRANSACTION)
-    await submitSignedTx(tx, AWAIT_IN_BLOCK)
+    await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
+      submitSignedTx(tx, AWAIT_IN_BLOCK)
+    )
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
       getBalance(ident.address),

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -14,7 +14,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
-  submitTx,
+  submitSignedTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Identity from '../identity/Identity'
@@ -71,7 +71,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
     const tx = await makeTransfer(faucet, ident.address, MIN_TRANSACTION)
-    await submitTx(tx, AWAIT_IN_BLOCK)
+    await submitSignedTx(tx, AWAIT_IN_BLOCK)
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
       getBalance(ident.address),
@@ -100,7 +100,7 @@ describe('When there are haves and have-nots', () => {
       richieRich,
       stormyD.address,
       MIN_TRANSACTION
-    ).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+    ).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     const balanceTo = await getBalance(stormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 40_000)
@@ -109,7 +109,7 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalance(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        submitTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, AWAIT_IN_BLOCK)
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
@@ -124,7 +124,7 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        submitTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, AWAIT_IN_BLOCK)
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -139,10 +139,10 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      submitTx(tx, AWAIT_READY)
+      submitSignedTx(tx, AWAIT_READY)
     )
     await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      submitTx(tx, AWAIT_IN_BLOCK)
+      submitSignedTx(tx, AWAIT_IN_BLOCK)
     )
 
     expect(listener).toBeCalledWith(
@@ -158,10 +158,10 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        submitTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, AWAIT_IN_BLOCK)
       ),
       makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        submitTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, AWAIT_IN_BLOCK)
       ),
     ])
     expect(listener).toBeCalledWith(faucet.address)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -11,8 +11,8 @@ import {
   makeTransfer,
 } from '../balance/Balance.chain'
 import {
-  AWAIT_IN_BLOCK,
-  AWAIT_READY,
+  IS_IN_BLOCK,
+  IS_READY,
   IBlockchainApi,
   submitSignedTx,
 } from '../blockchain/Blockchain'
@@ -71,7 +71,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalance(faucet.address)
     await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
-      submitSignedTx(tx, AWAIT_IN_BLOCK)
+      submitSignedTx(tx, [IS_IN_BLOCK])
     )
     const [balanceAfter, balanceIdent] = await Promise.all([
       getBalance(faucet.address),
@@ -101,7 +101,7 @@ describe('When there are haves and have-nots', () => {
       richieRich,
       stormyD.address,
       MIN_TRANSACTION
-    ).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+    ).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     const balanceTo = await getBalance(stormyD.address)
     expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 40_000)
@@ -110,7 +110,7 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalance(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        submitSignedTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, [IS_IN_BLOCK])
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
@@ -125,7 +125,7 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        submitSignedTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, [IS_IN_BLOCK])
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -140,10 +140,10 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      submitSignedTx(tx, AWAIT_READY)
+      submitSignedTx(tx, [IS_READY])
     )
     await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      submitSignedTx(tx, AWAIT_IN_BLOCK)
+      submitSignedTx(tx, [IS_IN_BLOCK])
     )
 
     expect(listener).toBeCalledWith(
@@ -159,10 +159,10 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        submitSignedTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, [IS_IN_BLOCK])
       ),
       makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        submitSignedTx(tx, AWAIT_IN_BLOCK)
+        submitSignedTx(tx, [IS_IN_BLOCK])
       ),
     ])
     expect(listener).toBeCalledWith(faucet.address)

--- a/src/__integrationtests__/Balance.spec.ts
+++ b/src/__integrationtests__/Balance.spec.ts
@@ -25,7 +25,7 @@ import {
   wannabeFaucet,
 } from './utils'
 
-let blockchain: IBlockchainApi
+let blockchain: IBlockchainApi | undefined
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
 })

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -9,6 +9,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
+  submitTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import CType from '../ctype/CType'
@@ -49,18 +50,14 @@ describe('When there is an CtypeCreator and a verifier', () => {
       Identity.generateMnemonic()
     )
     await expect(
-      ctype
-        .store(bobbyBroke)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      ctype.store(bobbyBroke).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)
 
   it('should be possible to create a claim type', async () => {
     const ctype = makeCType()
-    await ctype
-      .store(ctypeCreator)
-      .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+    await ctype.store(ctypeCreator).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
       expect(ctype.verifyStored()).resolves.toBeTruthy(),
@@ -71,13 +68,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype
-      .store(ctypeCreator)
-      .then((tx) => blockchain.submitTx(tx, AWAIT_READY))
+    await ctype.store(ctypeCreator).then((tx) => submitTx(tx, AWAIT_READY))
     await expect(
-      ctype
-        .store(ctypeCreator)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      ctype.store(ctypeCreator).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrowError(ERROR_CTYPE_ALREADY_EXISTS)
     // console.log('Triggered error on re-submit')
     await expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address)

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -18,7 +18,7 @@ import { ERROR_CTYPE_ALREADY_EXISTS } from '../errorhandling/ExtrinsicError'
 import ICType from '../types/CType'
 import { wannabeFaucet } from './utils'
 
-let blockchain: IBlockchainApi
+let blockchain: IBlockchainApi | undefined
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
 })

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -9,7 +9,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
-  submitTx,
+  submitSignedTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import CType from '../ctype/CType'
@@ -50,14 +50,16 @@ describe('When there is an CtypeCreator and a verifier', () => {
       Identity.generateMnemonic()
     )
     await expect(
-      ctype.store(bobbyBroke).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+      ctype.store(bobbyBroke).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)
 
   it('should be possible to create a claim type', async () => {
     const ctype = makeCType()
-    await ctype.store(ctypeCreator).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+    await ctype
+      .store(ctypeCreator)
+      .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
       expect(ctype.verifyStored()).resolves.toBeTruthy(),
@@ -68,9 +70,11 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype.store(ctypeCreator).then((tx) => submitTx(tx, AWAIT_READY))
+    await ctype
+      .store(ctypeCreator)
+      .then((tx) => submitSignedTx(tx, AWAIT_READY))
     await expect(
-      ctype.store(ctypeCreator).then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+      ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     ).rejects.toThrowError(ERROR_CTYPE_ALREADY_EXISTS)
     // console.log('Triggered error on re-submit')
     await expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address)

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -50,7 +50,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
       Identity.generateMnemonic()
     )
     await expect(
-      ctype.store(bobbyBroke).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      ctype.store(bobbyBroke).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)
@@ -59,7 +59,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     const ctype = makeCType()
     await ctype
       .store(ctypeCreator)
-      .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
       expect(ctype.verifyStored()).resolves.toBeTruthy(),
@@ -70,9 +70,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, [IS_READY]))
+    await ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, IS_READY))
     await expect(
-      ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     ).rejects.toThrowError(ERROR_CTYPE_ALREADY_EXISTS)
     // console.log('Triggered error on re-submit')
     await expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address)

--- a/src/__integrationtests__/Ctypes.spec.ts
+++ b/src/__integrationtests__/Ctypes.spec.ts
@@ -6,8 +6,8 @@
 
 import { Identity } from '..'
 import {
-  AWAIT_IN_BLOCK,
-  AWAIT_READY,
+  IS_IN_BLOCK,
+  IS_READY,
   IBlockchainApi,
   submitSignedTx,
 } from '../blockchain/Blockchain'
@@ -50,7 +50,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
       Identity.generateMnemonic()
     )
     await expect(
-      ctype.store(bobbyBroke).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+      ctype.store(bobbyBroke).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     ).rejects.toThrowError()
     await expect(ctype.verifyStored()).resolves.toBeFalsy()
   }, 20_000)
@@ -59,7 +59,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     const ctype = makeCType()
     await ctype
       .store(ctypeCreator)
-      .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+      .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     await Promise.all([
       expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address),
       expect(ctype.verifyStored()).resolves.toBeTruthy(),
@@ -70,11 +70,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype
-      .store(ctypeCreator)
-      .then((tx) => submitSignedTx(tx, AWAIT_READY))
+    await ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, [IS_READY]))
     await expect(
-      ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+      ctype.store(ctypeCreator).then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     ).rejects.toThrowError(ERROR_CTYPE_ALREADY_EXISTS)
     // console.log('Triggered error on re-submit')
     await expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address)

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -7,7 +7,11 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { Identity } from '..'
 import Attestation from '../attestation/Attestation'
-import { IBlockchainApi } from '../blockchain/Blockchain'
+import {
+  AWAIT_IN_BLOCK,
+  AWAIT_READY,
+  IBlockchainApi,
+} from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
 import Credential from '../credential/Credential'
@@ -30,7 +34,7 @@ import {
   wannabeFaucet,
 } from './utils'
 
-let blockchain: IBlockchainApi | undefined
+let blockchain: IBlockchainApi
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
 })
@@ -47,7 +51,9 @@ describe('when there is an account hierarchy', () => {
     attester = await wannabeAlice
 
     if (!(await CtypeOnChain(DriversLicense))) {
-      await DriversLicense.store(attester)
+      await DriversLicense.store(attester).then((tx) =>
+        blockchain.submitTx(tx, AWAIT_READY)
+      )
     }
   }, 30_000)
 
@@ -57,7 +63,9 @@ describe('when there is an account hierarchy', () => {
       DriversLicense.hash,
       uncleSam.address
     )
-    await rootNode.store(uncleSam)
+    await rootNode
+      .store(uncleSam)
+      .then((tx) => blockchain.submitTx(tx, AWAIT_READY))
     const delegatedNode = new DelegationNode(
       UUID.generate(),
       rootNode.id,
@@ -66,7 +74,9 @@ describe('when there is an account hierarchy', () => {
       rootNode.id
     )
     const HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
-    await delegatedNode.store(uncleSam, HashSignedByDelegate)
+    await delegatedNode
+      .store(uncleSam, HashSignedByDelegate)
+      .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
       expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -92,8 +102,12 @@ describe('when there is an account hierarchy', () => {
         rootNode.id
       )
       HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
-      await rootNode.store(uncleSam)
-      await delegatedNode.store(uncleSam, HashSignedByDelegate)
+      await rootNode
+        .store(uncleSam)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_READY))
+      await delegatedNode
+        .store(uncleSam, HashSignedByDelegate)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -122,8 +136,9 @@ describe('when there is an account hierarchy', () => {
         request,
         attester.getPublicIdentity()
       )
-      const result1 = await attestation.store(attester)
-      expect(result1.status.type).toBe('Finalized')
+      await attestation
+        .store(attester)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -134,8 +149,10 @@ describe('when there is an account hierarchy', () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
 
       // revoke attestation through root
-      const result2 = await attClaim.attestation.revoke(uncleSam)
-      expect(result2.status.type).toBe('Finalized')
+      await attClaim.attestation
+        .revoke(uncleSam)
+        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })
 })

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -11,6 +11,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
+  submitTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
@@ -52,7 +53,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        blockchain.submitTx(tx, AWAIT_READY)
+        submitTx(tx, AWAIT_READY)
       )
     }
   }, 30_000)
@@ -63,9 +64,7 @@ describe('when there is an account hierarchy', () => {
       DriversLicense.hash,
       uncleSam.address
     )
-    await rootNode
-      .store(uncleSam)
-      .then((tx) => blockchain.submitTx(tx, AWAIT_READY))
+    await rootNode.store(uncleSam).then((tx) => submitTx(tx, AWAIT_READY))
     const delegatedNode = new DelegationNode(
       UUID.generate(),
       rootNode.id,
@@ -76,7 +75,7 @@ describe('when there is an account hierarchy', () => {
     const HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
-      .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+      .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
       expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -102,12 +101,10 @@ describe('when there is an account hierarchy', () => {
         rootNode.id
       )
       HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
-      await rootNode
-        .store(uncleSam)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_READY))
+      await rootNode.store(uncleSam).then((tx) => submitTx(tx, AWAIT_READY))
       await delegatedNode
         .store(uncleSam, HashSignedByDelegate)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -138,7 +135,7 @@ describe('when there is an account hierarchy', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -151,7 +148,7 @@ describe('when there is an account hierarchy', () => {
       // revoke attestation through root
       await attClaim.attestation
         .revoke(uncleSam)
-        .then((tx) => blockchain.submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -35,7 +35,7 @@ import {
   wannabeFaucet,
 } from './utils'
 
-let blockchain: IBlockchainApi
+let blockchain: IBlockchainApi | undefined
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
 })

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -53,7 +53,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        submitSignedTx(tx, [IS_READY])
+        submitSignedTx(tx, IS_READY)
       )
     }
   }, 30_000)
@@ -64,7 +64,7 @@ describe('when there is an account hierarchy', () => {
       DriversLicense.hash,
       uncleSam.address
     )
-    await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, [IS_READY]))
+    await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, IS_READY))
     const delegatedNode = new DelegationNode(
       UUID.generate(),
       rootNode.id,
@@ -75,7 +75,7 @@ describe('when there is an account hierarchy', () => {
     const HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
-      .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+      .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
       expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -101,12 +101,10 @@ describe('when there is an account hierarchy', () => {
         rootNode.id
       )
       HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
-      await rootNode
-        .store(uncleSam)
-        .then((tx) => submitSignedTx(tx, [IS_READY]))
+      await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, IS_READY))
       await delegatedNode
         .store(uncleSam, HashSignedByDelegate)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -137,7 +135,7 @@ describe('when there is an account hierarchy', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -150,7 +148,7 @@ describe('when there is an account hierarchy', () => {
       // revoke attestation through root
       await attClaim.attestation
         .revoke(uncleSam)
-        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
+        .then((tx) => submitSignedTx(tx, IS_IN_BLOCK))
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -8,8 +8,8 @@ import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { Identity } from '..'
 import Attestation from '../attestation/Attestation'
 import {
-  AWAIT_IN_BLOCK,
-  AWAIT_READY,
+  IS_IN_BLOCK,
+  IS_READY,
   IBlockchainApi,
   submitSignedTx,
 } from '../blockchain/Blockchain'
@@ -53,7 +53,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        submitSignedTx(tx, AWAIT_READY)
+        submitSignedTx(tx, [IS_READY])
       )
     }
   }, 30_000)
@@ -64,7 +64,7 @@ describe('when there is an account hierarchy', () => {
       DriversLicense.hash,
       uncleSam.address
     )
-    await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, AWAIT_READY))
+    await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, [IS_READY]))
     const delegatedNode = new DelegationNode(
       UUID.generate(),
       rootNode.id,
@@ -75,7 +75,7 @@ describe('when there is an account hierarchy', () => {
     const HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
-      .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+      .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
       expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -103,10 +103,10 @@ describe('when there is an account hierarchy', () => {
       HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
       await rootNode
         .store(uncleSam)
-        .then((tx) => submitSignedTx(tx, AWAIT_READY))
+        .then((tx) => submitSignedTx(tx, [IS_READY]))
       await delegatedNode
         .store(uncleSam, HashSignedByDelegate)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -137,7 +137,7 @@ describe('when there is an account hierarchy', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -150,7 +150,7 @@ describe('when there is an account hierarchy', () => {
       // revoke attestation through root
       await attClaim.attestation
         .revoke(uncleSam)
-        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, [IS_IN_BLOCK]))
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })

--- a/src/__integrationtests__/Delegation.spec.ts
+++ b/src/__integrationtests__/Delegation.spec.ts
@@ -11,7 +11,7 @@ import {
   AWAIT_IN_BLOCK,
   AWAIT_READY,
   IBlockchainApi,
-  submitTx,
+  submitSignedTx,
 } from '../blockchain/Blockchain'
 import getCached, { DEFAULT_WS_ADDRESS } from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
@@ -53,7 +53,7 @@ describe('when there is an account hierarchy', () => {
 
     if (!(await CtypeOnChain(DriversLicense))) {
       await DriversLicense.store(attester).then((tx) =>
-        submitTx(tx, AWAIT_READY)
+        submitSignedTx(tx, AWAIT_READY)
       )
     }
   }, 30_000)
@@ -64,7 +64,7 @@ describe('when there is an account hierarchy', () => {
       DriversLicense.hash,
       uncleSam.address
     )
-    await rootNode.store(uncleSam).then((tx) => submitTx(tx, AWAIT_READY))
+    await rootNode.store(uncleSam).then((tx) => submitSignedTx(tx, AWAIT_READY))
     const delegatedNode = new DelegationNode(
       UUID.generate(),
       rootNode.id,
@@ -75,7 +75,7 @@ describe('when there is an account hierarchy', () => {
     const HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
     await delegatedNode
       .store(uncleSam, HashSignedByDelegate)
-      .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+      .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
     await Promise.all([
       expect(rootNode.verify()).resolves.toBeTruthy(),
       expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -101,10 +101,12 @@ describe('when there is an account hierarchy', () => {
         rootNode.id
       )
       HashSignedByDelegate = attester.signStr(delegatedNode.generateHash())
-      await rootNode.store(uncleSam).then((tx) => submitTx(tx, AWAIT_READY))
+      await rootNode
+        .store(uncleSam)
+        .then((tx) => submitSignedTx(tx, AWAIT_READY))
       await delegatedNode
         .store(uncleSam, HashSignedByDelegate)
-        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
       await Promise.all([
         expect(rootNode.verify()).resolves.toBeTruthy(),
         expect(delegatedNode.verify()).resolves.toBeTruthy(),
@@ -135,7 +137,7 @@ describe('when there is an account hierarchy', () => {
       )
       await attestation
         .store(attester)
-        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
 
       const attClaim = await Credential.fromRequestAndAttestation(
         claimer,
@@ -148,7 +150,7 @@ describe('when there is an account hierarchy', () => {
       // revoke attestation through root
       await attClaim.attestation
         .revoke(uncleSam)
-        .then((tx) => submitTx(tx, AWAIT_IN_BLOCK))
+        .then((tx) => submitSignedTx(tx, AWAIT_IN_BLOCK))
       await expect(attClaim.verify()).resolves.toBeFalsy()
     }, 75_000)
   })

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -7,7 +7,7 @@
 import BN from 'bn.js'
 import { Attestation, IBlockchainApi } from '..'
 import { makeTransfer } from '../balance'
-import { AWAIT_IN_BLOCK, submitTx } from '../blockchain/Blockchain'
+import { AWAIT_IN_BLOCK, submitSignedTx } from '../blockchain/Blockchain'
 import { DEFAULT_WS_ADDRESS, getCached } from '../blockchainApiConnection'
 import { ERROR_CTYPE_NOT_FOUND } from '../errorhandling'
 import Identity from '../identity'
@@ -35,7 +35,7 @@ it('records an extrinsic error when ctype does not exist', async () => {
     revoked: false,
   })
   const tx = await attestation.store(attester)
-  await expect(submitTx(tx, AWAIT_IN_BLOCK)).rejects.toThrow(
+  await expect(submitSignedTx(tx, AWAIT_IN_BLOCK)).rejects.toThrow(
     ERROR_CTYPE_NOT_FOUND
   )
 }, 40_000)

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -7,7 +7,7 @@
 import BN from 'bn.js'
 import { Attestation, IBlockchainApi } from '..'
 import { makeTransfer } from '../balance/Balance.chain'
-import { AWAIT_IN_BLOCK, submitSignedTx } from '../blockchain/Blockchain'
+import { IS_IN_BLOCK, submitSignedTx } from '../blockchain/Blockchain'
 import { DEFAULT_WS_ADDRESS, getCached } from '../blockchainApiConnection'
 import { ERROR_CTYPE_NOT_FOUND, ERROR_UNKNOWN } from '../errorhandling'
 import Identity from '../identity'
@@ -24,7 +24,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
   const to = await Identity.buildFromMnemonic('')
   await expect(
     makeTransfer(alice, to.address, new BN(1)).then((tx) =>
-      submitSignedTx(tx, AWAIT_IN_BLOCK)
+      submitSignedTx(tx, [IS_IN_BLOCK])
     )
   ).rejects.toThrow(ERROR_UNKNOWN)
 }, 30_000)
@@ -40,7 +40,7 @@ it('records an extrinsic error when ctype does not exist', async () => {
     revoked: false,
   })
   const tx = await attestation.store(alice)
-  await expect(submitSignedTx(tx, AWAIT_IN_BLOCK)).rejects.toThrow(
+  await expect(submitSignedTx(tx, [IS_IN_BLOCK])).rejects.toThrow(
     ERROR_CTYPE_NOT_FOUND
   )
 }, 30_000)

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @packageDocumentation
+ * @group integration/errorhandler
+ * @ignore
+ */
+
+import BN from 'bn.js'
+import { Attestation, IBlockchainApi } from '..'
+import { makeTransfer } from '../balance'
+import { AWAIT_IN_BLOCK, submitTx } from '../blockchain/Blockchain'
+import { DEFAULT_WS_ADDRESS, getCached } from '../blockchainApiConnection'
+import { ERROR_CTYPE_NOT_FOUND } from '../errorhandling'
+import Identity from '../identity'
+
+let blockchain: IBlockchainApi | undefined
+beforeAll(async () => {
+  blockchain = await getCached(DEFAULT_WS_ADDRESS)
+})
+
+xit('records an extrinsic error when transferring less than the existential amount', async () => {
+  const from = await Identity.buildFromURI('//Alice')
+  const to = await Identity.buildFromMnemonic('')
+  await expect(makeTransfer(from, to.address, new BN(1))).rejects.toThrow()
+})
+
+it('records an extrinsic error when ctype does not exist', async () => {
+  const attester = await Identity.buildFromURI('//Alice')
+  const attestation = Attestation.fromAttestation({
+    claimHash:
+      '0xfea1357cdba9982ebe7a8a3bb2db975cbb7424acd503d4dc3a7339778e8bb752',
+    cTypeHash:
+      '0x103752ecd8e284b1c9677337ccc91ea255ac8e6651dc65d90f0504f31d7e54f0',
+    delegationId: null,
+    owner: attester.address,
+    revoked: false,
+  })
+  const tx = await attestation.store(attester)
+  await expect(submitTx(tx, AWAIT_IN_BLOCK)).rejects.toThrow(
+    ERROR_CTYPE_NOT_FOUND
+  )
+}, 40_000)
+
+afterAll(() => {
+  if (typeof blockchain !== 'undefined') blockchain.api.disconnect()
+})

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -24,7 +24,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
   const to = await Identity.buildFromMnemonic('')
   await expect(
     makeTransfer(alice, to.address, new BN(1)).then((tx) =>
-      submitSignedTx(tx, [IS_IN_BLOCK])
+      submitSignedTx(tx, IS_IN_BLOCK)
     )
   ).rejects.toThrow(ERROR_UNKNOWN)
 }, 30_000)
@@ -40,7 +40,7 @@ it('records an extrinsic error when ctype does not exist', async () => {
     revoked: false,
   })
   const tx = await attestation.store(alice)
-  await expect(submitSignedTx(tx, [IS_IN_BLOCK])).rejects.toThrow(
+  await expect(submitSignedTx(tx, IS_IN_BLOCK)).rejects.toThrow(
     ERROR_CTYPE_NOT_FOUND
   )
 }, 30_000)

--- a/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/src/__integrationtests__/ErrorHandler.spec.ts
@@ -9,36 +9,41 @@ import { Attestation, IBlockchainApi } from '..'
 import { makeTransfer } from '../balance/Balance.chain'
 import { AWAIT_IN_BLOCK, submitSignedTx } from '../blockchain/Blockchain'
 import { DEFAULT_WS_ADDRESS, getCached } from '../blockchainApiConnection'
-import { ERROR_CTYPE_NOT_FOUND } from '../errorhandling'
+import { ERROR_CTYPE_NOT_FOUND, ERROR_UNKNOWN } from '../errorhandling'
 import Identity from '../identity'
 
 let blockchain: IBlockchainApi | undefined
+let alice: Identity
+
 beforeAll(async () => {
   blockchain = await getCached(DEFAULT_WS_ADDRESS)
+  alice = await Identity.buildFromURI('//Alice')
 })
 
-xit('records an extrinsic error when transferring less than the existential amount', async () => {
-  const from = await Identity.buildFromURI('//Alice')
+it('records an unknown extrinsic error when transferring less than the existential amount to new identity', async () => {
   const to = await Identity.buildFromMnemonic('')
-  await expect(makeTransfer(from, to.address, new BN(1))).rejects.toThrow()
-})
+  await expect(
+    makeTransfer(alice, to.address, new BN(1)).then((tx) =>
+      submitSignedTx(tx, AWAIT_IN_BLOCK)
+    )
+  ).rejects.toThrow(ERROR_UNKNOWN)
+}, 30_000)
 
 it('records an extrinsic error when ctype does not exist', async () => {
-  const attester = await Identity.buildFromURI('//Alice')
   const attestation = Attestation.fromAttestation({
     claimHash:
       '0xfea1357cdba9982ebe7a8a3bb2db975cbb7424acd503d4dc3a7339778e8bb752',
     cTypeHash:
       '0x103752ecd8e284b1c9677337ccc91ea255ac8e6651dc65d90f0504f31d7e54f0',
     delegationId: null,
-    owner: attester.address,
+    owner: alice.address,
     revoked: false,
   })
-  const tx = await attestation.store(attester)
+  const tx = await attestation.store(alice)
   await expect(submitSignedTx(tx, AWAIT_IN_BLOCK)).rejects.toThrow(
     ERROR_CTYPE_NOT_FOUND
   )
-}, 40_000)
+}, 30_000)
 
 afterAll(() => {
   if (typeof blockchain !== 'undefined') blockchain.api.disconnect()

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -92,7 +92,7 @@ export async function issueAttestation(
   }
   await attestation
     .store(attester)
-    .then((tx) => submitSignedTx(tx, [IS_FINALIZED]))
+    .then((tx) => submitSignedTx(tx, IS_FINALIZED))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -1,5 +1,5 @@
 import * as gabi from '@kiltprotocol/portablegabi'
-import { AWAIT_FINALIZED, submitTx } from '../blockchain/Blockchain'
+import { AWAIT_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import { getCached } from '../blockchainApiConnection'
 import {
@@ -90,7 +90,9 @@ export async function issueAttestation(
     witness = attestationInfo.witness
     peAttestation = attestationInfo.attestation
   }
-  await attestation.store(attester).then((tx) => submitTx(tx, AWAIT_FINALIZED))
+  await attestation
+    .store(attester)
+    .then((tx) => submitSignedTx(tx, AWAIT_FINALIZED))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -1,5 +1,5 @@
 import * as gabi from '@kiltprotocol/portablegabi'
-import { AWAIT_FINALIZED } from '../blockchain/Blockchain'
+import { AWAIT_FINALIZED, submitTx } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import { getCached } from '../blockchainApiConnection'
 import {
@@ -90,10 +90,7 @@ export async function issueAttestation(
     witness = attestationInfo.witness
     peAttestation = attestationInfo.attestation
   }
-  const blockchain = await getCached()
-  await attestation
-    .store(attester)
-    .then((tx) => blockchain.submitTx(tx, AWAIT_FINALIZED))
+  await attestation.store(attester).then((tx) => submitTx(tx, AWAIT_FINALIZED))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -1,5 +1,5 @@
 import * as gabi from '@kiltprotocol/portablegabi'
-import { AWAIT_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
+import { IS_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import { getCached } from '../blockchainApiConnection'
 import {
@@ -92,7 +92,7 @@ export async function issueAttestation(
   }
   await attestation
     .store(attester)
-    .then((tx) => submitSignedTx(tx, AWAIT_FINALIZED))
+    .then((tx) => submitSignedTx(tx, [IS_FINALIZED]))
 
   const revocationHandle: IRevocationHandle = {
     witness,

--- a/src/actor/Attester.ts
+++ b/src/actor/Attester.ts
@@ -1,4 +1,5 @@
 import * as gabi from '@kiltprotocol/portablegabi'
+import { AWAIT_FINALIZED } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import { getCached } from '../blockchainApiConnection'
 import {
@@ -89,7 +90,11 @@ export async function issueAttestation(
     witness = attestationInfo.witness
     peAttestation = attestationInfo.attestation
   }
-  await attestation.store(attester)
+  const blockchain = await getCached()
+  await attestation
+    .store(attester)
+    .then((tx) => blockchain.submitTx(tx, AWAIT_FINALIZED))
+
   const revocationHandle: IRevocationHandle = {
     witness,
     attestation,

--- a/src/attestation/Attestation.chain.ts
+++ b/src/attestation/Attestation.chain.ts
@@ -2,7 +2,6 @@
  * @packageDocumentation
  * @ignore
  */
-import { SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Option, Tuple } from '@polkadot/types'
 import { Codec } from '@polkadot/types/types'
@@ -18,7 +17,7 @@ const log = factory.getLogger('Attestation')
 export async function store(
   attestation: IAttestation,
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const txParams = {
     claimHash: attestation.claimHash,
     ctypeHash: attestation.cTypeHash,
@@ -33,7 +32,7 @@ export async function store(
     txParams.ctypeHash,
     txParams.delegationId
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }
 
 interface IChainAttestation extends Codec {
@@ -82,11 +81,11 @@ export async function query(claimHash: string): Promise<Attestation | null> {
 export async function revoke(
   claimHash: string,
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   log.debug(() => `Revoking attestations with claim hash ${claimHash}`)
   const tx: SubmittableExtrinsic = blockchain.api.tx.attestation.revoke(
     claimHash
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }

--- a/src/attestation/Attestation.ts
+++ b/src/attestation/Attestation.ts
@@ -11,7 +11,7 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import IRequestForAttestation from '../types/RequestForAttestation'
 import Identity from '../identity/Identity'
 import IAttestation, { CompressedAttestation } from '../types/Attestation'
@@ -42,7 +42,7 @@ export default class Attestation implements IAttestation {
    *
    * @param claimHash - The hash of the claim that corresponds to the attestation to revoke.
    * @param identity - The identity used to revoke the attestation (should be an attester identity, or have delegated rights).
-   * @returns A promise containing the SubmittableResult (transaction status).
+   * @returns A promise containing the SubmittableExtrinsic (submittable transaction).
    * @example ```javascript
    * Attestation.revoke('0xd8024cdc147c4fa9221cd177').then(() => {
    *   // the attestation was successfully revoked
@@ -52,7 +52,7 @@ export default class Attestation implements IAttestation {
   public static async revoke(
     claimHash: string,
     identity: Identity
-  ): Promise<SubmittableResult> {
+  ): Promise<SubmittableExtrinsic> {
     return revoke(claimHash, identity)
   }
 
@@ -162,7 +162,7 @@ export default class Attestation implements IAttestation {
    * [ASYNC] Stores the attestation on chain.
    *
    * @param identity - The identity used to store the attestation.
-   * @returns A promise containing the SubmittableResult (transaction status).
+   * @returns A promise containing the SubmittableExtrinsic (submittable transaction).
    * @example ```javascript
    * // Use [[store]] to store an attestation on chain, and to create an [[AttestedClaim]] upon success:
    * attestation.store(attester).then(() => {
@@ -170,7 +170,7 @@ export default class Attestation implements IAttestation {
    * });
    * ```
    */
-  public async store(identity: Identity): Promise<SubmittableResult> {
+  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
     return store(this, identity)
   }
 
@@ -178,14 +178,14 @@ export default class Attestation implements IAttestation {
    * [ASYNC] Revokes the attestation. Also available as a static method.
    *
    * @param identity - The identity used to revoke the attestation (should be an attester identity, or have delegated rights).
-   * @returns A promise containing the SubmittableResult (transaction status).
+   * @returns A promise containing the SubmittableExtrinsic (submittable transaction).
    * @example ```javascript
    * attestation.revoke(identity).then(() => {
    *   // the attestation was successfully revoked
    * });
    * ```
    */
-  public async revoke(identity: Identity): Promise<SubmittableResult> {
+  public async revoke(identity: Identity): Promise<SubmittableExtrinsic> {
     return revoke(this.claimHash, identity)
   }
 

--- a/src/balance/Balance.chain.ts
+++ b/src/balance/Balance.chain.ts
@@ -9,7 +9,7 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { UnsubscribePromise } from '@polkadot/api/types'
 import BN from 'bn.js'
 import { getCached } from '../blockchainApiConnection'
@@ -105,10 +105,10 @@ export async function listenToBalanceChanges(
  * const identity = ...
  * const address = ...
  * const amount: BN = new BN(42)
+ * const blockchain = await sdk.getCached()
  * sdk.Balance.makeTransfer(identity, address, amount)
- *   .then((status: SubmittableResult) => {
- *     console.log('Successfully transferred ${amount.toNumber()} tokens')
- *   })
+ *   .then(tx => blockchain.sendTx(tx))
+ *   .then(() => console.log('Successfully transferred ${amount.toNumber()} tokens'))
  *   .catch(err => {
  *     console.log('Transfer failed')
  *   })
@@ -118,8 +118,8 @@ export async function makeTransfer(
   identity: Identity,
   accountAddressTo: IPublicIdentity['address'],
   amount: BN
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const transfer = blockchain.api.tx.balances.transfer(accountAddressTo, amount)
-  return blockchain.submitTx(identity, transfer)
+  return blockchain.signTx(identity, transfer)
 }

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -9,6 +9,7 @@ import {
   makeTransfer,
 } from './Balance.chain'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
+import { getCached } from '../blockchainApiConnection'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -61,7 +62,10 @@ describe('Balance', () => {
     const alice = await Identity.buildFromURI('//Alice')
     const bob = await Identity.buildFromURI('//Bob')
 
-    const status = await makeTransfer(alice, bob.address, new BN(100))
+    const blockchain = await getCached()
+
+    const tx = await makeTransfer(alice, bob.address, new BN(100))
+    const status = await blockchain.submitTx(tx)
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -9,7 +9,7 @@ import {
   makeTransfer,
 } from './Balance.chain'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
-import { submitSignedTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain'
 import BalanceUtils from './Balance.utils'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -9,7 +9,7 @@ import {
   makeTransfer,
 } from './Balance.chain'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
-import { getCached } from '../blockchainApiConnection'
+import { submitTx } from '../blockchain/Blockchain'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -62,10 +62,8 @@ describe('Balance', () => {
     const alice = await Identity.buildFromURI('//Alice')
     const bob = await Identity.buildFromURI('//Bob')
 
-    const blockchain = await getCached()
-
     const tx = await makeTransfer(alice, bob.address, new BN(100))
-    const status = await blockchain.submitTx(tx)
+    const status = await submitTx(tx)
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -9,7 +9,7 @@ import {
   makeTransfer,
 } from './Balance.chain'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
-import { submitTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain/Blockchain'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -63,7 +63,7 @@ describe('Balance', () => {
     const bob = await Identity.buildFromURI('//Bob')
 
     const tx = await makeTransfer(alice, bob.address, new BN(100))
-    const status = await submitTx(tx)
+    const status = await submitSignedTx(tx)
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -15,7 +15,7 @@ import { Text } from '@polkadot/types'
 import { Header, Index } from '@polkadot/types/interfaces/types'
 import { AnyJson, Codec } from '@polkadot/types/types'
 import { factory as LoggerFactory } from '../config/ConfigLog'
-import { ErrorHandler } from '../errorhandling/ErrorHandler'
+import { ErrorHandler } from '../errorhandling'
 import { ERROR_UNKNOWN, ExtrinsicError } from '../errorhandling/ExtrinsicError'
 import Identity from '../identity/Identity'
 
@@ -78,10 +78,9 @@ export async function submitSignedTx(
         resolve(result)
       }
     })
-      .then((cb) => {
-        unsubscribe = cb
+      .then((subsciptionHandle: () => void) => {
+        unsubscribe = subsciptionHandle
       })
-      // not sure we need this final catch block
       .catch((err: Error) => {
         // just reject with the original tx error from the chain
         reject(err)
@@ -99,6 +98,13 @@ export default class Blockchain implements IBlockchainApi {
     const json = queryResult.toJSON()
     if (json instanceof Array) return json
     return []
+  }
+
+  public static submitSignedTx(
+    tx: SubmittableExtrinsic,
+    resolveOn: txStatusPromiseResolver = AWAIT_FINALIZED
+  ): Promise<SubmittableResult> {
+    return submitSignedTx(tx, resolveOn)
   }
 
   public api: ApiPromise

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -29,9 +29,11 @@ export type Stats = {
   nodeVersion: string
 }
 
+export type ResultEvaluator = Evaluator<SubmittableResult>
+
 export interface SubscriptionPromiseOptions {
-  resolveOn?: Evaluator<SubmittableResult>
-  rejectOn?: Evaluator<SubmittableResult>
+  resolveOn?: ResultEvaluator
+  rejectOn?: ResultEvaluator
   timeout?: number
 }
 
@@ -53,18 +55,15 @@ export interface IBlockchainApi {
   getNonce(accountAddress: string): Promise<Codec>
 }
 
-export const IS_READY: Evaluator<SubmittableResult> = (result) =>
-  result.status.isReady
-export const IS_IN_BLOCK: Evaluator<SubmittableResult> = (result) =>
-  result.isInBlock
-export const EXTRINSIC_EXECUTED: Evaluator<SubmittableResult> = (result) =>
+export const IS_READY: ResultEvaluator = (result) => result.status.isReady
+export const IS_IN_BLOCK: ResultEvaluator = (result) => result.isInBlock
+export const EXTRINSIC_EXECUTED: ResultEvaluator = (result) =>
   ErrorHandler.extrinsicSuccessful(result)
-export const IS_FINALIZED: Evaluator<SubmittableResult> = (result) =>
-  result.isFinalized
+export const IS_FINALIZED: ResultEvaluator = (result) => result.isFinalized
 
-export const IS_ERROR: Evaluator<SubmittableResult> = (result) =>
+export const IS_ERROR: ResultEvaluator = (result) =>
   result.isError && ERROR_UNKNOWN()
-export const EXTRINSIC_FAILED: Evaluator<SubmittableResult> = (result) =>
+export const EXTRINSIC_FAILED: ResultEvaluator = (result) =>
   ErrorHandler.extrinsicFailed(result) &&
   (ErrorHandler.getExtrinsicError(result) || UNKNOWN_EXTRINSIC_ERROR)
 
@@ -85,8 +84,8 @@ export const EXTRINSIC_FAILED: Evaluator<SubmittableResult> = (result) =>
  */
 export async function submitSignedTx(
   tx: SubmittableExtrinsic,
-  resolveOn: Evaluator<SubmittableResult> = IS_FINALIZED,
-  rejectOn: Evaluator<SubmittableResult> = (result) =>
+  resolveOn: ResultEvaluator = IS_FINALIZED,
+  rejectOn: ResultEvaluator = (result) =>
     IS_ERROR(result) || EXTRINSIC_FAILED(result),
   timeout?: number
 ): Promise<SubmittableResult> {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -54,7 +54,7 @@ export const AWAIT_IN_BLOCK: txStatusPromiseResolver = (result) =>
 export const AWAIT_FINALIZED: txStatusPromiseResolver = (result) =>
   result.isFinalized
 
-export async function submitTx(
+export async function submitSignedTx(
   tx: SubmittableExtrinsic,
   resolveOn: txStatusPromiseResolver = AWAIT_FINALIZED
 ): Promise<SubmittableResult> {
@@ -145,7 +145,7 @@ export default class Blockchain implements IBlockchainApi {
     resolveOn: txStatusPromiseResolver = AWAIT_FINALIZED
   ) {
     const signedTx = await this.signTx(identity, tx)
-    return submitTx(signedTx, resolveOn)
+    return submitSignedTx(signedTx, resolveOn)
   }
 
   public async getNonce(accountAddress: string): Promise<Index> {

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -144,12 +144,11 @@ export default class Blockchain implements IBlockchainApi {
     return signed
   }
 
-  // TODO: should this be renamed signAndSubmitTx ?
   public async submitTx(
     identity: Identity,
     tx: SubmittableExtrinsic,
     resolveOn: txStatusPromiseResolver = AWAIT_FINALIZED
-  ) {
+  ): Promise<SubmittableResult> {
     const signedTx = await this.signTx(identity, tx)
     return submitSignedTx(signedTx, resolveOn)
   }

--- a/src/blockchain/index.ts
+++ b/src/blockchain/index.ts
@@ -3,4 +3,4 @@
  * @ignore
  */
 
-export { default, IBlockchainApi } from './Blockchain'
+export { default, IBlockchainApi, submitSignedTx } from './Blockchain'

--- a/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -38,9 +38,7 @@ export async function buildConnection(
     provider,
     types: CUSTOM_TYPES,
   })
-  const bc = new Blockchain(api)
-  await bc.ready
-  return bc
+  return new Blockchain(api)
 }
 
 export async function getCached(

--- a/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -79,16 +79,20 @@ class MockSubmittableExtrinsic {
     return this
   }
 
-  public send(callable: Function) {
+  public async send(callable: Function) {
     if (callable) {
       callable(this.result)
+      return () => {}
     }
+    return '0x123'
   }
 
-  public signAndSend(a: any, callable: Function) {
+  public async signAndSend(a: any, callable: Function) {
     if (callable) {
       callable(this.result)
+      return () => {}
     }
+    return '0x123'
   }
 }
 

--- a/src/ctype/CType.chain.ts
+++ b/src/ctype/CType.chain.ts
@@ -3,7 +3,6 @@
  * @ignore
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Option } from '@polkadot/types'
 import { AccountId } from '@polkadot/types/interfaces'
@@ -19,11 +18,11 @@ const log = factory.getLogger('CType')
 export async function store(
   ctype: ICType,
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   log.debug(() => `Create tx for 'ctype.add'`)
   const tx: SubmittableExtrinsic = blockchain.api.tx.ctype.add(ctype.hash)
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }
 
 // decoding is not backwards compatible with mashnet-node 0.22 anymore

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,7 +1,7 @@
 import { SubmittableResult } from '@polkadot/api'
 import { TypeRegistry } from '@polkadot/types'
 import { Option } from '@polkadot/types/codec'
-import getCached from '../blockchainApiConnection'
+import { submitTx } from '../blockchain/Blockchain'
 import Claim from '../claim/Claim'
 import {
   ERROR_ADDRESS_INVALID,
@@ -101,9 +101,8 @@ describe('CType', () => {
   it('stores ctypes', async () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
-    const blockchain = await getCached()
     const tx = await ctype.store(identityAlice)
-    const result = await blockchain.submitTx(tx)
+    const result = await submitTx(tx)
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,7 +1,7 @@
 import { SubmittableResult } from '@polkadot/api'
 import { TypeRegistry } from '@polkadot/types'
 import { Option } from '@polkadot/types/codec'
-
+import getCached from '../blockchainApiConnection'
 import Claim from '../claim/Claim'
 import {
   ERROR_ADDRESS_INVALID,
@@ -101,7 +101,9 @@ describe('CType', () => {
   it('stores ctypes', async () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
-    const result = await ctype.store(identityAlice)
+    const blockchain = await getCached()
+    const tx = await ctype.store(identityAlice)
+    const result = await blockchain.submitTx(tx)
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,7 +1,7 @@
 import { SubmittableResult } from '@polkadot/api'
 import { TypeRegistry } from '@polkadot/types'
 import { Option } from '@polkadot/types/codec'
-import { submitSignedTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain'
 import Claim from '../claim/Claim'
 import {
   ERROR_ADDRESS_INVALID,

--- a/src/ctype/CType.spec.ts
+++ b/src/ctype/CType.spec.ts
@@ -1,7 +1,7 @@
 import { SubmittableResult } from '@polkadot/api'
 import { TypeRegistry } from '@polkadot/types'
 import { Option } from '@polkadot/types/codec'
-import { submitTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain/Blockchain'
 import Claim from '../claim/Claim'
 import {
   ERROR_ADDRESS_INVALID,
@@ -102,7 +102,7 @@ describe('CType', () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
     const tx = await ctype.store(identityAlice)
-    const result = await submitTx(tx)
+    const result = await submitSignedTx(tx)
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/src/ctype/CType.ts
+++ b/src/ctype/CType.ts
@@ -10,7 +10,7 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import Identity from '../identity/Identity'
 import IClaim from '../types/Claim'
 import ICType, { CompressedCType, CTypeSchemaWithoutId } from '../types/CType'
@@ -87,9 +87,9 @@ export default class CType implements ICType {
    *
    * @param identity The identity which submits the blockchain transaction to store the [[CType]].
    *
-   * @returns A promise of a SubmittableResult .
+   * @returns A promise of a SubmittableExtrinsic .
    */
-  public async store(identity: Identity): Promise<SubmittableResult> {
+  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
     return store(this, identity)
   }
 

--- a/src/delegation/Delegation.ts
+++ b/src/delegation/Delegation.ts
@@ -14,7 +14,7 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import Attestation from '../attestation/Attestation'
 import { query } from '../attestation/Attestation.chain'
 import Identity from '../identity/Identity'
@@ -99,7 +99,7 @@ export default abstract class DelegationBaseNode
   /**
    * Revokes this delegation node on chain.
    *
-   * @returns Promise containing the transaction status.
+   * @returns Promise containing a submittable transaction.
    */
-  public abstract revoke(identity: Identity): Promise<SubmittableResult>
+  public abstract revoke(identity: Identity): Promise<SubmittableExtrinsic>
 }

--- a/src/delegation/DelegationNode.chain.ts
+++ b/src/delegation/DelegationNode.chain.ts
@@ -3,7 +3,6 @@
  * @ignore
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Option, Tuple } from '@polkadot/types'
 import { getCached } from '../blockchainApiConnection'
@@ -22,7 +21,7 @@ export async function store(
   delegation: IDelegationNode,
   identity: Identity,
   signature: string
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const includeParentId: boolean = delegation.parentId
     ? delegation.parentId !== delegation.rootId
@@ -35,7 +34,7 @@ export async function store(
     permissionsAsBitset(delegation),
     signature
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }
 
 export async function query(
@@ -64,12 +63,12 @@ export async function query(
 export async function revoke(
   delegationId: IDelegationNode['id'],
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.revokeDelegation(
     delegationId
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }
 
 // function lives here to avoid circular imports between DelegationBaseNode and DelegationNode

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -1,3 +1,4 @@
+import getCached from '../blockchainApiConnection'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import { Permission } from '../types/Delegation'
@@ -87,7 +88,11 @@ describe('Delegation', () => {
       'myAccount',
       []
     )
-    const revokeStatus = await aDelegationNode.revoke(identityAlice)
+    const blockchain = await getCached()
+    const revokeStatus = await aDelegationNode
+      .revoke(identityAlice)
+      .then((tx) => blockchain.submitTx(tx))
+
     expect(revokeStatus).toBeDefined()
   })
 

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -1,4 +1,4 @@
-import getCached from '../blockchainApiConnection'
+import { submitTx } from '../blockchain/Blockchain'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import { Permission } from '../types/Delegation'
@@ -88,10 +88,9 @@ describe('Delegation', () => {
       'myAccount',
       []
     )
-    const blockchain = await getCached()
     const revokeStatus = await aDelegationNode
       .revoke(identityAlice)
-      .then((tx) => blockchain.submitTx(tx))
+      .then((tx) => submitTx(tx))
 
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -1,4 +1,4 @@
-import { submitSignedTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import { Permission } from '../types/Delegation'

--- a/src/delegation/DelegationNode.spec.ts
+++ b/src/delegation/DelegationNode.spec.ts
@@ -1,4 +1,4 @@
-import { submitTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain/Blockchain'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import Identity from '../identity/Identity'
 import { Permission } from '../types/Delegation'
@@ -90,7 +90,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationNode
       .revoke(identityAlice)
-      .then((tx) => submitTx(tx))
+      .then((tx) => submitSignedTx(tx))
 
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationNode.ts
+++ b/src/delegation/DelegationNode.ts
@@ -1,3 +1,4 @@
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 /**
  * Delegation nodes are used within the KILT protocol to construct the trust hierarchy.
  *
@@ -8,7 +9,6 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { factory } from '../config/ConfigLog'
 import Crypto from '../crypto'
 import { coToUInt8, u8aConcat, u8aToHex } from '../crypto/Crypto'
@@ -134,12 +134,12 @@ export default class DelegationNode extends DelegationBaseNode
    *
    * @param identity Account used to store the delegation node.
    * @param signature Signature of the delegate to ensure it's done under his permission.
-   * @returns Promise containing the SubmittableResult.
+   * @returns Promise containing a SubmittableExtrinsic.
    */
   public async store(
     identity: Identity,
     signature: string
-  ): Promise<SubmittableResult> {
+  ): Promise<SubmittableExtrinsic> {
     log.info(`:: store(${this.id})`)
     return store(this, identity, signature)
   }
@@ -158,9 +158,9 @@ export default class DelegationNode extends DelegationBaseNode
    * [ASYNC] Revokes the delegation node on chain.
    *
    * @param identity The identity used to revoke the delegation.
-   * @returns Promise containing the SubmittableResult.
+   * @returns Promise containing a SubmittableExtrinsic.
    */
-  public async revoke(identity: Identity): Promise<SubmittableResult> {
+  public async revoke(identity: Identity): Promise<SubmittableExtrinsic> {
     log.debug(`:: revoke(${this.id})`)
     return revoke(this.id, identity)
   }

--- a/src/delegation/DelegationRootNode.chain.ts
+++ b/src/delegation/DelegationRootNode.chain.ts
@@ -3,7 +3,6 @@
  * @ignore
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Option, Tuple } from '@polkadot/types'
 import { getCached } from '../blockchainApiConnection'
@@ -15,13 +14,13 @@ import DelegationRootNode from './DelegationRootNode'
 export async function store(
   delegation: IDelegationRootNode,
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.createRoot(
     delegation.id,
     delegation.cTypeHash
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }
 
 export async function query(
@@ -46,10 +45,10 @@ export async function query(
 export async function revoke(
   delegation: IDelegationRootNode,
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.revokeRoot(
     delegation.id
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -1,4 +1,5 @@
 import { Crypto, Identity } from '..'
+import { submitTx } from '../blockchain/Blockchain'
 import getCached from '../blockchainApiConnection'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import DelegationRootNode from './DelegationRootNode'
@@ -39,10 +40,7 @@ describe('Delegation', () => {
       ctypeHash,
       identityAlice.address
     )
-    const blockchain = await getCached()
-    await rootDelegation
-      .store(identityAlice)
-      .then((tx) => blockchain.submitTx(tx))
+    await rootDelegation.store(identityAlice).then((tx) => submitTx(tx))
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
@@ -105,7 +103,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationRootNode
       .revoke(identityAlice)
-      .then((tx) => blockchain.submitTx(tx))
+      .then((tx) => submitTx(tx))
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith('myRootId')
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -1,5 +1,5 @@
 import { Crypto, Identity } from '..'
-import { submitSignedTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain'
 import getCached from '../blockchainApiConnection'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import DelegationRootNode from './DelegationRootNode'

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -1,5 +1,5 @@
 import { Crypto, Identity } from '..'
-import { submitTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain/Blockchain'
 import getCached from '../blockchainApiConnection'
 import { mockChainQueryReturn } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
 import DelegationRootNode from './DelegationRootNode'
@@ -40,7 +40,7 @@ describe('Delegation', () => {
       ctypeHash,
       identityAlice.address
     )
-    await rootDelegation.store(identityAlice).then((tx) => submitTx(tx))
+    await rootDelegation.store(identityAlice).then((tx) => submitSignedTx(tx))
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
@@ -103,7 +103,7 @@ describe('Delegation', () => {
     )
     const revokeStatus = await aDelegationRootNode
       .revoke(identityAlice)
-      .then((tx) => submitTx(tx))
+      .then((tx) => submitSignedTx(tx))
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith('myRootId')
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationRootNode.spec.ts
+++ b/src/delegation/DelegationRootNode.spec.ts
@@ -39,7 +39,11 @@ describe('Delegation', () => {
       ctypeHash,
       identityAlice.address
     )
-    rootDelegation.store(identityAlice)
+    const blockchain = await getCached()
+    await rootDelegation
+      .store(identityAlice)
+      .then((tx) => blockchain.submitTx(tx))
+
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
       expect(rootNode.id).toBe(ROOT_IDENTIFIER)
@@ -99,7 +103,9 @@ describe('Delegation', () => {
       ctypeHash,
       'myAccount'
     )
-    const revokeStatus = await aDelegationRootNode.revoke(identityAlice)
+    const revokeStatus = await aDelegationRootNode
+      .revoke(identityAlice)
+      .then((tx) => blockchain.submitTx(tx))
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith('myRootId')
     expect(revokeStatus).toBeDefined()
   })

--- a/src/delegation/DelegationRootNode.ts
+++ b/src/delegation/DelegationRootNode.ts
@@ -1,3 +1,4 @@
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 /**
  * KILT enables top-down trust structures.
  * On the lowest level, a delegation structure is always a **tree**.
@@ -11,7 +12,6 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { factory } from '../config/ConfigLog'
 import Identity from '../identity/Identity'
 import { IDelegationRootNode } from '../types/Delegation'
@@ -69,9 +69,9 @@ export default class DelegationRootNode extends DelegationBaseNode
    * Stores the delegation root node on chain.
    *
    * @param identity The account used to store the delegation root node.
-   * @returns Promise containing the SubmittableResult.
+   * @returns Promise containing the SubmittableExtrinsic.
    */
-  public async store(identity: Identity): Promise<SubmittableResult> {
+  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
     log.debug(`:: store(${this.id})`)
     return store(this, identity)
   }
@@ -81,7 +81,7 @@ export default class DelegationRootNode extends DelegationBaseNode
     return node !== null && !node.revoked
   }
 
-  public async revoke(identity: Identity): Promise<SubmittableResult> {
+  public async revoke(identity: Identity): Promise<SubmittableExtrinsic> {
     log.debug(`:: revoke(${this.id})`)
     return revoke(this, identity)
   }

--- a/src/did/Did.chain.ts
+++ b/src/did/Did.chain.ts
@@ -3,7 +3,6 @@
  * @ignore
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { Option, Tuple } from '@polkadot/types'
 import { getCached } from '../blockchainApiConnection'
@@ -40,21 +39,23 @@ export async function queryByAddress(
   return decoded
 }
 
-export async function remove(identity: Identity): Promise<SubmittableResult> {
+export async function remove(
+  identity: Identity
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const tx: SubmittableExtrinsic = blockchain.api.tx.did.remove()
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }
 
 export async function store(
   did: IDid,
   identity: Identity
-): Promise<SubmittableResult> {
+): Promise<SubmittableExtrinsic> {
   const blockchain = await getCached()
   const tx: SubmittableExtrinsic = blockchain.api.tx.did.add(
     did.publicBoxKey,
     did.publicSigningKey,
     did.documentStore
   )
-  return blockchain.submitTx(identity, tx)
+  return blockchain.signTx(identity, tx)
 }

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -1,6 +1,6 @@
 import { U8aFixed } from '@polkadot/types'
 import { Did, IDid } from '..'
-import getCached from '../blockchainApiConnection'
+import { submitTx } from '../blockchain/Blockchain'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
@@ -67,12 +67,8 @@ describe('DID', () => {
   it('store did', async () => {
     const alice = await Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
-    const blockchain = await getCached()
     const tx = await did.store(alice)
-    await expect(blockchain.submitTx(tx)).resolves.toHaveProperty(
-      'isFinalized',
-      true
-    )
+    await expect(submitTx(tx)).resolves.toHaveProperty('isFinalized', true)
   })
 
   it('creates default did document', async () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -4,7 +4,10 @@ import { submitSignedTx } from '../blockchain'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
-import { ERROR_DID_IDENTIFIER_MISMATCH } from '../errorhandling/SDKErrors'
+import {
+  ERROR_DID_IDENTIFIER_MISMATCH,
+  ERROR_INVALID_DID_PREFIX,
+} from '../errorhandling/SDKErrors'
 import Identity from '../identity/Identity'
 import {
   getIdentifierFromAddress,
@@ -61,7 +64,10 @@ describe('DID', () => {
   })
 
   it('query by identifier invalid identifier', async () => {
-    await expect(Did.queryByIdentifier('invalidIdentifier')).rejects.toThrow()
+    const identifier = 'invalidIdentifier'
+    await expect(Did.queryByIdentifier(identifier)).rejects.toThrow(
+      ERROR_INVALID_DID_PREFIX(identifier)
+    )
   })
 
   it('store did', async () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -1,6 +1,6 @@
 import { U8aFixed } from '@polkadot/types'
 import { Did, IDid } from '..'
-import { submitSignedTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -60,13 +60,8 @@ describe('DID', () => {
     } as IDid)
   })
 
-  it('query by identifier invalid identifier', async (done) => {
-    try {
-      await Did.queryByIdentifier('invalidIdentifier')
-      done.fail('should have detected an invalid DID')
-    } catch (err) {
-      done()
-    }
+  it('query by identifier invalid identifier', async () => {
+    await expect(Did.queryByIdentifier('invalidIdentifier')).rejects.toThrow()
   })
 
   it('store did', async () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -1,6 +1,6 @@
 import { U8aFixed } from '@polkadot/types'
 import { Did, IDid } from '..'
-import { submitTx } from '../blockchain/Blockchain'
+import { submitSignedTx } from '../blockchain/Blockchain'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
@@ -68,7 +68,10 @@ describe('DID', () => {
     const alice = await Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
     const tx = await did.store(alice)
-    await expect(submitTx(tx)).resolves.toHaveProperty('isFinalized', true)
+    await expect(submitSignedTx(tx)).resolves.toHaveProperty(
+      'isFinalized',
+      true
+    )
   })
 
   it('creates default did document', async () => {

--- a/src/did/Did.spec.ts
+++ b/src/did/Did.spec.ts
@@ -1,5 +1,6 @@
 import { U8aFixed } from '@polkadot/types'
 import { Did, IDid } from '..'
+import getCached from '../blockchainApiConnection'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '../blockchainApiConnection/__mocks__/BlockchainQuery'
@@ -71,7 +72,12 @@ describe('DID', () => {
   it('store did', async () => {
     const alice = await Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
-    await expect(did.store(alice)).resolves.toHaveProperty('isFinalized', true)
+    const blockchain = await getCached()
+    const tx = await did.store(alice)
+    await expect(blockchain.submitTx(tx)).resolves.toHaveProperty(
+      'isFinalized',
+      true
+    )
   })
 
   it('creates default did document', async () => {

--- a/src/did/Did.ts
+++ b/src/did/Did.ts
@@ -1,3 +1,4 @@
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 /**
  * A Decentralized Identifier (DID) is a new type of identifier that is globally unique, resolvable with high availability, and cryptographically verifiable.
  * Although it's not mandatory in KILT, users can optionally create a DID and anchor it to the KILT blockchain.
@@ -11,7 +12,6 @@
  * @preferred
  */
 
-import { SubmittableResult } from '@polkadot/api'
 import { AnyJson } from '@polkadot/types/types'
 import { factory } from '../config/ConfigLog'
 import Identity from '../identity/Identity'
@@ -126,9 +126,9 @@ export default class Did implements IDid {
    * [ASYNC] Stores the [[Did]] object on-chain.
    *
    * @param identity The identity used to store the [[Did]] object on-chain.
-   * @returns A promise containing the SubmittableResult (transaction status).
+   * @returns A promise containing the SubmittableExtrinsic (transaction status).
    */
-  public async store(identity: Identity): Promise<SubmittableResult> {
+  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
     log.debug(`Create tx for 'did.add'`)
     return store(this, identity)
   }
@@ -157,9 +157,11 @@ export default class Did implements IDid {
    * [STATIC] Removes the [[Did]] object attached to a given [[Identity]] from the chain.
    *
    * @param identity The identity for which to delete the [[Did]].
-   * @returns A promise containing the SubmittableResult (transaction status).
+   * @returns A promise containing a SubmittableExtrinsic (submittable transaction).
    */
-  public static async remove(identity: Identity): Promise<SubmittableResult> {
+  public static async remove(
+    identity: Identity
+  ): Promise<SubmittableExtrinsic> {
     log.debug(`Create tx for 'did.remove'`)
     return remove(identity)
   }

--- a/src/errorhandling/ErrorHandler.spec.ts
+++ b/src/errorhandling/ErrorHandler.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { ApiPromise, SubmittableResult } from '@polkadot/api'
+import { SubmittableResult } from '@polkadot/api'
 import { Tuple } from '@polkadot/types'
 import { ErrorHandler } from './ErrorHandler'
 import { ErrorCode, ERROR_CTYPE_NOT_FOUND } from './ExtrinsicError'
@@ -51,57 +51,7 @@ describe('ErrorHandler', () => {
     expect(ErrorHandler.extrinsicFailed(submittableResult)).toBeFalsy()
   })
 
-  const modules = [
-    {
-      events: {
-        isEmpty: false,
-      },
-      name: {
-        toString: jest.fn(() => {
-          return 'system'
-        }),
-      },
-    },
-    {
-      events: {
-        isEmpty: true,
-      },
-      name: {
-        toString: jest.fn(() => {
-          return 'balances'
-        }),
-      },
-    },
-    {
-      events: {
-        isEmpty: false,
-      },
-      name: {
-        toString: jest.fn(() => {
-          return 'Error'
-        }),
-      },
-    },
-  ]
-
-  const apiPromise: ApiPromise = {
-    runtimeMetadata: {
-      asV11: {
-        // @ts-ignore
-        modules,
-      },
-    },
-  }
-  it('test get error module index', async () => {
-    // @ts-ignore
-    expect(await ErrorHandler.getErrorModuleIndex(apiPromise)).toBe(1)
-  })
-
   it('test get extrinsic error', async () => {
-    const errorHandler: ErrorHandler = new ErrorHandler(apiPromise)
-    // @ts-ignore
-    errorHandler.moduleIndex = 1
-
     // @ts-ignore
     const errorCode: Tuple = {
       // @ts-ignore
@@ -116,7 +66,7 @@ describe('ErrorHandler', () => {
         },
       },
       event: {
-        index: [1],
+        section: 'error',
         data: [errorCode],
       },
     }
@@ -126,7 +76,7 @@ describe('ErrorHandler', () => {
     }
 
     // @ts-ignore
-    expect(errorHandler.getExtrinsicError(submittableResult)).toBe(
+    expect(ErrorHandler.getExtrinsicError(submittableResult)).toBe(
       ERROR_CTYPE_NOT_FOUND
     )
   })

--- a/src/errorhandling/ErrorHandler.spec.ts
+++ b/src/errorhandling/ErrorHandler.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { SubmittableResult } from '@polkadot/api'
 import { Tuple } from '@polkadot/types'
-import { ErrorHandler } from './ErrorHandler'
+import { ErrorHandler } from '.'
 import { ErrorCode, ERROR_CTYPE_NOT_FOUND } from './ExtrinsicError'
 
 describe('ErrorHandler', () => {

--- a/src/errorhandling/ErrorHandler.ts
+++ b/src/errorhandling/ErrorHandler.ts
@@ -17,53 +17,51 @@ export enum SystemEvent {
   ExtrinsicFailed = '0x0001',
 }
 
-export class ErrorHandler {
-  private static readonly ERROR_MODULE_NAME = 'error'
+const ERROR_MODULE_NAME = 'error'
 
-  /**
-   * [STATIC] Checks if there is `SystemEvent.ExtrinsicFailed` in the list of
-   * transaction events within the given `extrinsicResult`.
-   *
-   * @param extrinsicResult The result of a submission.
-   * @returns Whether the extrinsic submission failed.
-   */
-  public static extrinsicFailed(extrinsicResult: SubmittableResult): boolean {
-    const events: EventRecord[] = extrinsicResult.events || []
-    return events.some((eventRecord: EventRecord) => {
-      return (
-        !eventRecord.phase.asApplyExtrinsic.isEmpty &&
-        eventRecord.event.index.toHex() === SystemEvent.ExtrinsicFailed
-      )
-    })
-  }
+/**
+ * Checks if there is `SystemEvent.ExtrinsicFailed` in the list of
+ * transaction events within the given `extrinsicResult`.
+ *
+ * @param extrinsicResult The result of a submission.
+ * @returns Whether the extrinsic submission failed.
+ */
+export function extrinsicFailed(extrinsicResult: SubmittableResult): boolean {
+  const events: EventRecord[] = extrinsicResult.events || []
+  return events.some((eventRecord: EventRecord) => {
+    return (
+      !eventRecord.phase.asApplyExtrinsic.isEmpty &&
+      eventRecord.event.index.toHex() === SystemEvent.ExtrinsicFailed
+    )
+  })
+}
 
-  /**
-   * Get the extrinsic error from the transaction result.
-   *
-   * @param extrinsicResult The transaction result.
-   * @returns The extrinsic error.
-   */
-  public static getExtrinsicError(
-    extrinsicResult: SubmittableResult
-  ): ExtrinsicError | null {
-    const events: EventRecord[] = extrinsicResult.events || []
+/**
+ * Get the extrinsic error from the transaction result.
+ *
+ * @param extrinsicResult The transaction result.
+ * @returns The extrinsic error.
+ */
+export function getExtrinsicError(
+  extrinsicResult: SubmittableResult
+): ExtrinsicError | null {
+  const events: EventRecord[] = extrinsicResult.events || []
 
-    const errorEvent = events.find((eventRecord: EventRecord) => {
-      return (
-        !eventRecord.phase.asApplyExtrinsic.isEmpty &&
-        eventRecord.event.section === ErrorHandler.ERROR_MODULE_NAME
-      )
-    })
-    if (errorEvent) {
-      const { data } = errorEvent.event
-      const errorCode = data && !data.isEmpty ? data[0].toJSON() : null
-      if (errorCode && typeof errorCode === 'number') {
-        return errorForCode(errorCode)
-      }
-      log.warn(`error event doesn't have a valid error code: ${data}`)
-    } else {
-      log.warn('no error event found in transaction result')
+  const errorEvent = events.find((eventRecord: EventRecord) => {
+    return (
+      !eventRecord.phase.asApplyExtrinsic.isEmpty &&
+      eventRecord.event.section === ERROR_MODULE_NAME
+    )
+  })
+  if (errorEvent) {
+    const { data } = errorEvent.event
+    const errorCode = data && !data.isEmpty ? data[0].toJSON() : null
+    if (errorCode && typeof errorCode === 'number') {
+      return errorForCode(errorCode)
     }
-    return null
+    log.warn(`error event doesn't have a valid error code: ${data}`)
+  } else {
+    log.warn('no error event found in transaction result')
   }
+  return null
 }

--- a/src/errorhandling/ErrorHandler.ts
+++ b/src/errorhandling/ErrorHandler.ts
@@ -5,8 +5,8 @@
  * @ignore
  */
 
-import { ApiPromise, SubmittableResult } from '@polkadot/api'
-import { EventRecord, ModuleMetadataV11 } from '@polkadot/types/interfaces'
+import { SubmittableResult } from '@polkadot/api'
+import { EventRecord } from '@polkadot/types/interfaces'
 import { factory as LoggerFactory } from '../config/ConfigLog'
 import { errorForCode, ExtrinsicError } from './ExtrinsicError'
 
@@ -18,7 +18,7 @@ export enum SystemEvent {
 }
 
 export class ErrorHandler {
-  private static readonly ERROR_MODULE_NAME = 'Error'
+  private static readonly ERROR_MODULE_NAME = 'error'
 
   /**
    * [STATIC] Checks if there is `SystemEvent.ExtrinsicFailed` in the list of
@@ -29,29 +29,13 @@ export class ErrorHandler {
    */
   public static extrinsicFailed(extrinsicResult: SubmittableResult): boolean {
     const events: EventRecord[] = extrinsicResult.events || []
-    return (
-      events.find((eventRecord: EventRecord) => {
-        return (
-          !eventRecord.phase.asApplyExtrinsic.isEmpty &&
-          eventRecord.event.index.toHex() === SystemEvent.ExtrinsicFailed
-        )
-      }) !== undefined
-    )
-  }
-
-  public constructor(apiPromise: ApiPromise) {
-    this.ready = ErrorHandler.getErrorModuleIndex(apiPromise)
-      .then((moduleIndex: number) => {
-        this.moduleIndex = moduleIndex
-      })
-      .then(
-        () => true,
-        () => false
+    return events.some((eventRecord: EventRecord) => {
+      return (
+        !eventRecord.phase.asApplyExtrinsic.isEmpty &&
+        eventRecord.event.index.toHex() === SystemEvent.ExtrinsicFailed
       )
+    })
   }
-
-  private moduleIndex = -1
-  public readonly ready: Promise<boolean>
 
   /**
    * Get the extrinsic error from the transaction result.
@@ -59,16 +43,15 @@ export class ErrorHandler {
    * @param extrinsicResult The transaction result.
    * @returns The extrinsic error.
    */
-  public getExtrinsicError(
+  public static getExtrinsicError(
     extrinsicResult: SubmittableResult
   ): ExtrinsicError | null {
     const events: EventRecord[] = extrinsicResult.events || []
 
     const errorEvent = events.find((eventRecord: EventRecord) => {
-      const eventIndex = eventRecord.event.index
       return (
         !eventRecord.phase.asApplyExtrinsic.isEmpty &&
-        eventIndex[0] === this.moduleIndex
+        eventRecord.event.section === ErrorHandler.ERROR_MODULE_NAME
       )
     })
     if (errorEvent) {
@@ -82,25 +65,5 @@ export class ErrorHandler {
       log.warn('no error event found in transaction result')
     }
     return null
-  }
-
-  /**
-   * [STATIC] Derive the module index from the metadata module descriptor.
-   *
-   * @param apiPromise The api promise object from polkadot/api.
-   * @returns The error module index.
-   */
-  private static async getErrorModuleIndex(
-    apiPromise: ApiPromise
-  ): Promise<number> {
-    const { modules } = apiPromise.runtimeMetadata.asV11
-    const filtered: ModuleMetadataV11[] = modules.filter(
-      (mod: ModuleMetadataV11) => {
-        return !mod.events.isEmpty
-      }
-    )
-    return filtered
-      .map((m) => m.name.toString())
-      .indexOf(ErrorHandler.ERROR_MODULE_NAME)
   }
 }

--- a/src/errorhandling/ErrorHandler.ts
+++ b/src/errorhandling/ErrorHandler.ts
@@ -37,6 +37,25 @@ export function extrinsicFailed(extrinsicResult: SubmittableResult): boolean {
 }
 
 /**
+ * Checks if there is `SystemEvent.ExtrinsicSuccess` in the list of
+ * transaction events within the given `extrinsicResult`.
+ *
+ * @param extrinsicResult The result of a submission.
+ * @returns Whether the extrinsic submission succeeded.
+ */
+export function extrinsicSuccessful(
+  extrinsicResult: SubmittableResult
+): boolean {
+  const events: EventRecord[] = extrinsicResult.events || []
+  return events.some((eventRecord: EventRecord) => {
+    return (
+      !eventRecord.phase.asApplyExtrinsic.isEmpty &&
+      eventRecord.event.index.toHex() === SystemEvent.ExtrinsicSuccess
+    )
+  })
+}
+
+/**
  * Get the extrinsic error from the transaction result.
  *
  * @param extrinsicResult The transaction result.

--- a/src/errorhandling/ExtrinsicError.ts
+++ b/src/errorhandling/ExtrinsicError.ts
@@ -125,7 +125,7 @@ export const ERROR_ROOT_NOT_FOUND: ExtrinsicError = new ExtrinsicError(
 
 export const ERROR_UNKNOWN: ExtrinsicError = new ExtrinsicError(
   ErrorCode.ERROR_UNKNOWN,
-  'an unknown error ocurred'
+  'an unknown extrinsic error ocurred'
 )
 
 /**

--- a/src/errorhandling/SDKErrors.ts
+++ b/src/errorhandling/SDKErrors.ts
@@ -67,6 +67,7 @@ export enum ErrorCode {
   ERROR_MESSAGE_TYPE = 40005,
 
   ERROR_UNKNOWN = -1,
+  ERROR_TIMEOUT = -2,
 }
 
 export class SDKError extends Error {
@@ -525,6 +526,10 @@ export const ERROR_MESSAGE_TYPE: (
 
 export const ERROR_UNKNOWN: () => SDKError = () => {
   return new SDKError(ErrorCode.ERROR_UNKNOWN, 'an unknown error ocurred')
+}
+
+export const ERROR_TIMEOUT: () => SDKError = () => {
+  return new SDKError(ErrorCode.ERROR_TIMEOUT, 'operation timed out')
 }
 
 export const ERROR_PE_VERIFICATION: (

--- a/src/errorhandling/index.ts
+++ b/src/errorhandling/index.ts
@@ -3,4 +3,5 @@
  * @ignore
  */
 
+export * as ErrorHandler from './ErrorHandler'
 export * from './ExtrinsicError'

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -331,6 +331,6 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => submitSignedTx(tx, [IS_FINALIZED]))
+      .then((tx) => submitSignedTx(tx, IS_FINALIZED))
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -8,6 +8,7 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { KeyringPair } from '@polkadot/keyring/types'
 import * as u8aUtil from '@polkadot/util/u8a'
+import { AWAIT_FINALIZED } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import getCached from '../blockchainApiConnection'
 import {
@@ -328,6 +329,9 @@ export default class AttesterIdentity extends Identity {
       })
       await this.updateAccumulator(newAcc)
     }
-    await new Attestation(handle.attestation).revoke(this)
+    const blockchain = await getCached()
+    await new Attestation(handle.attestation)
+      .revoke(this)
+      .then((tx) => blockchain.submitTx(tx, AWAIT_FINALIZED))
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -8,7 +8,7 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { KeyringPair } from '@polkadot/keyring/types'
 import * as u8aUtil from '@polkadot/util/u8a'
-import { AWAIT_FINALIZED, submitTx } from '../blockchain/Blockchain'
+import { AWAIT_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import getCached from '../blockchainApiConnection'
 import {
@@ -331,6 +331,6 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => submitTx(tx, AWAIT_FINALIZED))
+      .then((tx) => submitSignedTx(tx, AWAIT_FINALIZED))
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -8,7 +8,7 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { KeyringPair } from '@polkadot/keyring/types'
 import * as u8aUtil from '@polkadot/util/u8a'
-import { AWAIT_FINALIZED } from '../blockchain/Blockchain'
+import { AWAIT_FINALIZED, submitTx } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import getCached from '../blockchainApiConnection'
 import {
@@ -329,9 +329,8 @@ export default class AttesterIdentity extends Identity {
       })
       await this.updateAccumulator(newAcc)
     }
-    const blockchain = await getCached()
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => blockchain.submitTx(tx, AWAIT_FINALIZED))
+      .then((tx) => submitTx(tx, AWAIT_FINALIZED))
   }
 }

--- a/src/identity/AttesterIdentity.ts
+++ b/src/identity/AttesterIdentity.ts
@@ -8,7 +8,7 @@
 import * as gabi from '@kiltprotocol/portablegabi'
 import { KeyringPair } from '@polkadot/keyring/types'
 import * as u8aUtil from '@polkadot/util/u8a'
-import { AWAIT_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
+import { IS_FINALIZED, submitSignedTx } from '../blockchain/Blockchain'
 import Attestation from '../attestation/Attestation'
 import getCached from '../blockchainApiConnection'
 import {
@@ -331,6 +331,6 @@ export default class AttesterIdentity extends Identity {
     }
     await new Attestation(handle.attestation)
       .revoke(this)
-      .then((tx) => submitSignedTx(tx, AWAIT_FINALIZED))
+      .then((tx) => submitSignedTx(tx, [IS_FINALIZED]))
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import RequestForAttestation, {
 } from './requestforattestation'
 
 export { SubmittableResult } from '@polkadot/api'
+export { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 export * from './errorhandling'
 export * from './messaging'
 // ---- Types, which define the most basic KILT objects ----

--- a/src/util/SubscriptionPromise.spec.ts
+++ b/src/util/SubscriptionPromise.spec.ts
@@ -1,0 +1,36 @@
+import {
+  Evaluator,
+  makeSubscriptionPromise,
+} from './SubscriptionPromise'
+
+const RESOLVE = 'resolve'
+const REJECT = 'reject'
+
+const RESOLVE_ON: Evaluator<string, string> = (value) => [
+  value === RESOLVE,
+  value,
+]
+const REJECT_ON: Evaluator<string, string> = (value) => [
+  value === REJECT,
+  value,
+]
+
+describe('function', () => {
+  it('resolves the promise', async () => {
+    const { promise, subscription } = makeSubscriptionPromise(
+      [RESOLVE_ON],
+      [REJECT_ON]
+    )
+    subscription(RESOLVE)
+    await expect(promise).resolves.toEqual(RESOLVE)
+  })
+
+  it('rejects the promise', async () => {
+    const { promise, subscription } = makeSubscriptionPromise(
+      [RESOLVE_ON],
+      [REJECT_ON]
+    )
+    subscription(REJECT)
+    await expect(promise).rejects.toEqual(REJECT)
+  })
+})

--- a/src/util/SubscriptionPromise.spec.ts
+++ b/src/util/SubscriptionPromise.spec.ts
@@ -4,19 +4,14 @@ import { Evaluator, makeSubscriptionPromise } from './SubscriptionPromise'
 const RESOLVE = 'resolve'
 const REJECT = 'reject'
 
-const RESOLVE_ON: Evaluator<string, string> = (value) => [
-  value === RESOLVE,
-  value,
-]
-const REJECT_ON: Evaluator<string, string> = (value) => [
-  value === REJECT,
-  value,
-]
+const RESOLVE_ON: Evaluator<string> = (value) => value === RESOLVE
+
+const REJECT_ON: Evaluator<string> = (value) => value === REJECT && 'error'
 
 it('rejects promise on timeout', async () => {
   const { promise, subscription } = makeSubscriptionPromise(
-    [RESOLVE_ON],
-    [REJECT_ON],
+    RESOLVE_ON,
+    REJECT_ON,
     500
   )
   subscription('something else')
@@ -25,8 +20,8 @@ it('rejects promise on timeout', async () => {
 
 it('resolves the promise', async () => {
   const { promise, subscription } = makeSubscriptionPromise(
-    [RESOLVE_ON],
-    [REJECT_ON]
+    RESOLVE_ON,
+    REJECT_ON
   )
   subscription(RESOLVE)
   await expect(promise).resolves.toEqual(RESOLVE)
@@ -34,9 +29,9 @@ it('resolves the promise', async () => {
 
 it('rejects the promise', async () => {
   const { promise, subscription } = makeSubscriptionPromise(
-    [RESOLVE_ON],
-    [REJECT_ON]
+    RESOLVE_ON,
+    REJECT_ON
   )
   subscription(REJECT)
-  await expect(promise).rejects.toEqual(REJECT)
+  await expect(promise).rejects.toEqual('error')
 })

--- a/src/util/SubscriptionPromise.spec.ts
+++ b/src/util/SubscriptionPromise.spec.ts
@@ -1,7 +1,5 @@
-import {
-  Evaluator,
-  makeSubscriptionPromise,
-} from './SubscriptionPromise'
+import { ERROR_TIMEOUT } from '../errorhandling/SDKErrors'
+import { Evaluator, makeSubscriptionPromise } from './SubscriptionPromise'
 
 const RESOLVE = 'resolve'
 const REJECT = 'reject'
@@ -15,22 +13,30 @@ const REJECT_ON: Evaluator<string, string> = (value) => [
   value,
 ]
 
-describe('function', () => {
-  it('resolves the promise', async () => {
-    const { promise, subscription } = makeSubscriptionPromise(
-      [RESOLVE_ON],
-      [REJECT_ON]
-    )
-    subscription(RESOLVE)
-    await expect(promise).resolves.toEqual(RESOLVE)
-  })
+it('rejects promise on timeout', async () => {
+  const { promise, subscription } = makeSubscriptionPromise(
+    [RESOLVE_ON],
+    [REJECT_ON],
+    500
+  )
+  subscription('something else')
+  await expect(promise).rejects.toThrow(ERROR_TIMEOUT())
+})
 
-  it('rejects the promise', async () => {
-    const { promise, subscription } = makeSubscriptionPromise(
-      [RESOLVE_ON],
-      [REJECT_ON]
-    )
-    subscription(REJECT)
-    await expect(promise).rejects.toEqual(REJECT)
-  })
+it('resolves the promise', async () => {
+  const { promise, subscription } = makeSubscriptionPromise(
+    [RESOLVE_ON],
+    [REJECT_ON]
+  )
+  subscription(RESOLVE)
+  await expect(promise).resolves.toEqual(RESOLVE)
+})
+
+it('rejects the promise', async () => {
+  const { promise, subscription } = makeSubscriptionPromise(
+    [RESOLVE_ON],
+    [REJECT_ON]
+  )
+  subscription(REJECT)
+  await expect(promise).rejects.toEqual(REJECT)
 })

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -1,33 +1,55 @@
 import { ERROR_TIMEOUT } from '../errorhandling/SDKErrors'
 
-export interface Evaluator<I, O> {
-  (value: I): [boolean, O]
+/**
+ * A function that determines whether a new incoming value should reject or resolve the promise.
+ *
+ * @param value A new incoming subscription value.
+ * @returns A truthy value if the promise should be rejected/resolved on this value. Return value is used
+ * as the reason in a rejected promise.
+ */
+export interface Evaluator<SubscriptionType> {
+  (value: SubscriptionType): any
 }
 
-export function makeSubscriptionPromise<SubscriptionType, PromiseType>(
-  resolveOn: Array<Evaluator<SubscriptionType, PromiseType>>,
-  rejectOn: Array<Evaluator<SubscriptionType, any>>,
+/**
+ * Helps building a promise associated to a subscription callback through which updates can be pushed to the promise.
+ * This promise is resolved with the value of latest update when a resolution criterion is met.
+ * It is rejected with a custom error/reason if a rejection criterion is met or on timeout (optional). Rejection takes precedent.
+ *
+ * @param resolveOn Resolution criterion. A function that evaluates an incoming update from the subscription.
+ * If it returns a truthy value, the promise is resolved with the value of the latest update.
+ * @param rejectOn Rejection criterion. A function that evaluates an incoming update from the subscription.
+ * If it returns a truthy value, this value is used as rejection reason.
+ * @param timeout Timeout in ms. If set, the promise will reject if not resolved before the time is up.
+ * @returns An object containing both a subscription callback
+ * and a promise which resolves or rejects depending on the values pushed to the callback.
+ */
+export function makeSubscriptionPromise<SubscriptionType>(
+  resolveOn: Evaluator<SubscriptionType>,
+  rejectOn?: Evaluator<SubscriptionType>,
   timeout?: number
 ): {
-  promise: Promise<PromiseType>
+  promise: Promise<SubscriptionType>
   subscription: (value: SubscriptionType) => void
 } {
-  let resolve: (value: PromiseType) => void
+  let resolve: (value: SubscriptionType) => void
   let reject: (reason: any) => void
-  const promise = new Promise<PromiseType>((res, rej) => {
+  const promise = new Promise<SubscriptionType>((res, rej) => {
     resolve = res
     reject = rej
   })
-  const subscription: (value: SubscriptionType) => void = (value) => {
-    rejectOn.forEach((evaluator) => {
-      const [rejected, rejectValue] = evaluator(value)
-      if (rejected) reject(rejectValue)
-    })
-    resolveOn.forEach((evaluator) => {
-      const [resolved, resolveValue] = evaluator(value)
-      if (resolved) resolve(resolveValue)
-    })
-  }
+  const subscription: (value: SubscriptionType) => void =
+    typeof rejectOn === 'function'
+      ? (value) => {
+          const rejectedReason = rejectOn(value)
+          if (rejectedReason) reject(rejectedReason)
+          const resolved = resolveOn(value)
+          if (resolved) resolve(value)
+        }
+      : (value) => {
+          const resolved = resolveOn(value)
+          if (resolved) resolve(value)
+        }
   if (timeout)
     setTimeout(() => {
       reject(ERROR_TIMEOUT())
@@ -35,17 +57,24 @@ export function makeSubscriptionPromise<SubscriptionType, PromiseType>(
   return { promise, subscription }
 }
 
-export function makeSubscriptionPromiseMulti<SubscriptionType, PromiseType>(
+/**
+ * A wrapper around [[makeSubscriptionPromise]] that helps building multiple promises which listen to the same subscription.
+ *
+ * @param args An array of objects each of which provides the arguments for creation of one promise.
+ * @returns An object containing both a subscription callback
+ * and an array of promises which resolve or reject depending on the values pushed to the callback.
+ */
+export function makeSubscriptionPromiseMulti<SubscriptionType>(
   args: Array<{
-    resolveOn: Array<Evaluator<SubscriptionType, PromiseType>>
-    rejectOn: Array<Evaluator<SubscriptionType, any>>
+    resolveOn: Evaluator<SubscriptionType>
+    rejectOn?: Evaluator<SubscriptionType>
     timeout?: number
   }>
 ): {
-  promises: Array<Promise<PromiseType>>
+  promises: Array<Promise<SubscriptionType>>
   subscription: (value: SubscriptionType) => void
 } {
-  const promises: Array<Promise<PromiseType>> = []
+  const promises: Array<Promise<SubscriptionType>> = []
   let subscriptions: Array<(value: SubscriptionType) => void>
   args.forEach(({ resolveOn, rejectOn, timeout }) => {
     const { promise, subscription } = makeSubscriptionPromise(

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -34,3 +34,30 @@ export function makeSubscriptionPromise<SubscriptionType, PromiseType>(
     }, timeout)
   return { promise, subscription }
 }
+
+export function makeSubscriptionPromiseMulti<SubscriptionType, PromiseType>(
+  args: Array<{
+    resolveOn: Array<Evaluator<SubscriptionType, PromiseType>>
+    rejectOn: Array<Evaluator<SubscriptionType, any>>
+    timeout?: number
+  }>
+): {
+  promises: Array<Promise<PromiseType>>
+  subscription: (value: SubscriptionType) => void
+} {
+  const promises: Array<Promise<PromiseType>> = []
+  let subscriptions: Array<(value: SubscriptionType) => void>
+  args.forEach(({ resolveOn, rejectOn, timeout }) => {
+    const { promise, subscription } = makeSubscriptionPromise(
+      resolveOn,
+      rejectOn,
+      timeout
+    )
+    promises.push(promise)
+    subscriptions.push(subscription)
+  })
+  const subscription = (value: SubscriptionType): void => {
+    subscriptions.forEach((s) => s(value))
+  }
+  return { promises, subscription }
+}

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -1,0 +1,29 @@
+export interface Evaluator<I, O> {
+  (value: I): [boolean, O]
+}
+
+export function makeSubscriptionPromise<SubscriptionType, PromiseType>(
+  resolveOn: Array<Evaluator<SubscriptionType, PromiseType>>,
+  rejectOn: Array<Evaluator<SubscriptionType, any>>
+): {
+  promise: Promise<PromiseType>
+  subscription: (value: SubscriptionType) => void
+} {
+  let resolve: (value: PromiseType) => void
+  let reject: (reason: any) => void
+  const promise = new Promise<PromiseType>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  const subscription: (value: SubscriptionType) => void = (value) => {
+    rejectOn.forEach((evaluator) => {
+      const [rejected, rejectValue] = evaluator(value)
+      if (rejected) reject(rejectValue)
+    })
+    resolveOn.forEach((evaluator) => {
+      const [resolved, resolveValue] = evaluator(value)
+      if (resolved) resolve(resolveValue)
+    })
+  }
+  return { promise, subscription }
+}

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -75,7 +75,7 @@ export function makeSubscriptionPromiseMulti<SubscriptionType>(
   subscription: (value: SubscriptionType) => void
 } {
   const promises: Array<Promise<SubscriptionType>> = []
-  let subscriptions: Array<(value: SubscriptionType) => void>
+  const subscriptions: Array<(value: SubscriptionType) => void> = []
   args.forEach(({ resolveOn, rejectOn, timeout }) => {
     const { promise, subscription } = makeSubscriptionPromise(
       resolveOn,

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -1,10 +1,13 @@
+import { ERROR_TIMEOUT } from '../errorhandling/SDKErrors'
+
 export interface Evaluator<I, O> {
   (value: I): [boolean, O]
 }
 
 export function makeSubscriptionPromise<SubscriptionType, PromiseType>(
   resolveOn: Array<Evaluator<SubscriptionType, PromiseType>>,
-  rejectOn: Array<Evaluator<SubscriptionType, any>>
+  rejectOn: Array<Evaluator<SubscriptionType, any>>,
+  timeout?: number
 ): {
   promise: Promise<PromiseType>
   subscription: (value: SubscriptionType) => void
@@ -25,5 +28,9 @@ export function makeSubscriptionPromise<SubscriptionType, PromiseType>(
       if (resolved) resolve(resolveValue)
     })
   }
+  if (timeout)
+    setTimeout(() => {
+      reject(ERROR_TIMEOUT())
+    }, timeout)
   return { promise, subscription }
 }

--- a/src/util/SubscriptionPromise.ts
+++ b/src/util/SubscriptionPromise.ts
@@ -8,7 +8,7 @@ import { ERROR_TIMEOUT } from '../errorhandling/SDKErrors'
  * as the reason in a rejected promise.
  */
 export interface Evaluator<SubscriptionType> {
-  (value: SubscriptionType): any
+  (value: SubscriptionType): boolean | any
 }
 
 /**


### PR DESCRIPTION
### fixes KILTProtocol/ticket#513
### fixes KILTProtocol/ticket#691

With this change, functions that require blockchain writes (store Attestation / Ctype, revoke Attestation, make transfer, etc.) will no longer submit the transaction, but only prepare it. A signed SubmittableExtrinsic is returned instead, which the end user then submits by calling its `send()` method (optionally attaching a listener to it) or by passing it to the `submitSignedTx()` helper function, which allows you to promisify and await any tx status change (e.g. `Finalised`, `inBlock`).
This also significantly speeds up integration testing, as we now await only `inBlock`, which is 3 times faster than awaiting finalisation.

We in part solve issues here that we wanted the tx subscription handler for and allow people to implement their own, so this may be closed as well - we could still think about publishing what we already created though, as a goodie or template.

As of now, anything in the `/actor` module will still await finalisation, both because those are fairly high-level and because KILT integrates with portable gabi at this point - in order to change this, we would probably have to make changes there as well. Input on how to handle this issue is appreciated.

## How to test:
unit & integration tests

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
