### PR TITLE
refactor: optimised structure for ExtrinsicErrors

### DIFF
--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -166,7 +166,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
           resolveOn: IS_IN_BLOCK,
         })
       )
-    ).rejects.toThrowError(ExtrinsicErrors.CType.ERROR_CTYPE_NOT_FOUND)
+    ).rejects.toThrowErrorWithCode(
+      ExtrinsicErrors.CType.ERROR_CTYPE_NOT_FOUND.code
+    )
   }, 60_000)
 
   describe('when there is an attested claim on-chain', () => {
@@ -200,7 +202,9 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
             resolveOn: IS_IN_BLOCK,
           })
         )
-      ).rejects.toThrowError(ExtrinsicErrors.Attestation.ERROR_ALREADY_ATTESTED)
+      ).rejects.toThrowErrorWithCode(
+        ExtrinsicErrors.Attestation.ERROR_ALREADY_ATTESTED.code
+      )
     }, 15_000)
 
     it('should not be possible to use attestation for different claim', async () => {

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -79,7 +79,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
           resolveOn: IS_IN_BLOCK,
         })
       )
-    ).rejects.toThrowError(ExtrinsicErrors.CType.ERROR_CTYPE_ALREADY_EXISTS)
+    ).rejects.toThrowErrorWithCode(
+      ExtrinsicErrors.CType.ERROR_CTYPE_ALREADY_EXISTS.code
+    )
     // console.log('Triggered error on re-submit')
     await expect(getOwner(ctype.hash)).resolves.toBe(ctypeCreator.address)
   }, 45_000)

--- a/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
@@ -26,7 +26,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
     makeTransfer(alice, to.address, new BN(1)).then((tx) =>
       submitTxWithReSign(tx, alice, { resolveOn: IS_IN_BLOCK })
     )
