### PR TITLE
ci: force all prerelease packages to have the same version

### DIFF
--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -25,8 +25,12 @@ jobs:
           node-version: 10
       - name: Install dependencies
         run: yarn install --immutable
-      - name: Set package version as prerelease
-        run: yarn run version prerelease
+      - name: Bump prerelease version of root package
+        run: yarn version prerelease
+      - name: Get current package version
+        run: package_version="$(node -pe "require('./package.json').version")"
+      - name: Set all other packages to same version
+        run: yarn run version $package_version
       - name: Build packages
         run: yarn run build
       - name: Publish to npm


### PR DESCRIPTION
## no ticket
I noticed our prereleases on npm may differ in version number. That's no biggie, but we could force them to be equal within a prerelease with this proposed change. This way there is no confusion which prereleased subpackage goes with which other.

## How to test:
You can try running the commands I added locally. Use bash.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
