### PR TITLE
Unit denomination and conversion

### DIFF
--- a/src/__integrationtests__/utils.ts
+++ b/src/__integrationtests__/utils.ts
@@ -9,9 +9,6 @@ import CType from '../ctype/CType'
 import { getOwner } from '../ctype/CType.chain'
 import Identity from '../identity/Identity'
 
-// FIXME: check with weights
-// export const GAS = new BN(1_000_000)
-export const GAS = new BN(125_000_000)
 export const MIN_TRANSACTION = new BN(100_000_000)
 export const ENDOWMENT = MIN_TRANSACTION.mul(new BN(100))
 

--- a/src/balance/Balance.chain.ts
+++ b/src/balance/Balance.chain.ts
@@ -15,6 +15,7 @@ import BN from 'bn.js'
 import { getCached } from '../blockchainApiConnection'
 import Identity from '../identity/Identity'
 import IPublicIdentity from '../types/PublicIdentity'
+import BalanceUtils from './Balance.utils'
 
 /**
  * Fetches the current balance of the account with [accountAddress].
@@ -93,7 +94,8 @@ export async function listenToBalanceChanges(
  *
  * @param identity Identity to use for token transfer.
  * @param accountAddressTo Address of the receiver account.
- * @param amount Amount of Femto-Kilt (1e-15) to transfer.
+ * @param amount Amount of Units to transfer.
+ * @param exponent Magnitude of the amount.
  * @returns Promise containing the transaction status.
  *
  * @example
@@ -117,9 +119,16 @@ export async function listenToBalanceChanges(
 export async function makeTransfer(
   identity: Identity,
   accountAddressTo: IPublicIdentity['address'],
-  amount: BN
+  amount: BN,
+  exponent = -15
 ): Promise<SubmittableResult> {
   const blockchain = await getCached()
-  const transfer = blockchain.api.tx.balances.transfer(accountAddressTo, amount)
+  const transfer = blockchain.api.tx.balances.transfer(
+    accountAddressTo,
+    BalanceUtils.convertToTxUnit(
+      amount,
+      (exponent >= 0 ? 1 : -1) * Math.floor(Math.abs(exponent))
+    )
+  )
   return blockchain.submitTx(identity, transfer)
 }

--- a/src/balance/Balance.chain.ts
+++ b/src/balance/Balance.chain.ts
@@ -90,12 +90,12 @@ export async function listenToBalanceChanges(
 
 /**
  * Transfer Kilt [amount] tokens to [toAccountAddress] using the given [[Identity]].
- * <B>Note that balance amount is in Femto-Kilt (1e-15) and must be translated to Kilt-Coin</B>.
+ * <B>Note that the value of the transferred currency and the balance amount reported by the chain is in Femto-Kilt (1e-15), and must be translated to Kilt-Coin</B>.
  *
  * @param identity Identity to use for token transfer.
  * @param accountAddressTo Address of the receiver account.
  * @param amount Amount of Units to transfer.
- * @param exponent Magnitude of the amount.
+ * @param exponent Magnitude of the amount. Default magnitude of Femto-Kilt.
  * @returns Promise containing the transaction status.
  *
  * @example
@@ -123,12 +123,13 @@ export async function makeTransfer(
   exponent = -15
 ): Promise<SubmittableResult> {
   const blockchain = await getCached()
+  const cleanExponent =
+    (exponent >= 0 ? 1 : -1) * Math.floor(Math.abs(exponent))
   const transfer = blockchain.api.tx.balances.transfer(
     accountAddressTo,
-    BalanceUtils.convertToTxUnit(
-      amount,
-      (exponent >= 0 ? 1 : -1) * Math.floor(Math.abs(exponent))
-    )
+    cleanExponent === -15
+      ? amount
+      : BalanceUtils.convertToTxUnit(amount, cleanExponent)
   )
   return blockchain.submitTx(identity, transfer)
 }

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -17,6 +17,8 @@ const BALANCE = 42
 const FEE = 30
 
 describe('Balance', () => {
+  let alice: Identity
+  let bob: Identity
   const blockchainApi = require('../blockchainApiConnection/BlockchainApiConnection')
     .__mocked_api
 
@@ -42,9 +44,11 @@ describe('Balance', () => {
       return accountInfo(BALANCE - FEE)
     }
   )
-
+  beforeAll(async () => {
+    alice = await Identity.buildFromURI('//Alice')
+    bob = await Identity.buildFromURI('//Bob')
+  })
   it('should listen to balance changes', async (done) => {
-    const bob = await Identity.buildFromURI('//Bob')
     const listener = (account: string, balance: BN, change: BN): void => {
       expect(account).toBe(bob.address)
       expect(balance.toNumber()).toBe(BALANCE)
@@ -59,16 +63,11 @@ describe('Balance', () => {
   })
 
   it('should make transfer', async () => {
-    const alice = await Identity.buildFromURI('//Alice')
-    const bob = await Identity.buildFromURI('//Bob')
-
     const status = await makeTransfer(alice, bob.address, new BN(100))
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })
   it('should make transfer of amount with arbitrary exponent', async () => {
-    const alice = await Identity.buildFromURI('//Alice')
-    const bob = await Identity.buildFromURI('//Bob')
     const amount = new BN(10)
     const exponent = -6
     const expectedAmount = BalanceUtils.convertToTxUnit(

--- a/src/balance/Balance.spec.ts
+++ b/src/balance/Balance.spec.ts
@@ -9,6 +9,7 @@ import {
   makeTransfer,
 } from './Balance.chain'
 import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
+import BalanceUtils from './Balance.utils'
 
 jest.mock('../blockchainApiConnection/BlockchainApiConnection')
 
@@ -62,6 +63,23 @@ describe('Balance', () => {
     const bob = await Identity.buildFromURI('//Bob')
 
     const status = await makeTransfer(alice, bob.address, new BN(100))
+    expect(status).toBeInstanceOf(SubmittableResult)
+    expect(status.isFinalized).toBeTruthy()
+  })
+  it('should make transfer of amount with arbitrary exponent', async () => {
+    const alice = await Identity.buildFromURI('//Alice')
+    const bob = await Identity.buildFromURI('//Bob')
+    const amount = new BN(10)
+    const exponent = -6
+    const expectedAmount = BalanceUtils.convertToTxUnit(
+      amount,
+      (exponent >= 0 ? 1 : -1) * Math.floor(Math.abs(exponent))
+    )
+    const status = await makeTransfer(alice, bob.address, amount, exponent)
+    expect(blockchainApi.tx.balances.transfer).toHaveBeenCalledWith(
+      bob.address,
+      expectedAmount
+    )
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })

--- a/src/balance/Balance.utils.spec.ts
+++ b/src/balance/Balance.utils.spec.ts
@@ -1,0 +1,95 @@
+import BN from 'bn.js'
+import {
+  formatKiltBalance,
+  convertToTxUnit,
+  asFemtoKilt,
+  TRANSACTION_FEE,
+} from './Balance.utils'
+
+describe('formatKiltBalance', () => {
+  const TESTVALUE = new BN('123456789000')
+  const baseValue = new BN('1')
+  it('formats the given balance', async () => {
+    expect(formatKiltBalance(TESTVALUE)).toEqual('123.456 micro KILT')
+    expect(formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(3))))).toEqual(
+      '1.000 pico KILT'
+    )
+    expect(formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(6))))).toEqual(
+      '1.000 nano KILT'
+    )
+    expect(formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(9))))).toEqual(
+      '1.000 micro KILT'
+    )
+    expect(
+      formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(12))))
+    ).toEqual('1.000 milli KILT')
+    expect(
+      formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(15))))
+    ).toEqual('1.000 KILT')
+    expect(
+      formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(18))))
+    ).toEqual('1.000 Kilo KILT')
+    expect(
+      formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(21))))
+    ).toEqual('1.000 Mega KILT')
+    expect(
+      formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(24))))
+    ).toEqual('1.000 Giga KILT')
+    expect(
+      formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(27))))
+    ).toEqual('1.000 Tera KILT')
+  })
+})
+describe('convertToTxUnit', () => {
+  it('converts given value with given power to femto KILT', () => {
+    expect(new BN(convertToTxUnit(new BN(1), -15).toString())).toEqual(
+      new BN(1)
+    )
+    expect(new BN(convertToTxUnit(new BN(1), -12).toString())).toEqual(
+      new BN('1000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), -9).toString())).toEqual(
+      new BN('1000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), -6).toString())).toEqual(
+      new BN('1000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), -3).toString())).toEqual(
+      new BN('1000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 0).toString())).toEqual(
+      new BN('1000000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 3).toString())).toEqual(
+      new BN('1000000000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 6).toString())).toEqual(
+      new BN('1000000000000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 9).toString())).toEqual(
+      new BN('1000000000000000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 12).toString())).toEqual(
+      new BN('1000000000000000000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 15).toString())).toEqual(
+      new BN('1000000000000000000000000000000')
+    )
+    expect(new BN(convertToTxUnit(new BN(1), 18).toString())).toEqual(
+      new BN('1000000000000000000000000000000000')
+    )
+  })
+})
+describe('asFemtoKilt', () => {
+  it('converts whole KILT to femtoKilt using convertToTxUnit', () => {
+    expect(new BN(asFemtoKilt(new BN(1000)).toString())).toEqual(
+      new BN('1000000000000000000')
+    )
+  })
+})
+
+describe('TRANSACTION_FEE', () => {
+  it('equals 125 nano KILT', () => {
+    expect(formatKiltBalance(TRANSACTION_FEE)).toEqual('125.000 nano KILT')
+  })
+})

--- a/src/balance/Balance.utils.ts
+++ b/src/balance/Balance.utils.ts
@@ -10,14 +10,11 @@ import { formatBalance } from '@polkadot/util'
 export const KILT_COIN = new BN(1)
 
 export function formatKiltBalance(amount: BN): string {
-  return formatBalance(
-    amount,
-    {
-      withSiFull: true,
-      withUnit: 'KILT',
-    },
-    15
-  )
+  return formatBalance(amount, {
+    decimals: 15,
+    withSiFull: true,
+    withUnit: 'KILT',
+  })
 }
 
 export function convertToTxUnit(balance: BN, power: number): BN {

--- a/src/balance/Balance.utils.ts
+++ b/src/balance/Balance.utils.ts
@@ -8,13 +8,6 @@ import BN from 'bn.js'
 import { formatBalance } from '@polkadot/util'
 
 export const KILT_COIN = new BN(1)
-export const KILT_FEMTO_COIN = new BN('1000000000000000')
-
-export const TRANSACTION_FEE = KILT_COIN.divn(1000000000).muln(125)
-
-export const MIN_BALANCE = KILT_COIN.muln(1)
-
-export const ENDOWMENT = KILT_COIN.muln(30)
 
 export function formatKiltBalance(amount: BN): string {
   return formatBalance(
@@ -27,20 +20,19 @@ export function formatKiltBalance(amount: BN): string {
   )
 }
 
-export function asFemtoKilt(balance: BN): BN {
-  return new BN(balance).mul(KILT_FEMTO_COIN)
-}
-
 export function convertToTxUnit(balance: BN, power: number): BN {
   return new BN(balance).mul(new BN(10).pow(new BN(15 + power)))
 }
 
+export function asFemtoKilt(balance: BN): BN {
+  return convertToTxUnit(balance, 0)
+}
+
+export const TRANSACTION_FEE = convertToTxUnit(new BN(125), -9)
+
 export default {
   KILT_COIN,
-  KILT_FEMTO_COIN,
   TRANSACTION_FEE,
-  MIN_BALANCE,
-  ENDOWMENT,
   formatKiltBalance,
   asFemtoKilt,
   convertToTxUnit,

--- a/src/balance/Balance.utils.ts
+++ b/src/balance/Balance.utils.ts
@@ -1,0 +1,47 @@
+/**
+ * @packageDocumentation
+ * @module BalanceUtils
+ * @preferred
+ */
+
+import BN from 'bn.js'
+import { formatBalance } from '@polkadot/util'
+
+export const KILT_COIN = new BN(1)
+export const KILT_FEMTO_COIN = new BN('1000000000000000')
+
+export const TRANSACTION_FEE = KILT_COIN.divn(1000000000).muln(125)
+
+export const MIN_BALANCE = KILT_COIN.muln(1)
+
+export const ENDOWMENT = KILT_COIN.muln(30)
+
+export function formatKiltBalance(amount: BN): string {
+  return formatBalance(
+    amount,
+    {
+      withSiFull: true,
+      withUnit: 'KILT',
+    },
+    15
+  )
+}
+
+export function asFemtoKilt(balance: BN): BN {
+  return new BN(balance).mul(KILT_FEMTO_COIN)
+}
+
+export function convertToTxUnit(balance: BN, power: number): BN {
+  return new BN(balance).mul(new BN(10).pow(new BN(15 + power)))
+}
+
+export default {
+  KILT_COIN,
+  KILT_FEMTO_COIN,
+  TRANSACTION_FEE,
+  MIN_BALANCE,
+  ENDOWMENT,
+  formatKiltBalance,
+  asFemtoKilt,
+  convertToTxUnit,
+}

