### PR TITLE
chore: prepare full npm publish

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: 10
       - run: yarn install --immutable
@@ -20,12 +20,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: 10
-          registry-url: https://registry.npmjs.org/
-      - run: yarn install --immutable
-      - run: npm publish --access public
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build packages
+        run: yarn run build
+      - name: Publish to NPM
+        run: yarn run publish --tag latest
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          YARN_NPM_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## relates to KILTProtocol/ticket#763
This PR fixes the npm publish ci workflow for full releases

## How to test:
Hard to test without doing the actual release.
Compare to the working devpack publish

## Checklist:

- [ ] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
