### PR TITLE
feat: flexible balance formatting

### DIFF
--- a/packages/core/src/balance/Balance.utils.spec.ts
+++ b/packages/core/src/balance/Balance.utils.spec.ts
@@ -8,10 +8,20 @@ import {
   convertToTxUnit,
   asFemtoKilt,
   TRANSACTION_FEE,
+  formatKiltBalanceDecimalPlacement,
 } from './Balance.utils'
 
+const TESTVALUE = new BN('123456789000')
+const TESTVALUE_2 = new BN('123456789000000')
 describe('formatKiltBalance', () => {
-  const TESTVALUE = new BN('123456789000')
+  const alterExistingOptions = {
+    decimals: 17,
+    withUnit: 'KIL',
+  }
+  const addingOptions = {
+    // When enables displays the full unit - micro KILT
+    withSiFull: false,
+  }
   const baseValue = new BN('1')
   it('formats the given balance', async () => {
     expect(formatKiltBalance(TESTVALUE)).toEqual('123.4567 micro KILT')
@@ -43,7 +53,42 @@ describe('formatKiltBalance', () => {
       formatKiltBalance(baseValue.mul(new BN(10).pow(new BN(27))))
     ).toEqual('1.0000 Tril KILT')
   })
+  it('changes formatting options for given balances', () => {
+    expect(
+      formatKiltBalance(
+        baseValue.mul(new BN(10).pow(new BN(12))),
+        alterExistingOptions
+      )
+    ).toEqual('10.0000 micro KIL')
+    expect(
+      formatKiltBalance(
+        baseValue.mul(new BN(10).pow(new BN(12))),
+        alterExistingOptions
+      )
+    ).not.toEqual('1.0000 micro KILT')
+    expect(
+      formatKiltBalance(
+        baseValue.mul(new BN(10).pow(new BN(12))),
+        addingOptions
+      )
+    ).toEqual('1.0000 mKILT')
+  })
 })
+
+describe('format', () => {
+  it('formats the decimal placements of given balance', () => {
+    expect(formatKiltBalanceDecimalPlacement(TESTVALUE, 3, 10)).toEqual(
+      '12.345'
+    )
+    expect(formatKiltBalanceDecimalPlacement(TESTVALUE, 8, 16)).toEqual(
+      '0.00001234'
+    )
+    expect(formatKiltBalanceDecimalPlacement(TESTVALUE_2, 2, 9)).toEqual(
+      '123456.78'
+    )
+  })
+})
+
 describe('convertToTxUnit', () => {
   it('converts given value with given power to femto KILT', () => {
     expect(new BN(convertToTxUnit(new BN(1), -15).toString())).toEqual(

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -38,7 +38,6 @@ export function formatKiltBalanceDecimalPlacement(
   const factoring = new BN(10).pow(new BN(denomination - decimal))
   const skimmedAmount = amount.div(new BN(factoring))
   return (skimmedAmount.toNumber() / 10 ** decimal).toString()
-
 }
 
 export function convertToTxUnit(balance: BN, power: number): BN {

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -8,12 +8,42 @@ import { formatBalance } from '@polkadot/util'
 
 export const KILT_COIN = new BN(1)
 
-export function formatKiltBalance(amount: BN): string {
-  return formatBalance(amount, {
+// Exported options from polkadot/util
+interface Options {
+  decimals?: number
+  forceUnit?: string
+  withSi?: boolean
+  withSiFull?: boolean
+  withUnit?: boolean | string
+}
+
+export function formatKiltBalance(
+  amount: BN,
+  additionalOptions?: Options
+): string {
+  const options = {
     decimals: 15,
     withSiFull: true,
     withUnit: 'KILT',
-  })
+    ...additionalOptions,
+  }
+  return formatBalance(amount, options)
+}
+
+export function formatKiltBalanceDecimalPlacement(
+  amount: BN,
+  decimal: number,
+  denomination: number
+): string {
+  const decimalBN = new BN(decimal)
+  const denominationBN = new BN(denomination)
+
+  const balanceFactoring = new BN(10).pow(denominationBN.sub(decimalBN))
+  const powersOfTen = new BN(10).pow(decimalBN).toNumber()
+  const amountFactoring = amount.div(balanceFactoring).toNumber()
+
+  const amountDenomination = amountFactoring / powersOfTen
+  return amountDenomination.toFixed(decimal)
 }
 
 export function convertToTxUnit(balance: BN, power: number): BN {

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -35,15 +35,10 @@ export function formatKiltBalanceDecimalPlacement(
   decimal: number,
   denomination: number
 ): string {
-  const decimalBN = new BN(decimal)
-  const denominationBN = new BN(denomination)
+  const factoring = new BN(10).pow(new BN(denomination - decimal))
+  const skimmedAmount = amount.div(new BN(factoring))
+  return (skimmedAmount.toNumber() / 10 ** decimal).toString()
 
-  const balanceFactoring = new BN(10).pow(denominationBN.sub(decimalBN))
-  const powersOfTen = new BN(10).pow(decimalBN).toNumber()
-  const amountFactoring = amount.div(balanceFactoring).toNumber()
-
-  const amountDenomination = amountFactoring / powersOfTen
-  return amountDenomination.toFixed(decimal)
 }
 
 export function convertToTxUnit(balance: BN, power: number): BN {

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -9,7 +9,7 @@ import { formatBalance } from '@polkadot/util'
 export const KILT_COIN = new BN(1)
 
 // Exported options from polkadot/util
-interface Options {
+export interface Options {
   decimals?: number
   forceUnit?: string
   withSi?: boolean
@@ -60,6 +60,7 @@ export default {
   KILT_COIN,
   TRANSACTION_FEE,
   formatKiltBalance,
+  formatKiltBalanceDecimalPlacement,
   asFemtoKilt,
   convertToTxUnit,
 }

--- a/packages/core/src/balance/index.ts
+++ b/packages/core/src/balance/index.ts
@@ -1,5 +1,5 @@
-import BalanceUtils from './Balance.utils'
+import BalanceUtils, { Options } from './Balance.utils'
 import * as Balance from './Balance.chain'
 
-export { Balance, BalanceUtils }
+export { Balance, BalanceUtils, Options }
 export default Balance


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1187
To make it easier for App developers to work with Balances, we should make our formatKiltBalance more flexible.

Additionally, format it for specific decimal places

## How to test:

Added new test to balance utils

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
