### PR TITLE
ci: use PAT for pushing prereleases

### DIFF
--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -3,13 +3,16 @@ on:
   push:
     branches:
       - develop
+      - tw-851-git-push
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: "! startsWith(github.event.head_commit.message, '[CI Skip]') && github.repository == 'kiltprotocol/sdk-js'"
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false # otherwise, the token used for git push is the GITHUB_TOKEN
       - uses: actions/setup-node@v1
         with:
           node-version: 10
@@ -22,13 +25,18 @@ jobs:
         run: npm publish --access public --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
-      - name: Commit and push changes
+      - name: Commit files
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config --local user.name "Github Action"
+          git config --local user.email "action@github.com"
           git add .
-          git commit -m "ci: publish prerelease"
+          git commit -m "[CI Skip] ci: publish prerelease" -n
           git push
+      # - name: Push changes
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ secrets.GH_PAT }}
+      #     branch: ${{ github.ref }}
 
   dispatch:
     needs: build

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          persist-credentials: false # otherwise, the token used for git push is the GITHUB_TOKEN
+          token: ${{ secrets.GH_PAT }}
       - uses: actions/setup-node@v1
         with:
           node-version: 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
   check_skip:
     runs-on: ubuntu-latest
     if: "! startsWith(github.event.head_commit.message, '[CI Skip]') && github.repository == 'kiltprotocol/sdk-js'"
+    steps:
+    - name: Not Skipped
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
     if: "! startsWith(github.event.head_commit.message, '[CI Skip]') && github.repository == 'kiltprotocol/sdk-js'"
     steps:
     - name: Not Skipped
+      run: echo "Not Skipped"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,15 @@ on:
       - master
 
 jobs:
+
+  check_skip:
+    runs-on: ubuntu-latest
+    if: "! startsWith(github.event.head_commit.message, '[CI Skip]') && github.repository == 'kiltprotocol/sdk-js'"
+
   build:
     runs-on: ubuntu-latest
+
+    needs: check_skip
 
     strategy:
       matrix:
@@ -37,6 +44,8 @@ jobs:
 
   integration_test:
     runs-on: ubuntu-latest
+
+    needs: check_skip
 
     steps:
       - uses: actions/checkout@v1
@@ -74,6 +83,8 @@ jobs:
   run_example:
     runs-on: ubuntu-latest
 
+    needs: check_skip
+
     steps:
       - uses: actions/checkout@v1
 
@@ -109,6 +120,8 @@ jobs:
 
   run_getting-started:
     runs-on: ubuntu-latest
+
+    needs: check_skip
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/sdk-js",
-  "version": "0.19.1-3",
+  "version": "0.19.1-4",
   "description": "",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/sdk-js",
-  "version": "0.19.1-5",
+  "version": "0.19.1-6",
   "description": "",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/sdk-js",
-  "version": "0.19.1-4",
+  "version": "0.19.1-5",
   "description": "",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",


### PR DESCRIPTION
## relates to KILTProtocol/ticket#851
Since the user with the github token can't push to restricted branches, we have to use one with more rights.