--- a/src/balance/index.ts
+++ b/src/balance/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './Balance.chain'
+export * from './Balance.utils'

--- a/src/balance/index.ts
+++ b/src/balance/index.ts
@@ -3,5 +3,8 @@
  * @ignore
  */
 
-export * from './Balance.chain'
-export * from './Balance.utils'
+import BalanceUtils from './Balance.utils'
+import * as Balance from './Balance.chain'
+
+export { Balance, BalanceUtils }
+export default Balance

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Accumulator, CombinedPresentation } from '@kiltprotocol/portablegabi'
 import { Attester, Claimer, Verifier } from './actor'
 import Attestation, { AttestationUtils } from './attestation'
 import AttestedClaim, { AttestedClaimUtils } from './attestedclaim'
-import * as Balance from './balance'
+import { Balance, BalanceUtils } from './balance'
 import Blockchain, { IBlockchainApi } from './blockchain'
 import * as BlockchainApiConnection from './blockchainApiConnection'
 import Claim, { ClaimUtils } from './claim'
@@ -66,6 +66,7 @@ export {
   IBlockchainApi,
   BlockchainApiConnection,
   Balance,
+  BalanceUtils,
   Crypto,
   Identity,
   AttesterIdentity,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#632

Adds `Balance.utils.ts` to the sdk to handle unit denomination and conversion in a central place instead of our separate components.

## How to test:

Create local instance, start demo client and services, add faucet and transfer funds to test if the portrayal of units is correct.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
