### PR TITLE
fix: undefined assignment on double spread

### DIFF
--- a/packages/core/src/blockchain/Blockchain.utils.ts
+++ b/packages/core/src/blockchain/Blockchain.utils.ts
@@ -64,14 +64,17 @@ export const EXTRINSIC_FAILED: ResultEvaluator = (result) =>
 export function parseSubscriptionOptions(
   opts?: Partial<SubscriptionPromiseOptions>
 ): SubscriptionPromiseOptions {
-  const defaults = {
-    resolveOn: IS_FINALIZED,
-    rejectOn: (result: SubmittableResult) =>
+  const {
+    resolveOn = IS_FINALIZED,
+    rejectOn = (result: SubmittableResult) =>
       IS_ERROR(result) || EXTRINSIC_FAILED(result) || IS_USURPED(result),
-  }
+    timeout,
+  } = { ...opts }
+
   return {
-    ...defaults,
-    ...opts,
+    resolveOn,
+    rejectOn,
+    timeout,
   }
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#859

@rflechtner pinpointed an issue with our double spread logic to apply defaults, it might assign properties that are set to undefined.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
