### PR TITLE
refactor: on-chain DID type

### DIFF
--- a/packages/core/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/core/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -46,7 +46,7 @@ export const CUSTOM_TYPES: RegistryTypes = {
     delegationId: 'Option<DelegationNodeId>',
     revoked: 'bool',
   },
-  Did: {
+  DidRecord: {
     signKey: 'Hash',
     boxKey: 'Hash',
     docRef: 'Option<Vec<u8>>',

--- a/packages/core/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/core/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -46,6 +46,11 @@ export const CUSTOM_TYPES: RegistryTypes = {
     delegationId: 'Option<DelegationNodeId>',
     revoked: 'bool',
   },
+  Did: {
+    signKey: 'Hash',
+    boxKey: 'Hash',
+    docRef: 'Option<Vec<u8>>',
+  },
 }
 
 export async function buildConnection(

--- a/packages/core/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/core/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -1,11 +1,4 @@
-import {
-  Option,
-  TypeRegistry,
-  U8aFixed,
-  U64,
-  Vec,
-  U8,
-} from '@polkadot/types'
+import { Option, TypeRegistry, U8aFixed, U64, Vec, U8 } from '@polkadot/types'
 import { Codec } from '@polkadot/types/types'
 import { Constructor } from '@polkadot/util/types'
 import { CUSTOM_TYPES } from '../BlockchainApiConnection'

--- a/packages/core/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/core/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -1,7 +1,5 @@
 import {
-  Bytes,
   Option,
-  Tuple,
   TypeRegistry,
   U8aFixed,
   U64,
@@ -63,11 +61,7 @@ const chainQueryReturnTuples: {
   },
   did: {
     // DID: account-id -> (public-signing-key, public-encryption-key, did-reference?)?
-    dIDs: Tuple.with([
-      TYPE_REGISTRY.getOrUnknown('PublicSigningKey'),
-      TYPE_REGISTRY.getOrUnknown('PublicBoxKey'),
-      Option.with(Bytes),
-    ]),
+    dIDs: TYPE_REGISTRY.getOrUnknown('Did'),
   },
   portablegabi: {
     // AccumulatorList: account-id -> [accumulators]?

--- a/packages/core/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/core/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -61,7 +61,7 @@ const chainQueryReturnTuples: {
   },
   did: {
     // DID: account-id -> (public-signing-key, public-encryption-key, did-reference?)?
-    dIDs: TYPE_REGISTRY.getOrUnknown('Did'),
+    dIDs: TYPE_REGISTRY.getOrUnknown('DidRecord'),
   },
   portablegabi: {
     // AccumulatorList: account-id -> [accumulators]?

--- a/packages/core/src/did/Did.chain.ts
+++ b/packages/core/src/did/Did.chain.ts
@@ -13,7 +13,7 @@ import {
   decodeDid,
   getAddressFromIdentifier,
   getIdentifierFromAddress,
-  IEncodedDid,
+  IEncodedDidRecord,
 } from './Did.utils'
 
 export async function queryByIdentifier(
@@ -23,7 +23,7 @@ export async function queryByIdentifier(
   const address = getAddressFromIdentifier(identifier)
   const decoded = decodeDid(
     identifier,
-    await blockchain.api.query.did.dIDs<Option<IEncodedDid>>(address)
+    await blockchain.api.query.did.dIDs<Option<IEncodedDidRecord>>(address)
   )
   return decoded
 }
@@ -35,7 +35,7 @@ export async function queryByAddress(
   const identifier = getIdentifierFromAddress(address)
   const decoded = decodeDid(
     identifier,
-    await blockchain.api.query.did.dIDs<Option<IEncodedDid>>(address)
+    await blockchain.api.query.did.dIDs<Option<IEncodedDidRecord>>(address)
   )
   return decoded
 }

--- a/packages/core/src/did/Did.chain.ts
+++ b/packages/core/src/did/Did.chain.ts
@@ -4,7 +4,7 @@
  */
 
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
-import { Option, Tuple } from '@polkadot/types'
+import { Option } from '@polkadot/types'
 import { IPublicIdentity } from '@kiltprotocol/types'
 import { getCached } from '../blockchainApiConnection'
 import Identity from '../identity/Identity'
@@ -13,6 +13,7 @@ import {
   decodeDid,
   getAddressFromIdentifier,
   getIdentifierFromAddress,
+  IEncodedDid,
 } from './Did.utils'
 
 export async function queryByIdentifier(
@@ -22,7 +23,7 @@ export async function queryByIdentifier(
   const address = getAddressFromIdentifier(identifier)
   const decoded = decodeDid(
     identifier,
-    await blockchain.api.query.did.dIDs<Option<Tuple>>(address)
+    await blockchain.api.query.did.dIDs<Option<IEncodedDid>>(address)
   )
   return decoded
 }
@@ -34,7 +35,7 @@ export async function queryByAddress(
   const identifier = getIdentifierFromAddress(address)
   const decoded = decodeDid(
     identifier,
-    await blockchain.api.query.did.dIDs<Option<Tuple>>(address)
+    await blockchain.api.query.did.dIDs<Option<IEncodedDid>>(address)
   )
   return decoded
 }

--- a/packages/core/src/did/Did.spec.ts
+++ b/packages/core/src/did/Did.spec.ts
@@ -32,7 +32,7 @@ describe('DID', () => {
           '0x687474703a2f2f6d794449442e6b696c742e696f',
         ])
       }
-      return mockChainQueryReturn('did', 'dIDs', [key1, key2, null])
+      return mockChainQueryReturn('did', 'dIDs', [key1, key2, ''])
     }
   )
 
@@ -52,7 +52,7 @@ describe('DID', () => {
       identifier: 'did:kilt:w/oDocumentStore',
       publicBoxKey: key2.toString(),
       publicSigningKey: key1.toString(),
-      documentStore: null,
+      documentStore: '',
     } as IDid)
   })
 
@@ -62,7 +62,7 @@ describe('DID', () => {
       identifier: 'did:kilt:w/oDocumentStore',
       publicBoxKey: key2.toString(),
       publicSigningKey: key1.toString(),
-      documentStore: null,
+      documentStore: '',
     } as IDid)
   })
 

