### PR TITLE
fix: add missing did type

### DIFF
--- a/packages/core/src/did/index.ts
+++ b/packages/core/src/did/index.ts
@@ -3,7 +3,12 @@
  * @ignore
  */
 
-import Did, { IDid, IDidDocument, IDidDocumentPublicKey } from './Did'
+import Did, {
+  IDid,
+  IDidDocument,
+  IDidDocumentPublicKey,
+  IDidDocumentSigned,
+} from './Did'
 
-export { Did, IDid, IDidDocument, IDidDocumentPublicKey }
+export { Did, IDid, IDidDocument, IDidDocumentPublicKey, IDidDocumentSigned }
 export default Did

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,12 @@ import {
   DelegationRootNode,
   DelegationNodeUtils,
 } from './delegation'
-import Did, { IDid, IDidDocument, IDidDocumentPublicKey } from './did'
+import Did, {
+  IDid,
+  IDidDocument,
+  IDidDocumentPublicKey,
+  IDidDocumentSigned,
+} from './did'
 import { Identity, IURLResolver, PublicIdentity } from './identity'
 import { ConfigService } from './config'
 import Quote, { QuoteSchema, QuoteUtils } from './quote'
@@ -60,6 +65,7 @@ export {
   IDid,
   IDidDocument,
   IDidDocumentPublicKey,
+  IDidDocumentSigned,
   Quote,
   QuoteUtils,
   QuoteSchema,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/utils",
-  "version": "0.19.1-24",
+  "version": "0.19.1-26",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1086


Type IDidDocumentSigned was used within the Demo-client but wasn't accessible as not exported.
Added a version fix to the utils folder not being updated.

## How to test:


n/a


## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
