### PR TITLE
fix listenToBalanceChanges example

### DIFF
--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -58,7 +58,7 @@ export async function getBalance(
  *
  * ```javascript
  * const address = ...
- * const unsubscribe = sdk.Balance.listenToBalanceChanges(address,
+ * const unsubscribe = await sdk.Balance.listenToBalanceChanges(address,
  *   (account: IPublicIdentity['address'], balance: BN, change: BN) => {
  *     console.log(`Balance has changed by ${change.toNumber()} to ${balance.toNumber()}`)
  *   });


### PR DESCRIPTION
The current example for `listenToBalanceChanges` doesn’t take into account that the method is `async` and returns a promise. I’ve just added an `await`.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