--- a/packages/core/src/did/Did.spec.ts
+++ b/packages/core/src/did/Did.spec.ts
@@ -32,7 +32,7 @@ describe('DID', () => {
           '0x687474703a2f2f6d794449442e6b696c742e696f',
         ])
       }
-      return mockChainQueryReturn('did', 'dIDs', [key1, key2, ''])
+      return mockChainQueryReturn('did', 'dIDs', [key1, key2, null])
     }
   )
 
@@ -52,7 +52,7 @@ describe('DID', () => {
       identifier: 'did:kilt:w/oDocumentStore',
       publicBoxKey: key2.toString(),
       publicSigningKey: key1.toString(),
-      documentStore: '',
+      documentStore: null,
     } as IDid)
   })
 
@@ -62,7 +62,7 @@ describe('DID', () => {
       identifier: 'did:kilt:w/oDocumentStore',
       publicBoxKey: key2.toString(),
       publicSigningKey: key1.toString(),
-      documentStore: '',
+      documentStore: null,
     } as IDid)
   })
 

--- a/packages/core/src/did/Did.ts
+++ b/packages/core/src/did/Did.ts
@@ -50,9 +50,8 @@ export interface IDid {
   /**
    * The document store reference, usually a URL.
    */
-  documentStore: string | null
+  documentStore: string | undefined
 }
