### PR TITLE
Proof of Concept: Exporting KILT credentials to VC format

### DIFF
--- a/src/util/toVerifiableCredential.spec.ts
+++ b/src/util/toVerifiableCredential.spec.ts
@@ -1,0 +1,160 @@
+import { Attestation, IClaim } from '..'
+import AttestedClaim from '../attestedclaim'
+import CType from '../ctype'
+import attClaimToVC, {
+  makeRevealPropertiesProof,
+  verifyAttestedProof,
+  verifyRevealPropertyProof,
+  verifySelfSignedProof,
+} from './toVerifiableCredential'
+
+jest.mock('../attestation/Attestation.chain', () => {
+  return { query: jest.fn() }
+})
+
+const ctype = CType.fromCType({
+  schema: {
+    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    title: 'AntiCov',
+    properties: {
+      photo: {
+        type: 'string',
+      },
+    },
+    type: 'object',
+    $id:
+      'kilt:ctype:0x2ea0486bf4a62423c644fb127226974a8c971da5ddd27ead23b9189161e8bcea',
+  },
+  owner: '5HDp5xMH6Xe5cNGczpQQPkpdEGXpZGuYeQDK4GseKkMVbQup',
+  hash: '0x2ea0486bf4a62423c644fb127226974a8c971da5ddd27ead23b9189161e8bcea',
+})
+
+const credential = AttestedClaim.fromAttestedClaim({
+  request: {
+    claim: {
+      cTypeHash:
+        '0x2ea0486bf4a62423c644fb127226974a8c971da5ddd27ead23b9189161e8bcea',
+      contents: {
+        photo: '<not available>',
+      },
+      owner: '5DWXHLumDybaDHL1KAdXHSAsevJn397xXh7SitvdJmGhBvA2',
+    },
+    claimOwner: {
+      nonce: '5cdeff3d-0e71-484c-83da-77f0db84a0a5',
+      hash:
+        '0xa5c40addbccab6053540a4c9dd75e4e0b885776d86e0f6aeaad2f2d2d789dacc',
+    },
+    cTypeHash: {
+      nonce: '3710db09-4d61-421e-8d37-5d6eb68d762f',
+      hash:
+        '0x90364302f3b6ccfa50f3d384ec0ab6369711e13298ba4a5316d7e2addd5647b2',
+    },
+    legitimations: [],
+    delegationId:
+      '0xca731f3697e9d78bbb908a72f59c4515978890336e0ea14df620dae13328d50d',
+    claimHashTree: {
+      photo: {
+        nonce: '0a0e48d8-7b35-4889-864c-4b5c2c19a7a5',
+        hash:
+          '0xde765261eada7d3c3de6e12b382ac3d4d80d9e7d668dfda0df7e69160fa5a2ec',
+      },
+    },
+    rootHash:
+      '0x7fa0fce3f6f526c769dbee5973cc75a5edfecef071766c3e1351d9aac4db945c',
+    claimerSignature:
+      '0x0036bed7fa5e8bdff6fea08f106f2fabb9800bc71a7894bc151849bf2477c9b2ccd129b7a16693b08606abf8e4bc1af830c25de1dfa32c3e1697710ecf92eb1607',
+    privacyEnhancement: null,
+  },
+  attestation: {
+    claimHash:
+      '0x7fa0fce3f6f526c769dbee5973cc75a5edfecef071766c3e1351d9aac4db945c',
+    cTypeHash:
+      '0x2ea0486bf4a62423c644fb127226974a8c971da5ddd27ead23b9189161e8bcea',
+    delegationId:
+      '0xca731f3697e9d78bbb908a72f59c4515978890336e0ea14df620dae13328d50d',
+    owner: '5D4FoyWD1y4Zn2UM4PiG8PAzmamUbCehpfFChiqyCXD7E2B4',
+    revoked: false,
+  },
+})
+
+it('exports credential to VC', () => {
+  expect(attClaimToVC(credential)).toMatchObject({
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential'],
+    credentialSubject: {
+      protected: {
+        claim: {
+          cTypeHash:
+            '0x90364302f3b6ccfa50f3d384ec0ab6369711e13298ba4a5316d7e2addd5647b2',
+          contents: {
+            photo:
+              '0xde765261eada7d3c3de6e12b382ac3d4d80d9e7d668dfda0df7e69160fa5a2ec',
+          },
+          owner:
+            '0xa5c40addbccab6053540a4c9dd75e4e0b885776d86e0f6aeaad2f2d2d789dacc',
+        },
+        delegationId:
+          '0xca731f3697e9d78bbb908a72f59c4515978890336e0ea14df620dae13328d50d',
+        legitimations: [],
+      },
+    },
+    id: '0x7fa0fce3f6f526c769dbee5973cc75a5edfecef071766c3e1351d9aac4db945c',
+    issuanceDate: expect.any(String),
+    issuer: 'did:kilt:5D4FoyWD1y4Zn2UM4PiG8PAzmamUbCehpfFChiqyCXD7E2B4',
+    nonTransferable: true,
+  })
+})
+
+describe('proofs', () => {
+  const VC = attClaimToVC(credential)
+
+  it('it verifies self-signed proof', () => {
+    expect(verifySelfSignedProof(VC, VC.proof[0])).toMatchObject({
+      verified: true,
+    })
+  })
+
+  it('it verifies credential with all properties revealed', () => {
+    const revealAll = makeRevealPropertiesProof(
+      credential.request.claim,
+      credential.request
+    )
+    expect(verifyRevealPropertyProof(VC, revealAll)).toMatchObject({
+      verified: true,
+    })
+  })
+
+  it('it verifies credential and schema', () => {
+    const revealAll = makeRevealPropertiesProof(
+      credential.request.claim,
+      credential.request
+    )
+    expect(verifyRevealPropertyProof(VC, revealAll, ctype)).toMatchObject({
+      verified: true,
+    })
+  })
+
+  it('it verifies credential with selected properties revealed', () => {
+    const { request } = credential
+    const claim: Partial<IClaim> = {
+      owner: request.claim.owner,
+      contents: { photo: request.claim.contents.photo },
+    }
+    const revealSome = makeRevealPropertiesProof(claim, request)
+    expect(verifyRevealPropertyProof(VC, revealSome)).toMatchObject({
+      verified: true,
+    })
+  })
+
+  describe('on-chain proof', () => {
+    require('../attestation/Attestation.chain').query.mockResolvedValue(
+      Attestation.fromAttestation(credential.attestation)
+    )
+
+    it('verifies attestation proof', async () => {
+      await expect(
+        verifyAttestedProof(VC, VC.proof[1])
+      ).resolves.toMatchObject({ verified: true })
+    })
+  })
+})

