### PR TITLE
feat: export utils in sdk-js

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -29,6 +29,7 @@
     "@kiltprotocol/chain-helpers": "workspace:*",
     "@kiltprotocol/core": "workspace:*",
     "@kiltprotocol/messaging": "workspace:*",
-    "@kiltprotocol/types": "workspace:*"
+    "@kiltprotocol/types": "workspace:*",
+    "@kiltprotocol/utils": "workspace:*"
   }
 }

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -12,6 +12,7 @@ import {
   SubscriptionPromise,
 } from '@kiltprotocol/chain-helpers'
 import * as ChainHelpers from '@kiltprotocol/chain-helpers'
+import * as Utils from '@kiltprotocol/utils'
 
 export * from '@kiltprotocol/types'
 export * from '@kiltprotocol/core'
@@ -26,6 +27,7 @@ export {
   BlockchainUtils,
   SubscriptionPromise,
   ChainHelpers,
+  Utils,
 }
 
 export default {
@@ -40,4 +42,5 @@ export default {
   BlockchainUtils,
   SubscriptionPromise,
   ChainHelpers,
+  Utils,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,6 +880,7 @@ __metadata:
     "@kiltprotocol/core": "workspace:*"
     "@kiltprotocol/messaging": "workspace:*"
     "@kiltprotocol/types": "workspace:*"
+    "@kiltprotocol/utils": "workspace:*"
     rimraf: ^3.0.2
     typescript: ^3.9.7
   languageName: unknown


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1151
This PR re-exports the utils package in the sdk-js package

## How to test:
- Import the sdk-js package
- try to access a util function

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