-
 export interface IDidDocumentCore {
   // id and context are the only mandatory properties, described as "MUST"s in the w3c spec https://w3c.github.io/did-core/
   id: string
@@ -91,13 +90,13 @@ export default class Did implements IDid {
   public readonly identifier: string
   public readonly publicBoxKey: string
   public readonly publicSigningKey: string
-  public readonly documentStore: string | null
+  public readonly documentStore: string | undefined
 
   private constructor(
     identifier: string,
     publicBoxKey: string,
     publicSigningKey: string,
-    documentStore: string | null = null
+    documentStore?: string
   ) {
     this.identifier = identifier
     this.publicBoxKey = publicBoxKey

--- a/packages/core/src/did/Did.ts
+++ b/packages/core/src/did/Did.ts
@@ -50,7 +50,7 @@ export interface IDid {
   /**
    * The document store reference, usually a URL.
    */
-  documentStore: string | undefined
+  documentStore: string | null
 }
 export interface IDidDocumentCore {
   // id and context are the only mandatory properties, described as "MUST"s in the w3c spec https://w3c.github.io/did-core/
@@ -90,13 +90,13 @@ export default class Did implements IDid {
   public readonly identifier: string
   public readonly publicBoxKey: string
   public readonly publicSigningKey: string
-  public readonly documentStore: string | undefined
+  public readonly documentStore: string | null
 
   private constructor(
     identifier: string,
     publicBoxKey: string,
     publicSigningKey: string,
-    documentStore?: string
+    documentStore: string | null = null
   ) {
     this.identifier = identifier
     this.publicBoxKey = publicBoxKey

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -30,7 +30,7 @@ export function decodeDid(
   identifier: string,
   encoded: Option<IEncodedDidRecord>
 ): IDid | null {
-  DecoderUtils.assertCodecIsType(encoded, ['Option<Did>'])
+  DecoderUtils.assertCodecIsType(encoded, ['Option<DidRecord>'])
   if (encoded.isSome) {
     const did = encoded.unwrap()
     return {

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -34,11 +34,14 @@ export function decodeDid(
   DecoderUtils.assertCodecIsType(encoded, ['Option<DidRecord>'])
   if (encoded.isSome) {
     const did = encoded.unwrap()
+    const documentStore = did.docRef.isSome
+      ? hexToString(did.docRef.toHex())
+      : undefined
     return {
       identifier,
       publicSigningKey: did.signKey.toString(),
       publicBoxKey: did.boxKey.toString(),
-      documentStore: hexToString(did.docRef.unwrapOrDefault().toHex()),
+      documentStore,
     }
   }
 

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -7,6 +7,7 @@ import { Option, Struct, u8, Vec } from '@polkadot/types'
 import { IPublicIdentity } from '@kiltprotocol/types'
 import { Crypto, DecoderUtils, SDKErrors } from '@kiltprotocol/utils'
 import { Hash } from '@polkadot/types/interfaces'
+import { hexToString } from '@polkadot/util'
 import Identity from '../identity/Identity'
 import {
   CONTEXT,
@@ -37,7 +38,7 @@ export function decodeDid(
       identifier,
       publicSigningKey: did.signKey.toString(),
       publicBoxKey: did.boxKey.toString(),
-      documentStore: did.docRef.unwrapOrDefault().toHuman()?.toString(),
+      documentStore: hexToString(did.docRef.unwrapOrDefault().toHex()),
     }
   }
 

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -36,11 +36,11 @@ export function decodeDid(
     const did = encoded.unwrap()
     const documentStore = did.docRef.isSome
       ? hexToString(did.docRef.unwrap().toHex())
-      : undefined
+      : null
     return {
       identifier,
-      publicSigningKey: did.signKey.toString(),
-      publicBoxKey: did.boxKey.toString(),
+      publicSigningKey: did.signKey.toHex(),
+      publicBoxKey: did.boxKey.toHex(),
       documentStore,
     }
   }

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -35,7 +35,7 @@ export function decodeDid(
   if (encoded.isSome) {
     const did = encoded.unwrap()
     const documentStore = did.docRef.isSome
-      ? hexToString(did.docRef.toHex())
+      ? hexToString(did.docRef.unwrap().toHex())
       : undefined
     return {
       identifier,

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -141,11 +141,10 @@ export function verifyDidDocumentSignature(
   if (identifier !== id) {
     throw SDKErrors.ERROR_DID_IDENTIFIER_MISMATCH(identifier, id)
   }
-  const unsignedDidDocument = { ...didDocument, signature: undefined }
-  delete unsignedDidDocument.signature
+  const { signature, ...unsignedDidDocument } = didDocument
   return Crypto.verify(
     Crypto.hashObjectAsStr(unsignedDidDocument),
-    didDocument.signature,
+    signature,
     getAddressFromIdentifier(identifier)
   )
 }

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -20,7 +20,7 @@ import {
   SERVICE_KILT_MESSAGING,
 } from './Did'
 
-export interface IEncodedDid extends Struct {
+export interface IEncodedDidRecord extends Struct {
   readonly signKey: Hash
   readonly boxKey: Hash
   readonly docRef: Option<Vec<u8>>
@@ -28,7 +28,7 @@ export interface IEncodedDid extends Struct {
 
 export function decodeDid(
   identifier: string,
-  encoded: Option<IEncodedDid>
+  encoded: Option<IEncodedDidRecord>
 ): IDid | null {
   DecoderUtils.assertCodecIsType(encoded, ['Option<Did>'])
   if (encoded.isSome) {

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -141,7 +141,7 @@ export function verifyDidDocumentSignature(
   if (identifier !== id) {
     throw SDKErrors.ERROR_DID_IDENTIFIER_MISMATCH(identifier, id)
   }
-  const unsignedDidDocument = { ...didDocument }
+  const unsignedDidDocument = { ...didDocument, signature: undefined }
   delete unsignedDidDocument.signature
   return Crypto.verify(
     Crypto.hashObjectAsStr(unsignedDidDocument),


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1116
Applies changes to DID type on the mashnet-node proposed in https://github.com/KILTprotocol/mashnet-node/pull/118 as a result of mashnet-node CI failure due to clippy.

## How to test:

```
docker pull kiltprotocol/mashnet-node:develop
docker run -p 9944:9944 kiltprotocol/mashnet-node:develop --dev --ws-port 9944 --ws-external --rpc-external
yarn test:integration
```

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
