### PR TITLE
docs: Dev vs Master mixups

### DIFF
--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,6 +18,8 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
+* The Links found here are related to the `master` branch. Be aware that you might see this on the `develop` branch which is the current unstable development version. *
+
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
 - [KILT workshop](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,7 +18,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
-*You are currently viewing the develop branch documentation! This is the latest development and might break. Have a look at the [master branch](https://github.com/KILTprotocol/sdk-js/tree/master) for the released version*
+*You are currently viewing the develop branch documentation! This is the latest development and might be unstable. Have a look at the [master branch](https://github.com/KILTprotocol/sdk-js/tree/master) for the released stable version*
 
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,7 +18,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
-* The Links found here are related to the `master` branch aka the current released version. * Links outside this section point to the version you are currently viewing.
+> **The Links found here are related to the `master` branch aka the current released version.** Links outside this section point to the version you are currently viewing.
 
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,7 +18,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
-> To avoid confusion between the latest released SDK version and the `develop` default branch, the links in the list that **follow point to the master branch**, which always contains the latest official release of the SDK.
+> To avoid confusion between the latest released SDK version and the `develop` default branch, the links in the list **point to the master branch**, which always contains the latest official release of the SDK.
 
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
@@ -29,7 +29,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 - [Demo client](https://kilt.io/developers-sub/kilt-demo-client/)
 - [Demo client code](https://github.com/KILTprotocol/demo-client)
 
-To help improve, please see our [contribution page](https://github.com/KILTprotocol/sdk-js/blob/master/docs/contribution-guide.md).
+To help improve, please see our [contribution page](/docs/contribution-guide.md).
 
 ## How to install the SDK
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,14 +18,12 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
-*You are currently viewing the develop branch documentation! This is the latest development and might be unstable. Have a look at the [master branch](https://github.com/KILTprotocol/sdk-js/tree/master) for the released stable version*
-
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
-- [KILT workshop (Release Version)](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics
-- [Getting started guide (Develop Version)](/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
-- [KILT Developer overview (Released Version)](https://dev.kilt.io/) 👈 Checkout for an overview of the codebase, infrastructure and deployed KILT instances.
-- [API documentation (Released Version)](https://kiltprotocol.github.io/sdk-js)
+- [KILT workshop](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics
+- [Getting started guide](https://github.com/KILTprotocol/sdk-js/blob/master/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
+- [KILT Developer overview](https://dev.kilt.io/) 👈 Checkout for an overview of the codebase, infrastructure and deployed KILT instances.
+- [API documentation](https://kiltprotocol.github.io/sdk-js)
 - [Demo client](https://kilt.io/developers-sub/kilt-demo-client/)
 - [Demo client code](https://github.com/KILTprotocol/demo-client)
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,7 +18,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
-> **The Links found here are related to the `master` branch aka the current released version.** Links outside this section point to the version you are currently viewing.
+> To avoid confusion between the latest released SDK version and the `develop` default branch, the links in the list that **follow point to the master branch**, which always contains the latest official release of the SDK.
 
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,7 +18,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
-* The Links found here are related to the `master` branch. Be aware that you might see this on the `develop` branch which is the current unstable development version. *
+* The Links found here are related to the `master` branch aka the current released version. * Links outside this section point to the version you are currently viewing.
 
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
@@ -29,7 +29,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 - [Demo client](https://kilt.io/developers-sub/kilt-demo-client/)
 - [Demo client code](https://github.com/KILTprotocol/demo-client)
 
-To help improve, please see our [contribution page](/docs/contribution-guide.md).
+To help improve, please see our [contribution page](https://github.com/KILTprotocol/sdk-js/blob/master/docs/contribution-guide.md).
 
 ## How to install the SDK
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -21,13 +21,13 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
 - [KILT workshop](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics
-- [Getting started guide](https://github.com/KILTprotocol/sdk-js/blob/master/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
+- [Getting started guide](/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
 - [KILT Developer overview](https://dev.kilt.io/) 👈 Checkout for an overview of the codebase, infrastructure and deployed KILT instances.
 - [API documentation](https://kiltprotocol.github.io/sdk-js)
 - [Demo client](https://kilt.io/developers-sub/kilt-demo-client/)
 - [Demo client code](https://github.com/KILTprotocol/demo-client)
 
-To help improve, please see our [contribution page](https://github.com/KILTprotocol/sdk-js/blob/develop/docs/contribution-guide.md).
+To help improve, please see our [contribution page](/docs/contribution-guide.md).
 
 ## How to install the SDK
 
@@ -45,7 +45,7 @@ yarn add @kiltprotocol/sdk-js
 
 ## Example
 
-Please have a look at our examples within our [getting started guide](https://github.com/KILTprotocol/sdk-js/blob/develop/docs/getting-started.md).
+Please have a look at our examples within our [getting started guide](/docs/getting-started.md).
 
 A claim type (CTYPE) can be a credential of any kind, e.g. a drivers license, a sports club membership or even a fairtrade certificate for chocolate.
 
@@ -70,7 +70,7 @@ Claim {
 
 ## Development Setup
 
-[Development Setup](https://github.com/KILTprotocol/sdk-js/blob/develop/docs/development-setup.md)
+[Development Setup](/docs/development-setup.md)
 
 ## Job Board
 
@@ -78,4 +78,4 @@ Check to see if we have any [Job Offers](https://kilt.io/job-offers/)
 
 ## License
 
-[License](https://github.com/KILTprotocol/sdk-js/blob/develop/LICENSE)
+[License](/LICENSE)

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -18,12 +18,14 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 ## Documentation
 
+*You are currently viewing the develop branch documentation! This is the latest development and might break. Have a look at the [master branch](https://github.com/KILTprotocol/sdk-js/tree/master) for the released version*
+
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
-- [KILT workshop](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics
-- [Getting started guide](/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
-- [KILT Developer overview](https://dev.kilt.io/) 👈 Checkout for an overview of the codebase, infrastructure and deployed KILT instances.
-- [API documentation](https://kiltprotocol.github.io/sdk-js)
+- [KILT workshop (Release Version)](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics
+- [Getting started guide (Develop Version)](/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
+- [KILT Developer overview (Released Version)](https://dev.kilt.io/) 👈 Checkout for an overview of the codebase, infrastructure and deployed KILT instances.
+- [API documentation (Released Version)](https://kiltprotocol.github.io/sdk-js)
 - [Demo client](https://kilt.io/developers-sub/kilt-demo-client/)
 - [Demo client code](https://github.com/KILTprotocol/demo-client)
 


### PR DESCRIPTION
# Removes Links to Develop from Master branch

Some links are hard coded to point to the master or develop branch. This can be very confusing.

Looks like GitHub can resolve paths in the local repository. Removing the domain and branch info prevents jumps between develop and master branch.

We might need to check how this works, when the README is displayed in the API doc or on NPM.

## How to test

* ho to the start page
* select this branch
* click on links to other documentation

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