--- a/src/util/toVerifiableCredential.spec.ts
+++ b/src/util/toVerifiableCredential.spec.ts
@@ -105,6 +105,19 @@ it('exports credential to VC', () => {
   })
 })
 
+it('exports includes ctype as schema', () => {
+  expect(attClaimToVC(credential, undefined, ctype)).toMatchObject({
+    credentialSchema: {
+      id:
+        'kilt:ctype:0x2ea0486bf4a62423c644fb127226974a8c971da5ddd27ead23b9189161e8bcea',
+      name: 'AntiCov',
+      type: 'JsonSchemaValidator2018',
+      author: '5HDp5xMH6Xe5cNGczpQQPkpdEGXpZGuYeQDK4GseKkMVbQup',
+      schema: ctype.schema,
+    },
+  })
+})
+
 describe('proofs', () => {
   const VC = attClaimToVC(credential)
 
@@ -125,11 +138,18 @@ describe('proofs', () => {
   })
 
   it('it verifies credential and schema', () => {
+    const VCWithSchema = attClaimToVC(credential, undefined, ctype)
     const revealAll = makeRevealPropertiesProof(
       credential.request.claim,
       credential.request
     )
-    expect(verifyRevealPropertyProof(VC, revealAll, ctype)).toMatchObject({
+    expect(
+      verifyRevealPropertyProof(
+        VC,
+        revealAll,
+        VCWithSchema.credentialSchema?.schema
+      )
+    ).toMatchObject({
       verified: true,
     })
   })

--- a/src/util/toVerifiableCredential.ts
+++ b/src/util/toVerifiableCredential.ts
@@ -1,0 +1,188 @@
+import { decodeAddress } from '@polkadot/keyring'
+import { u8aToHex } from '@polkadot/util'
+import { IDidDocumentPublicKey } from '../did/Did'
+import { IAttestedClaim, Did, IPartialClaim } from '..'
+
+/**
+ * Constant for default context.
+ */
+const DEFAULT_VERIFIABLECREDENTIAL_CONTEXT =
+  'https://www.w3.org/2018/credentials/v1'
+/**
+ * Constant for default type.
+ */
+const DEFAULT_VERIFIABLECREDENTIAL_TYPE = 'VerifiableCredential'
+/**
+ * Constant for default type.
+ */
+// const DEFAULT_VERIFIABLEPRESENTATION_TYPE = 'VerifiablePresentation'
+
+const KILT_SELF_SIGNED_PROOF_TYPE = 'KILTSelfSigned2020'
+const KILT_ATTESTED_PROOF_TYPE = 'KILTAttestation2020'
+const KILT_MATCH_PROPERTY_TYPE = 'KILTMatchProperty2020'
+
+const KILT_STATUS_TYPE = 'KILTProtocolStatus2020'
+
+interface JSONreference {
+  $ref: string
+}
+
+type publicKey = Partial<IDidDocumentPublicKey> &
+  Pick<IDidDocumentPublicKey, 'publicKeyHex' | 'type'>
+
+interface proof {
+  type: string
+  created?: string
+  proofPurpose?: string
+  [key: string]: any
+}
+
+interface selfSignedProof extends proof {
+  type: typeof KILT_SELF_SIGNED_PROOF_TYPE
+  verificationMethod: string | publicKey
+  signature: string
+}
+
+interface attestedProof extends proof {
+  type: typeof KILT_ATTESTED_PROOF_TYPE
+  credentialId: string | JSONreference
+  attesterAddress: string | JSONreference
+  delegationId?: string | JSONreference
+}
+
+interface matchPropertyProof extends proof {
+  type: typeof KILT_MATCH_PROPERTY_TYPE
+  protected: {
+    claim: IPartialClaim
+  }
+  nonces: {
+    claim: IPartialClaim
+  }
+}
+
+interface KILTcredentialStatus {
+  type: typeof KILT_STATUS_TYPE
+  credentialId: string | JSONreference
+  attesterAddress: string
+}
+
+interface VerifiableCredential {
+  '@context': [typeof DEFAULT_VERIFIABLECREDENTIAL_CONTEXT, ...string[]]
+  // the credential types, which declare what data to expect in the credential
+  type: [typeof DEFAULT_VERIFIABLECREDENTIAL_TYPE, ...string[]]
+  id: string
+  // the entity that issued the credential
+  issuer: string
+  // when the credential was issued
+  issuanceDate: string
+  // claims about the subjects of the credential
+  credentialSubject: Record<string, unknown>
+  // digital proof that makes the credential tamper-evident
+  proof: proof | proof[]
+  nonTransferable?: boolean
+  credentialStatus: KILTcredentialStatus
+  expirationDate?: any
+}
+
+export default function attClaimToVC(
+  input: IAttestedClaim,
+  subjectDid = false
+): VerifiableCredential {
+  const {
+    claimHashTree,
+    claimOwner,
+    cTypeHash,
+    legitimations,
+    delegationId,
+    rootHash,
+    claimerSignature,
+    claim,
+  } = input.request
+
+  // write root hash to id
+  const id = rootHash
+
+  // add credential body containing hash tree only
+  const contentHashes: Record<string, string> = {}
+  Object.keys(claimHashTree).forEach((key) => {
+    contentHashes[key] = claimHashTree[key].hash
+  })
+  const credentialSubject: VerifiableCredential['credentialSubject'] = {
+    protected: {
+      claim: {
+        owner: claimOwner.hash,
+        cTypeHash: cTypeHash.hash,
+        contents: contentHashes,
+      },
+      legitimations: legitimations.map(
+        (legitimation) => legitimation.attestation.claimHash
+      ),
+      delegationId,
+    },
+  }
+  if (subjectDid)
+    credentialSubject.id = Did.getIdentifierFromAddress(claim.owner)
+
+  // add self-signed proof
+  const proof: proof[] = []
+  proof.push({
+    type: KILT_SELF_SIGNED_PROOF_TYPE,
+    verificationMethod: {
+      type: 'Ed25519VerificationKey2018',
+      publicKeyHex: u8aToHex(decodeAddress(claim.owner)),
+    },
+    signature: claimerSignature,
+  } as selfSignedProof)
+
+  // fill in property values
+  const contentNonces: Record<string, string> = {}
+  Object.keys(claimHashTree).forEach((key) => {
+    const { nonce } = claimHashTree[key]
+    if (nonce) {
+      contentNonces[key] = nonce
+    }
+  })
+
+  proof.push({
+    type: KILT_MATCH_PROPERTY_TYPE,
+    protected: { claim },
+    nonces: {
+      claim: {
+        cTypeHash: cTypeHash.nonce,
+        contents: contentNonces,
+        owner: claimOwner.nonce,
+      },
+    },
+  } as matchPropertyProof)
+
+  // add attestation proof
+  const attester = input.attestation.owner
+  const issuer = Did.getIdentifierFromAddress(attester)
+  proof.push({
+    type: KILT_ATTESTED_PROOF_TYPE,
+    attesterAddress: attester,
+    credentialId: { $ref: '#/id' },
+    delegationId: delegationId
+      ? { $ref: '#/credentialSubject/protected/delegationId' }
+      : undefined,
+  } as attestedProof)
+
+  const credentialStatus: KILTcredentialStatus = {
+    type: KILT_STATUS_TYPE,
+    attesterAddress: attester,
+    credentialId: { $ref: '#/id' },
+  }
+
+  const issuanceDate = new Date().toISOString()
+  return {
+    '@context': [DEFAULT_VERIFIABLECREDENTIAL_CONTEXT],
+    type: [DEFAULT_VERIFIABLECREDENTIAL_TYPE],
+    id,
+    credentialSubject,
+    nonTransferable: true,
+    proof,
+    issuer,
+    issuanceDate,
+    credentialStatus,
+  }
+}

--- a/src/util/toVerifiableCredential.ts
+++ b/src/util/toVerifiableCredential.ts
@@ -1,9 +1,12 @@
 import { decodeAddress } from '@polkadot/keyring'
 import { hexToU8a, u8aConcat, u8aToHex } from '@polkadot/util'
 import { signatureVerify } from '@polkadot/util-crypto'
+import CType from '../ctype'
+import { ERROR_CLAIM_CONTENTS_MALFORMED } from '../errorhandling/SDKErrors'
 import { IDidDocumentPublicKey } from '../did/Did'
-import { IAttestedClaim, Did, IPartialClaim, Attestation } from '..'
+import { IAttestedClaim, Did, Attestation, IClaim } from '..'
 import { hash } from '../crypto'
+import IRequestForAttestation from '../types/RequestForAttestation'
 
 /**
  * Constant for default context.
@@ -21,7 +24,7 @@ const DEFAULT_VERIFIABLECREDENTIAL_TYPE = 'VerifiableCredential'
 
 const KILT_SELF_SIGNED_PROOF_TYPE = 'KILTSelfSigned2020'
 const KILT_ATTESTED_PROOF_TYPE = 'KILTAttestation2020'
-const KILT_MATCH_PROPERTY_TYPE = 'KILTMatchProperty2020'
+const KILT_REVEAL_PROPERTY_TYPE = 'KILTRevealProperties2020'
 
 const KILT_STATUS_TYPE = 'KILTProtocolStatus2020'
 
@@ -47,25 +50,22 @@ interface selfSignedProof extends proof {
 
 interface attestedProof extends proof {
   type: typeof KILT_ATTESTED_PROOF_TYPE
-  credentialId: string | JSONreference
   attesterAddress: string | JSONreference
   delegationId?: string | JSONreference
 }
 
-interface matchPropertyProof extends proof {
-  type: typeof KILT_MATCH_PROPERTY_TYPE
+interface revealPropertyProof extends proof {
+  type: typeof KILT_REVEAL_PROPERTY_TYPE
   protected: {
-    claim: IPartialClaim
+    claim: Partial<IClaim>
   }
   nonces: {
-    claim: IPartialClaim
+    claim: Partial<IClaim>
   }
 }
 
 interface KILTcredentialStatus {
   type: typeof KILT_STATUS_TYPE
-  credentialId: string | JSONreference
-  attesterAddress: string
 }
 
 interface VerifiableCredential {
@@ -78,11 +78,14 @@ interface VerifiableCredential {
   // when the credential was issued
   issuanceDate: string
   // claims about the subjects of the credential
-  credentialSubject: Record<string, unknown>
+  credentialSubject: {
+    protected: Record<string, unknown>
+    id?: string
+  }
   // digital proof that makes the credential tamper-evident
   proof: proof | proof[]
   nonTransferable?: boolean
-  credentialStatus: KILTcredentialStatus
+  credentialStatus?: KILTcredentialStatus
   expirationDate?: any
 }
 
@@ -136,46 +139,18 @@ export default function attClaimToVC(
     signature: claimerSignature,
   } as selfSignedProof)
 
-  // fill in property values
-  const contentNonces: Record<string, string> = {}
-  Object.keys(claimHashTree).forEach((key) => {
-    const { nonce } = claimHashTree[key]
-    if (nonce) {
-      contentNonces[key] = nonce
-    }
-  })
-
-  proof.push({
-    type: KILT_MATCH_PROPERTY_TYPE,
-    protected: { claim },
-    nonces: {
-      claim: {
-        cTypeHash: cTypeHash.nonce,
-        contents: contentNonces,
-        owner: claimOwner.nonce,
-      },
-    },
-  } as matchPropertyProof)
-
   // add attestation proof
   const attester = input.attestation.owner
   const issuer = Did.getIdentifierFromAddress(attester)
   proof.push({
     type: KILT_ATTESTED_PROOF_TYPE,
     attesterAddress: attester,
-    credentialId: { $ref: '#/id' },
-    delegationId: delegationId
-      ? { $ref: '#/credentialSubject/protected/delegationId' }
-      : undefined,
   } as attestedProof)
 
-  const credentialStatus: KILTcredentialStatus = {
-    type: KILT_STATUS_TYPE,
-    attesterAddress: attester,
-    credentialId: { $ref: '#/id' },
-  }
-
+  // add current date bc we have no issuance date on credential
+  // TODO: could we get this from block time or something?
   const issuanceDate = new Date().toISOString()
+
   return {
     '@context': [DEFAULT_VERIFIABLECREDENTIAL_CONTEXT],
     type: [DEFAULT_VERIFIABLECREDENTIAL_TYPE],
@@ -185,7 +160,45 @@ export default function attClaimToVC(
     proof,
     issuer,
     issuanceDate,
-    credentialStatus,
+  }
+}
+
+/**
+ * This proof can be added to a credential to reveal selected properties to the verifier.
+ * For each property to be revealed, it also contains a nonce which is required to verify against the hash in the credential.
+ * Values, nonces and hashes are mapped to each through via identical data structures.
+ *
+ * @param partialClaim Claim object containing only the values you want to reveal.
+ * @param requestForAttestation The full [[IRequestForAttestation]] object from which necessary nonces are picked.
+ * @returns Proof object that can be included in a Verifiable Credential / Verifiable Presentation's proof section.
+ */
+export function makeRevealPropertiesProof(
+  partialClaim: Partial<IClaim>,
+  requestForAttestation: IRequestForAttestation
+): revealPropertyProof {
+  const { claimHashTree, cTypeHash, claimOwner } = requestForAttestation
+  // pull nonce for each property in claim contents that has not been removed or nullified
+  const contentNonces: Record<string, string> = {}
+  if (partialClaim.contents) {
+    Object.entries(partialClaim.contents).forEach(([key, value]) => {
+      const { nonce } = claimHashTree[key]
+      if (nonce && typeof value !== 'undefined' && value !== null) {
+        contentNonces[key] = nonce
+      }
+    })
+  }
+  // compile object with structure identical to IClaim object
+  const claimNonces: Partial<IClaim> = {
+    contents: contentNonces,
+  }
+  // add nonces for cTypeHash & owner if not removed/nullified in claim
+  if (partialClaim.cTypeHash) claimNonces.cTypeHash = cTypeHash.nonce
+  if (partialClaim.owner) claimNonces.owner = claimOwner.nonce
+  // return the proof containing values and nonces in two objects of identical structure
+  return {
+    type: KILT_REVEAL_PROPERTY_TYPE,
+    protected: { claim: partialClaim },
+    nonces: { claim: claimNonces },
   }
 }
 
@@ -200,6 +213,16 @@ const CREDENTIAL_MALFORMED_ERROR = (reason: string): Error =>
 const PROOF_MALFORMED_ERROR = (reason: string): Error =>
   new Error(`Proof malformed: ${reason}`)
 
+/**
+ * Verifies a KILT self signed proof (claimer signature) against a KILT style Verifiable Credential.
+ * This entails computing the root hash from the hashes contained in the `protected` section of the credentialSubject.
+ * The resulting hash is then verified against the signature and public key contained in the proof (the latter
+ * could be a DID reference in the future). It is also expected to by identical to the credential id.
+ *
+ * @param credential Verifiable Credential to verify proof against.
+ * @param proof KILT self signed proof object.
+ * @returns Object indicating whether proof could be verified.
+ */
 export function verifySelfSignedProof(
   credential: VerifiableCredential,
   proof: selfSignedProof
@@ -235,7 +258,7 @@ export function verifySelfSignedProof(
     while (queue.length) {
       // pop first element off array
       const first = queue.shift()
-      if (typeof first === 'object') {
+      if (typeof first === 'object' && first) {
         // if first element is object, retrieve values and push to BEGINNING of queue
         queue = Object.values(first).concat(...queue)
       } else if (typeof first === 'string') {
@@ -253,10 +276,15 @@ export function verifySelfSignedProof(
       ...hashes.map((hexHash) => hexToU8a(hexHash))
     )
     const rootHash = hash(concatenated)
+
+    // throw if root hash does not match expected (=id)
+    const expectedRootHash = credential.id
+    if (expectedRootHash !== u8aToHex(rootHash))
+      throw new Error('computed root hash does not match expected')
+
     // validate signature over root hash
-    if (!signatureVerify(rootHash, proof.signature, signerPubKey).isValid) {
+    if (!signatureVerify(rootHash, proof.signature, signerPubKey).isValid)
       throw new Error('signature could not be verified')
-    }
     return result
   } catch (e) {
     result.verified = false
@@ -265,6 +293,15 @@ export function verifySelfSignedProof(
   }
 }
 
+/**
+ * Verifies a KILT attestation proof by querying data from the KILT blockchain.
+ * This includes querying the KILT blockchain with the credential id, which returns an attestation record if attested.
+ * This record is then compared against attester address and delegation id (the latter of which is taken directly from the credential).
+ *
+ * @param credential Verifiable Credential to verify proof against.
+ * @param proof KILT self signed proof object.
+ * @returns Object indicating whether proof could be verified.
+ */
 export async function verifyAttestedProof(
   credential: VerifiableCredential,
   proof: attestedProof
@@ -274,47 +311,34 @@ export async function verifyAttestedProof(
     // check proof
     if (proof.type !== KILT_ATTESTED_PROOF_TYPE)
       throw new Error('Proof type mismatch')
-    let attesterAddress: string
-    if (typeof proof.attesterAddress === 'string') {
-      attesterAddress = proof.attesterAddress
-      // } else if (proof.attesterAddress === { $ref: '#/id' }) {
-      //   attesterAddress = credential.id
-    } else {
+    const { attesterAddress } = proof
+    if (typeof attesterAddress !== 'string' || !attesterAddress)
       throw PROOF_MALFORMED_ERROR('attester address not understood')
-    }
-    let claimHash: string
-    if (typeof proof.credentialId === 'string') {
-      claimHash = proof.credentialId
-    } else if (
-      typeof proof.credentialId === 'object' &&
-      proof.credentialId.$ref === '#/id'
-    ) {
-      claimHash = credential.id
-    } else {
-      throw PROOF_MALFORMED_ERROR('credentialId reference not understood')
-    }
+    const claimHash = credential.id
+    if (typeof claimHash !== 'string' || !claimHash)
+      throw CREDENTIAL_MALFORMED_ERROR(
+        'claim id (=claim hash) missing / invalid'
+      )
     let delegationId: string | null
-    if (typeof proof.delegationId === 'undefined') {
-      delegationId = null
-    } else if (typeof proof.delegationId === 'string') {
-      delegationId = proof.delegationId
-    } else if (
-      typeof proof.delegationId === 'object' &&
-      proof.delegationId.$ref ===
-        '#/credentialSubject/protected/delegationId' &&
-      typeof (credential.credentialSubject as any).protected.delegationId ===
-        'string'
-    ) {
-      delegationId = (credential.credentialSubject as any).protected
-        .delegationId
-    } else {
-      throw PROOF_MALFORMED_ERROR('credentialId reference not understood')
+
+    switch (typeof credential.credentialSubject.protected.delegationId) {
+      case 'string':
+        delegationId = credential.credentialSubject.protected.delegationId
+        break
+      case 'undefined':
+        delegationId = null
+        break
+      default:
+        throw CREDENTIAL_MALFORMED_ERROR('delegationId not understood')
     }
+    // query on-chain data by credential id (= claim root hash)
     const onChain = await Attestation.query(claimHash)
+    // if not found, credential has not been attested, proof is invalid
     if (!onChain)
       throw new Error(
         `attestation for credential with id ${claimHash} not found`
       )
+    // if data on proof does not correspond to data on chain, proof is incorrect
     if (
       onChain.owner !== attesterAddress ||
       onChain.delegationId !== delegationId
@@ -325,6 +349,7 @@ export async function verifyAttestedProof(
           delegation: delegationId,
         }}`
       )
+    // if proof data is valid but attestation is flagged as revoked, credential is no longer valid
     if (onChain.revoked) throw new Error('attestation revoked')
     return result
   } catch (e) {
@@ -334,14 +359,28 @@ export async function verifyAttestedProof(
   }
 }
 
-export function verifyPropertyProof(
+function getByPath(object: Record<string, any>, path: string[]): any | null {
+  return path.reduce((indexable, nextIndex) => indexable?.[nextIndex], object)
+}
+
+/**
+ * Verifies a proof that reveals the content of selected properties to a verifier. This enables selective disclosure.
+ * Values and nonces contained within this proof will be hashed, the result of which is expected to equal hashes on the credential.
+ *
+ * @param credential Verifiable Credential to verify proof against.
+ * @param proof KILT self signed proof object.
+ * @param schema If the CType for this credential is passed, the revealed properties will additionally be subjected to a schema validation.
+ * @returns Object indicating whether proof could be verified.
+ */
+export function verifyRevealPropertyProof(
   credential: VerifiableCredential,
-  proof: matchPropertyProof
+  proof: revealPropertyProof,
+  schema?: CType
 ): VerificationResult {
   const result: VerificationResult = { verified: true }
   try {
     // check proof
-    if (proof.type !== KILT_MATCH_PROPERTY_TYPE)
+    if (proof.type !== KILT_REVEAL_PROPERTY_TYPE)
       throw new Error('Proof type mismatch')
     if (
       typeof proof.nonces !== 'object' ||
@@ -355,11 +394,11 @@ export function verifyPropertyProof(
     if (typeof protectedBody !== 'object' || !protectedBody)
       throw CREDENTIAL_MALFORMED_ERROR('protected credential body missing')
 
-    const getNested = (
-      object: Record<string, any>,
-      path: string[]
-    ): any | null =>
-      path.reduce((indexable, nextIndex) => indexable?.[nextIndex], object)
+    // perform schema validation
+    if (schema && !schema.verifyClaimStructure(proof.protected.claim as IClaim))
+      throw ERROR_CLAIM_CONTENTS_MALFORMED()
+
+    // iteratively hash nonce + value and compare to hash in credential
     const verificationQueue: string[][] = Object.entries(
       proof.protected
     ).map(([key]) => [key])
@@ -368,15 +407,15 @@ export function verifyPropertyProof(
     while (verificationQueue.length) {
       // pop last element off array
       const path = verificationQueue.pop() || []
-      const value = getNested(proof.protected, path)
+      const value = getByPath(proof.protected, path)
       if (typeof value === 'object' && value) {
         // if first value is object, retrieve values and push to end of queue
         verificationQueue.push(
           ...Object.entries(value).map(([key]) => [...path, key])
         )
       } else {
-        const nonce = getNested(proof.nonces, path)
-        const hashInCredential = getNested(protectedBody, path)
+        const nonce = getByPath(proof.nonces, path)
+        const hashInCredential = getByPath(protectedBody, path)
         const pathAsString = path.reduce((last, next) => `${last}.${next}`)
         if (typeof nonce !== 'string')
           throw PROOF_MALFORMED_ERROR(


### PR DESCRIPTION
## closes KILTProtocol/ticket#767
This is a first attempt at coming up with a data structure for KILT credentials that complies with the emerging Verifiable Credential standard. 
The proposed solution is based on multiple custom proof types that perform 3 different verification tasks:
1. Verify content hashes agains root hash and verify signature over root hash against claimer signature (self-signed proof). This proof is equivalent to integrity protection and authentication provided by the `RequestForAttestation`
2. Verify disclosed properties (actual claim contents) and "salt" (nonces) against content hashes.
3. Use root hash (=credential id) to query & verify on-chain attestation and check revocation status.

## How to test:
Some unit tests are included to demonstrate the functionality. As illustrated in these tests, you may:
1. export a credential to a vc
2. run validation functions over the resulting credential and proofs
3. generate a proof for property disclosure
4. run validation functions over the credential and generated proof

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
