### PR TITLE
fix claim error check

### DIFF
--- a/src/claim/Claim.spec.ts
+++ b/src/claim/Claim.spec.ts
@@ -56,6 +56,16 @@ describe('Claim', () => {
     expect(Claim.fromClaim(claimObj, testCType.schema)).toEqual(claim)
   })
 
+  it('allows falsy claim values', () => {
+    const claimWithFalsy: IClaim = {
+      ...claim,
+      contents: {
+        name: '',
+      },
+    }
+    expect(() => ClaimUtils.errorCheck(claimWithFalsy)).not.toThrow()
+  })
+
   it('compresses and decompresses the Claim object', () => {
     expect(ClaimUtils.compress(claim)).toEqual(compressedClaim)
 

--- a/src/claim/Claim.utils.ts
+++ b/src/claim/Claim.utils.ts
@@ -27,11 +27,11 @@ export function errorCheck(input: IClaim): void {
     validateAddress(input.owner, 'Claim owner')
   }
   if (input.contents !== undefined) {
-    Object.entries(input.contents).forEach((entry) => {
+    Object.entries(input.contents).forEach(([key, value]) => {
       if (
-        !entry[0] ||
-        !entry[1] ||
-        !['string', 'number', 'boolean', 'object'].includes(typeof entry[1])
+        !key ||
+        typeof key !== 'string' ||
+        !['string', 'number', 'boolean', 'object'].includes(typeof value)
       ) {
         throw SDKErrors.ERROR_CLAIM_CONTENTS_MALFORMED()
       }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#781
Fixes Claim errorCheck function to allow falsy values in Claim contents like `0`, `false`, `''`.
Improves readability as well.

## How to test:
create Claim containing the above values.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