-  ).rejects.toThrow(ExtrinsicErrors.UNKNOWN_ERROR)
+  ).rejects.toThrowErrorWithCode(ExtrinsicErrors.UNKNOWN_ERROR.code)
 }, 30_000)
 
 it('records an extrinsic error when ctype does not exist', async () => {
@@ -42,7 +42,9 @@ it('records an extrinsic error when ctype does not exist', async () => {
   const tx = await attestation.store(alice)
   await expect(
     submitTxWithReSign(tx, alice, { resolveOn: IS_IN_BLOCK })
-  ).rejects.toThrow(ExtrinsicErrors.CType.ERROR_CTYPE_NOT_FOUND)
+  ).rejects.toThrowErrorWithCode(
+    ExtrinsicErrors.CType.ERROR_CTYPE_ALREADY_EXISTS.code
+  )
 }, 30_000)
 
 afterAll(() => {

--- a/packages/core/src/blockchain/Blockchain.utils.ts
+++ b/packages/core/src/blockchain/Blockchain.utils.ts
@@ -12,7 +12,10 @@ import {
   makeSubscriptionPromise,
   TerminationOptions,
 } from '../util/SubscriptionPromise'
-import { ExtrinsicErrors } from '../errorhandling/ExtrinsicError'
+import {
+  ExtrinsicError,
+  ExtrinsicErrors,
+} from '../errorhandling/ExtrinsicError'
 import { ErrorHandler } from '../errorhandling'
 import { factory as LoggerFactory } from '../config/ConfigService'
 import Identity from '../identity/Identity'
@@ -54,7 +57,11 @@ export const IS_ERROR: ResultEvaluator = (result) => {
 }
 export const EXTRINSIC_FAILED: ResultEvaluator = (result) =>
   ErrorHandler.extrinsicFailed(result) &&
-  (ErrorHandler.getExtrinsicError(result) || ExtrinsicErrors.UNKNOWN_ERROR)
+  (ErrorHandler.getExtrinsicError(result) ||
+    new ExtrinsicError(
+      ExtrinsicErrors.UNKNOWN_ERROR.code,
+      ExtrinsicErrors.UNKNOWN_ERROR.message
+    ))
 
 /**
  * Parses potentially incomplete or undefined options and returns complete [[SubscriptionPromiseOptions]].

--- a/packages/core/src/errorhandling/ExtrinsicError.ts
+++ b/packages/core/src/errorhandling/ExtrinsicError.ts
@@ -17,111 +17,148 @@ export class ExtrinsicError extends Error {
   }
 }
 
-/**
- * This dictionary holds all [[ExtrinsicError]]s, divided by pallets.
- *
- * @packageDocumentation
- * @module ExtrinsicErrors
- * @preferred
- */
 export const ExtrinsicErrors = {
   CType: {
-    ERROR_CTYPE_NOT_FOUND: new ExtrinsicError(2000, 'CType not found'),
-    ERROR_CTYPE_ALREADY_EXISTS: new ExtrinsicError(
-      2001,
-      'CType already exists'
-    ),
-    UNKNOWN_ERROR: new ExtrinsicError(2100, 'an  unknown CType error occured'),
+    ERROR_CTYPE_NOT_FOUND: { code: 11000, message: 'CType not found' },
+    ERROR_CTYPE_ALREADY_EXISTS: {
+      code: 11001,
+      message: 'CType already exists',
+    },
+    UNKNOWN_ERROR: { code: 11100, message: 'an  unknown CType error occured' },
   },
   Attestation: {
-    ERROR_ALREADY_ATTESTED: new ExtrinsicError(3000, 'already attested'),
-    ERROR_ALREADY_REVOKED: new ExtrinsicError(3001, 'already revoked'),
-    ERROR_ATTESTATION_NOT_FOUND: new ExtrinsicError(
-      3002,
-      'attestation not found'
-    ),
-    ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING: new ExtrinsicError(
-      3003,
-      'CType of delegation does not match'
-    ),
-    ERROR_DELEGATION_NOT_AUTHORIZED_TO_ATTEST: new ExtrinsicError(
-      3004,
-      'delegation not authorized to attest'
-    ),
-    ERROR_DELEGATION_REVOKED: new ExtrinsicError(3005, 'delegation is revoked'),
-    ERROR_NOT_DELEGATED_TO_ATTESTER: new ExtrinsicError(
-      3006,
-      'not delegated to attester'
-    ),
-    ERROR_NOT_PERMITTED_TO_REVOKE_ATTESTATION: new ExtrinsicError(
-      3007,
-      'not permitted to revoke attestation'
-    ),
-    UNKNOWN_ERROR: new ExtrinsicError(
-      3100,
-      'an unknown attestation module error occured'
-    ),
+    ERROR_ALREADY_ATTESTED: { code: 12000, message: 'already attested' },
+    ERROR_ALREADY_REVOKED: { code: 12001, message: 'already revoked' },
+    ERROR_ATTESTATION_NOT_FOUND: {
+      code: 12002,
+      message: 'attestation not found',
+    },
+    ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING: {
+      code: 12003,
+      message: 'CType of delegation does not match',
+    },
+    ERROR_DELEGATION_NOT_AUTHORIZED_TO_ATTEST: {
+      code: 12004,
+      message: 'delegation not authorized to attest',
+    },
+    ERROR_DELEGATION_REVOKED: { code: 12005, message: 'delegation is revoked' },
+    ERROR_NOT_DELEGATED_TO_ATTESTER: {
+      code: 12006,
+      message: 'not delegated to attester',
+    },
+    ERROR_NOT_PERMITTED_TO_REVOKE_ATTESTATION: {
+      code: 12007,
+      message: 'not permitted to revoke attestation',
+    },
+    UNKNOWN_ERROR: {
+      code: 12100,
+      message: 'an unknown attestation module error occured',
+    },
   },
   Delegation: {
-    ERROR_DELEGATION_ALREADY_EXISTS: new ExtrinsicError(
-      3000,
-      'delegation already exists'
-    ),
-    ERROR_BAD_DELEGATION_SIGNATURE: new ExtrinsicError(
-      3001,
-      'bad delegate signature'
-    ),
-    ERROR_DELEGATION_NOT_FOUND: new ExtrinsicError(
-      3002,
-      'delegation not found'
-    ),
-    ERROR_ROOT_ALREADY_EXISTS: new ExtrinsicError(3003, 'root already exist'),
-    ERROR_ROOT_NOT_FOUND: new ExtrinsicError(3004, 'root not found'),
-    ERROR_MAX_DELEGATION_SEARCH_DEPTH_REACHED: new ExtrinsicError(
-      3005,
-      'maximum delegation search depth reached'
-    ),
-    ERROR_NOT_OWNER_OF_PARENT: new ExtrinsicError(3006, 'not owner of parent'),
-    ERROR_NOT_OWNER_OF_ROOT: new ExtrinsicError(3007, 'not owner of root'),
-    ERROR_PARENT_NOT_FOUND: new ExtrinsicError(3008, 'parent not found'),
-    ERROR_NOT_PERMITTED_TO_REVOKE: new ExtrinsicError(
-      3009,
-      'not permitted to revoke'
-    ),
-    ERROR_NOT_AUTHORIZED_TO_DELEGATE: new ExtrinsicError(
-      3010,
-      'not authorized to delegate'
-    ),
-    ERROR_EXCEEDED_REVOCATION_BOUNDS: new ExtrinsicError(
-      3011,
-      'exceeded revocation bounds'
-    ),
-    UNKNOWN_ERROR: new ExtrinsicError(
-      3100,
-      'an unknown delegation module error occured'
-    ),
+    ERROR_DELEGATION_ALREADY_EXISTS: {
+      code: 13000,
+      message: 'delegation already exists',
+    },
+    ERROR_BAD_DELEGATION_SIGNATURE: {
+      code: 13001,
+      message: 'bad delegate signature',
+    },
+    ERROR_DELEGATION_NOT_FOUND: {
+      code: 13002,
+      message: 'delegation not found',
+    },
+    ERROR_ROOT_ALREADY_EXISTS: { code: 13003, message: 'root already exist' },
+    ERROR_ROOT_NOT_FOUND: { code: 13004, message: 'root not found' },
+    ERROR_MAX_DELEGATION_SEARCH_DEPTH_REACHED: {
+      code: 13005,
+      message: 'maximum delegation search depth reached',
+    },
+    ERROR_NOT_OWNER_OF_PARENT: { code: 13006, message: 'not owner of parent' },
+    ERROR_NOT_OWNER_OF_ROOT: { code: 13007, message: 'not owner of root' },
+    ERROR_PARENT_NOT_FOUND: { code: 13008, message: 'parent not found' },
+    ERROR_NOT_PERMITTED_TO_REVOKE: {
+      code: 13009,
+      message: 'not permitted to revoke',
+    },
+    ERROR_NOT_AUTHORIZED_TO_DELEGATE: {
+      code: 13010,
+      message: 'not authorized to delegate',
+    },
+    ERROR_EXCEEDED_REVOCATION_BOUNDS: {
+      code: 13011,
+      message: 'exceeded revocation bounds',
+    },
+    UNKNOWN_ERROR: {
+      code: 13100,
+      message: 'an unknown delegation module error occured',
+    },
   },
   DID: {
-    UNKNOWN_ERROR: new ExtrinsicError(
-      4100,
-      'an unknown DID module error occured'
-    ),
+    UNKNOWN_ERROR: {
+      code: 14100,
+      message: 'an unknown DID module error occured',
+    },
   },
-  UNKNOWN_ERROR: new ExtrinsicError(-1, 'an unknown extrinsic error ocurred'),
+  UNKNOWN_ERROR: { code: -1, message: 'an unknown extrinsic error ocurred' },
 }
 
 /**
  * PalletIndex reflects the numerical index of a pallet assigned in the chain's metadata.
- *
- * @packageDocumentation
- * @module ExtrinsicErrors
- * @preferred
  */
 export enum PalletIndex {
   CType = 11,
   Attestation = 12,
   Delegation = 13,
   DID = 14,
+}
+interface IPalletToExtrinsicErrors {
+  [key: number]: {
+    [key: number]: {
+      code: number
+      message: string
+    }
+  }
+}
+
+/**
+ * This dictionary holds all [[ExtrinsicError]]s, divided by pallets.
+ */
+const PalletToExtrinsicErrors: IPalletToExtrinsicErrors = {
+  [PalletIndex.CType]: {
+    0: ExtrinsicErrors.CType.ERROR_CTYPE_NOT_FOUND,
+    1: ExtrinsicErrors.CType.ERROR_CTYPE_ALREADY_EXISTS,
+    [-1]: ExtrinsicErrors.CType.UNKNOWN_ERROR,
+  },
+  [PalletIndex.Attestation]: {
+    0: ExtrinsicErrors.Attestation.ERROR_ALREADY_ATTESTED,
+    1: ExtrinsicErrors.Attestation.ERROR_ALREADY_REVOKED,
+    2: ExtrinsicErrors.Attestation.ERROR_ATTESTATION_NOT_FOUND,
+    3: ExtrinsicErrors.Attestation.ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING,
+    4: ExtrinsicErrors.Attestation.ERROR_DELEGATION_NOT_AUTHORIZED_TO_ATTEST,
+    5: ExtrinsicErrors.Attestation.ERROR_DELEGATION_REVOKED,
+    6: ExtrinsicErrors.Attestation.ERROR_NOT_DELEGATED_TO_ATTESTER,
+    7: ExtrinsicErrors.Attestation.ERROR_NOT_PERMITTED_TO_REVOKE_ATTESTATION,
+    [-1]: ExtrinsicErrors.Attestation.UNKNOWN_ERROR,
+  },
+  [PalletIndex.Delegation]: {
+    0: ExtrinsicErrors.Delegation.ERROR_DELEGATION_ALREADY_EXISTS,
+    1: ExtrinsicErrors.Delegation.ERROR_BAD_DELEGATION_SIGNATURE,
+    2: ExtrinsicErrors.Delegation.ERROR_DELEGATION_NOT_FOUND,
+    3: ExtrinsicErrors.Delegation.ERROR_ROOT_ALREADY_EXISTS,
+    4: ExtrinsicErrors.Delegation.ERROR_ROOT_NOT_FOUND,
+    5: ExtrinsicErrors.Delegation.ERROR_MAX_DELEGATION_SEARCH_DEPTH_REACHED,
+    6: ExtrinsicErrors.Delegation.ERROR_NOT_OWNER_OF_PARENT,
+    7: ExtrinsicErrors.Delegation.ERROR_NOT_OWNER_OF_ROOT,
+    8: ExtrinsicErrors.Delegation.ERROR_PARENT_NOT_FOUND,
+    9: ExtrinsicErrors.Delegation.ERROR_NOT_PERMITTED_TO_REVOKE,
+    10: ExtrinsicErrors.Delegation.ERROR_NOT_AUTHORIZED_TO_DELEGATE,
+    11: ExtrinsicErrors.Delegation.ERROR_EXCEEDED_REVOCATION_BOUNDS,
+    [-1]: ExtrinsicErrors.Delegation.UNKNOWN_ERROR,
+  },
+  [PalletIndex.DID]: {
+    [-1]: ExtrinsicErrors.DID.UNKNOWN_ERROR,
+  },
 }
 
 /**
@@ -131,24 +168,27 @@ export enum PalletIndex {
  * @param p.index The index of the KILT pallet in the metadata.
  * @param p.error The index of the position of the pallet's error definition inside the chain code.
  *
- * @returns The [[ExtrinsicError]] for the committed key.
+ * @returns A new corresponding [[ExtrinsicError]].
  */
 export function errorForPallet({
   index: moduleIndex,
   error: errorCode,
 }: ModuleError['Module']): ExtrinsicError {
-  // get moduleName by checking whether moduleIndex is in PalletIndex values
-  const [moduleName] = Object.entries(PalletIndex).find(
-    ([, value]) => value === moduleIndex
-  ) || ['UNKNOWN_ERROR']
-  if (moduleName !== 'UNKNOWN_ERROR' && moduleName in ExtrinsicErrors) {
-    // get error name for index
-    const errorName = Object.keys(ExtrinsicErrors[moduleName])[errorCode]
-    // return unknown module error if index is out of bounds
-    return errorName
-      ? ExtrinsicErrors[moduleName][errorName]
-      : ExtrinsicErrors[moduleName].UNKNOWN_ERROR
+  if (!PalletToExtrinsicErrors[moduleIndex]) {
+    return new ExtrinsicError(
+      ExtrinsicErrors.UNKNOWN_ERROR.code,
+      ExtrinsicErrors.UNKNOWN_ERROR.message
+    )
   }
-  // return unknown error per default
-  return ExtrinsicErrors.UNKNOWN_ERROR
+  if (!PalletToExtrinsicErrors[moduleIndex][errorCode]) {
+    return new ExtrinsicError(
+      PalletToExtrinsicErrors[moduleIndex][-1].code,
+      PalletToExtrinsicErrors[moduleIndex][-1].message
+    )
+  }
+
+  return new ExtrinsicError(
+    PalletToExtrinsicErrors[moduleIndex][errorCode].code,
+    PalletToExtrinsicErrors[moduleIndex][errorCode].message
+  )
 }


### PR DESCRIPTION
## relates to KILTProtocol/ticket#940
This PR refactors changes from https://github.com/KILTprotocol/sdk-js/pull/335, to 
- not rely on the order of the keys to map the pallet code to the ExtrinsicError
- not initiate an Error object per ExtrinsicError

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
