### PR TITLE
feat: adding balance locked, reserved and free

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -35,7 +35,7 @@ async function setup(): Promise<{
   )
   console.log(
     'Attester balance is:',
-    await Kilt.Balance.getBalance(attester.address)
+    await Kilt.Balance.getBalances(attester.address)
   )
 
   // ------------------------- CType    ----------------------------------------

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -5,7 +5,7 @@
 import BN from 'bn.js/'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import {
-  getBalance,
+  getBalances,
   listenToBalanceChanges,
   makeTransfer,
 } from '../balance/Balance.chain'
@@ -35,24 +35,24 @@ describe('when there is a dev chain with a faucet', () => {
   })
 
   it('should have enough coins available on the faucet', async () => {
-    const balance = await getBalance(faucet.address)
+    const balance = await getBalances(faucet.address)
     expect(balance.free.gt(new BN(100_000_000))).toBeTruthy()
     // console.log(`Faucet has ${Number(balance)} micro Kilt`)
   })
 
   it('Bob has tokens', async () => {
-    const balance = await getBalance(bob.address)
+    const balance = await getBalances(bob.address)
     expect(balance.free.gt(new BN(100_000_000))).toBeTruthy()
   })
 
   it('Alice has tokens', async () => {
-    const balance = await getBalance(alice.address)
+    const balance = await getBalances(alice.address)
     expect(balance.free.gt(new BN(100_000_000))).toBeTruthy()
   })
 
-  it('getBalance should return 0 for new identity', async () => {
+  it('getBalances should return 0 for new identity', async () => {
     return expect(
-      getBalance(
+      getBalances(
         Identity.buildFromMnemonic(Identity.generateMnemonic()).address
       ).then((n) => n.free.toNumber())
     ).resolves.toEqual(0)
@@ -62,15 +62,15 @@ describe('when there is a dev chain with a faucet', () => {
     const ident = Identity.buildFromMnemonic(Identity.generateMnemonic())
     const funny = jest.fn()
     listenToBalanceChanges(ident.address, funny)
-    const balanceBefore = await getBalance(faucet.address)
+    const balanceBefore = await getBalances(faucet.address)
     await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
       BlockchainUtils.submitTxWithReSign(tx, faucet, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
       })
     )
     const [balanceAfter, balanceIdent] = await Promise.all([
-      getBalance(faucet.address),
-      getBalance(ident.address),
+      getBalances(faucet.address),
+      getBalances(ident.address),
     ])
     expect(
       balanceBefore.free.sub(balanceAfter.free).gt(MIN_TRANSACTION)
@@ -100,12 +100,12 @@ describe('When there are haves and have-nots', () => {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
         })
     )
-    const balanceTo = await getBalance(stormyD.address)
+    const balanceTo = await getBalances(stormyD.address)
     expect(balanceTo.free.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 40_000)
 
   it('should not accept transactions from identity with zero balance', async () => {
-    const originalBalance = await getBalance(stormyD.address)
+    const originalBalance = await getBalances(stormyD.address)
     await expect(
       makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
         BlockchainUtils.submitTxWithReSign(tx, bobbyBroke, {
@@ -114,15 +114,15 @@ describe('When there are haves and have-nots', () => {
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
     const [newBalance, zeroBalance] = await Promise.all([
-      getBalance(stormyD.address),
-      getBalance(bobbyBroke.address),
+      getBalances(stormyD.address),
+      getBalances(bobbyBroke.address),
     ])
     expect(newBalance.free.toNumber()).toBe(originalBalance.free.toNumber())
     expect(zeroBalance.free.toNumber()).toBe(0)
   }, 50_000)
 
   xit('should not accept transactions when sender cannot pay gas, but will keep gas fee', async () => {
-    const RichieBalance = await getBalance(richieRich.address)
+    const RichieBalance = await getBalances(richieRich.address)
     await expect(
       makeTransfer(richieRich, bobbyBroke.address, RichieBalance.free).then(
         (tx) =>
@@ -132,8 +132,8 @@ describe('When there are haves and have-nots', () => {
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
-      getBalance(richieRich.address),
-      getBalance(bobbyBroke.address),
+      getBalances(richieRich.address),
+      getBalances(bobbyBroke.address),
     ])
     expect(zeroBalance.free.toString()).toEqual('0')
     expect(newBalance.free.lt(RichieBalance.free))

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -36,25 +36,25 @@ describe('when there is a dev chain with a faucet', () => {
 
   it('should have enough coins available on the faucet', async () => {
     const balance = await getBalance(faucet.address)
-    expect(balance.gt(new BN(100_000_000))).toBeTruthy()
+    expect(balance.free.gt(new BN(100_000_000))).toBeTruthy()
     // console.log(`Faucet has ${Number(balance)} micro Kilt`)
   })
 
   it('Bob has tokens', async () => {
     const balance = await getBalance(bob.address)
-    expect(balance.gt(new BN(100_000_000))).toBeTruthy()
+    expect(balance.free.gt(new BN(100_000_000))).toBeTruthy()
   })
 
   it('Alice has tokens', async () => {
     const balance = await getBalance(alice.address)
-    expect(balance.gt(new BN(100_000_000))).toBeTruthy()
+    expect(balance.free.gt(new BN(100_000_000))).toBeTruthy()
   })
 
   it('getBalance should return 0 for new identity', async () => {
     return expect(
       getBalance(
         Identity.buildFromMnemonic(Identity.generateMnemonic()).address
-      ).then((n) => n.toNumber())
+      ).then((n) => n.free.toNumber())
     ).resolves.toEqual(0)
   })
 
@@ -72,8 +72,10 @@ describe('when there is a dev chain with a faucet', () => {
       getBalance(faucet.address),
       getBalance(ident.address),
     ])
-    expect(balanceBefore.sub(balanceAfter).gt(MIN_TRANSACTION)).toBeTruthy()
-    expect(balanceIdent.toNumber()).toBe(MIN_TRANSACTION.toNumber())
+    expect(
+      balanceBefore.free.sub(balanceAfter.free).gt(MIN_TRANSACTION)
+    ).toBeTruthy()
+    expect(balanceIdent.free.toNumber()).toBe(MIN_TRANSACTION.toNumber())
     expect(funny).toBeCalled()
   }, 30_000)
 })
@@ -99,7 +101,7 @@ describe('When there are haves and have-nots', () => {
         })
     )
     const balanceTo = await getBalance(stormyD.address)
-    expect(balanceTo.toNumber()).toBe(MIN_TRANSACTION.toNumber())
+    expect(balanceTo.free.toNumber()).toBe(MIN_TRANSACTION.toNumber())
   }, 40_000)
 
   it('should not accept transactions from identity with zero balance', async () => {
@@ -115,25 +117,26 @@ describe('When there are haves and have-nots', () => {
       getBalance(stormyD.address),
       getBalance(bobbyBroke.address),
     ])
-    expect(newBalance.toNumber()).toBe(originalBalance.toNumber())
-    expect(zeroBalance.toNumber()).toBe(0)
+    expect(newBalance.free.toNumber()).toBe(originalBalance.free.toNumber())
+    expect(zeroBalance.free.toNumber()).toBe(0)
   }, 50_000)
 
   xit('should not accept transactions when sender cannot pay gas, but will keep gas fee', async () => {
     const RichieBalance = await getBalance(richieRich.address)
     await expect(
-      makeTransfer(richieRich, bobbyBroke.address, RichieBalance).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, richieRich, {
-          resolveOn: BlockchainUtils.IS_IN_BLOCK,
-        })
+      makeTransfer(richieRich, bobbyBroke.address, RichieBalance.free).then(
+        (tx) =>
+          BlockchainUtils.submitTxWithReSign(tx, richieRich, {
+            resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          })
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
       getBalance(richieRich.address),
       getBalance(bobbyBroke.address),
     ])
-    expect(zeroBalance.toString()).toEqual('0')
-    expect(newBalance.lt(RichieBalance))
+    expect(zeroBalance.free.toString()).toEqual('0')
+    expect(newBalance.free.lt(RichieBalance.free))
   }, 30_000)
 
   it('should be able to make a new transaction once the last is ready', async () => {

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -10,7 +10,11 @@
 
 import { UnsubscribePromise } from '@polkadot/api/types'
 import BN from 'bn.js'
-import type { IPublicIdentity, SubmittableExtrinsic } from '@kiltprotocol/types'
+import type {
+  Balances,
+  IPublicIdentity,
+  SubmittableExtrinsic,
+} from '@kiltprotocol/types'
 import {
   BlockchainApiConnection,
   // BlockchainUtils,
@@ -19,13 +23,6 @@ import { AccountData } from '@polkadot/types/interfaces'
 
 import Identity from '../identity/Identity'
 import BalanceUtils from './Balance.utils'
-
-export type Balance = {
-  free: BN
-  reserved: BN
-  miscFrozen: BN
-  feeFrozen: BN
-}
 
 /**
  * Fetches the current balance of the account with [accountAddress].
@@ -79,8 +76,8 @@ export async function listenToBalanceChanges(
   accountAddress: IPublicIdentity['address'],
   listener: (
     account: IPublicIdentity['address'],
-    balance: Balance,
-    change: Balance
+    balance: Balances,
+    change: Balances
   ) => void
 ): Promise<UnsubscribePromise> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -49,7 +49,7 @@ export async function getBalances(
 
 /**
  * Attaches the given [listener] for balance changes on the account with [accountAddress].
- * <B>Note that the balance amounts is in Femto-Kilt (1e-15) and must be translated to Kilt-Coin</B>.
+ * <B>Note that the balance amounts are in Femto-Kilt (1e-15) and must be translated to Kilt-Coin</B>.
  *
  * @param accountAddress Address of the account on which to listen for all balance changes.
  * @param listener Listener to receive all balance change updates.

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -40,13 +40,13 @@ export type Balance = {
  * ```javascript
  *
  * const address = ...
- * sdk.Balance.getBalance(address)
+ * sdk.Balance.getBalances(address)
  *   .then((balance: BN) => {
  *     console.log(`balance is ${balance.toNumber()}`)
  *   })
  * ```
  */
-export async function getBalance(
+export async function getBalances(
   accountAddress: IPublicIdentity['address']
 ): Promise<AccountData> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
@@ -84,7 +84,7 @@ export async function listenToBalanceChanges(
   ) => void
 ): Promise<UnsubscribePromise> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const previous = await getBalance(accountAddress)
+  const previous = await getBalances(accountAddress)
 
   const previousFree = new BN(previous.free.toString())
   const previousReserved = new BN(previous.reserved.toString())

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -16,7 +16,6 @@ import type {
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import { AccountData } from '@polkadot/types/interfaces'
 
 import Identity from '../identity/Identity'
 import BalanceUtils from './Balance.utils'
@@ -42,7 +41,7 @@ import BalanceUtils from './Balance.utils'
  */
 export async function getBalances(
   accountAddress: IPublicIdentity['address']
-): Promise<AccountData> {
+): Promise<Balances> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
 
   return (await blockchain.api.query.system.account(accountAddress)).data
@@ -80,20 +79,16 @@ export async function listenToBalanceChanges(
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const previousBalances = await getBalances(accountAddress)
 
-  const previousFree = new BN(previousBalances.free.toString())
-  const previousReserved = new BN(previousBalances.reserved.toString())
-  const previousMiscFrozen = new BN(previousBalances.miscFrozen.toString())
-  const previousFeeFrozen = new BN(previousBalances.feeFrozen.toString())
-
   return blockchain.api.query.system.account(
     accountAddress,
     ({ data: { free, reserved, miscFrozen, feeFrozen } }) => {
       const balancesChange = {
-        free: free.sub(previousFree),
-        reserved: reserved.sub(previousReserved),
-        miscFrozen: miscFrozen.sub(previousMiscFrozen),
-        feeFrozen: feeFrozen.sub(previousFeeFrozen),
+        free: free.sub(previousBalances.free),
+        reserved: reserved.sub(previousBalances.reserved),
+        miscFrozen: miscFrozen.sub(previousBalances.miscFrozen),
+        feeFrozen: feeFrozen.sub(previousBalances.feeFrozen),
       }
+
       const current = {
         free: new BN(free),
         reserved: new BN(reserved),

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -22,7 +22,7 @@ import BalanceUtils from './Balance.utils'
 
 /**
  * Fetches the current balances of the account with [accountAddress].
- * <B>Note that the balance amounts is in Femto-Kilt (1e-15)and must be translated to Kilt-Coin</B>.
+ * <B>Note that the balance amounts are in Femto-Kilt (1e-15)and must be translated to Kilt-Coin</B>.
  *
  * @param accountAddress Address of the account for which to get the balances.
  * @returns A promise containing the current balances of the account.

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -11,7 +11,7 @@ import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import Identity from '../identity/Identity'
 import {
   Balance,
-  getBalance,
+  getBalances,
   listenToBalanceChanges,
   makeTransfer,
 } from './Balance.chain'
@@ -71,7 +71,7 @@ describe('Balance', () => {
     }
 
     await listenToBalanceChanges(bob.address, listener)
-    const currentBalance = await getBalance(bob.address)
+    const currentBalance = await getBalances(bob.address)
     expect(currentBalance.free.toNumber()).toBeTruthy()
     expect(currentBalance.free.toNumber()).toEqual(BALANCE - FEE)
   })

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -8,9 +8,9 @@ import { AccountData, AccountInfo } from '@polkadot/types/interfaces'
 import BN from 'bn.js/'
 import TYPE_REGISTRY from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Balances } from '@kiltprotocol/types'
 import Identity from '../identity/Identity'
 import {
-  Balance,
   getBalances,
   listenToBalanceChanges,
   makeTransfer,
@@ -61,8 +61,8 @@ describe('Balance', () => {
   it('should listen to balance changes', async (done) => {
     const listener = (
       account: string,
-      balance: Balance,
-      change: Balance
+      balance: Balances,
+      change: Balances
     ): void => {
       expect(account).toBe(bob.address)
       expect(balance.free.toNumber()).toBe(BALANCE)

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -10,6 +10,7 @@ import TYPE_REGISTRY from '@kiltprotocol/chain-helpers/lib/blockchainApiConnecti
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import Identity from '../identity/Identity'
 import {
+  Balance,
   getBalance,
   listenToBalanceChanges,
   makeTransfer,
@@ -58,17 +59,21 @@ describe('Balance', () => {
     bob = Identity.buildFromURI('//Bob')
   })
   it('should listen to balance changes', async (done) => {
-    const listener = (account: string, balance: BN, change: BN): void => {
+    const listener = (
+      account: string,
+      balance: Balance,
+      change: Balance
+    ): void => {
       expect(account).toBe(bob.address)
-      expect(balance.toNumber()).toBe(BALANCE)
-      expect(change.toNumber()).toBe(FEE)
+      expect(balance.free.toNumber()).toBe(BALANCE)
+      expect(change.free.toNumber()).toBe(FEE)
       done()
     }
 
     await listenToBalanceChanges(bob.address, listener)
     const currentBalance = await getBalance(bob.address)
-    expect(currentBalance.toNumber()).toBeTruthy()
-    expect(currentBalance.toNumber()).toEqual(BALANCE - FEE)
+    expect(currentBalance.free.toNumber()).toBeTruthy()
+    expect(currentBalance.free.toNumber()).toEqual(BALANCE - FEE)
   })
 
   it('should make transfer', async () => {

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -61,12 +61,12 @@ describe('Balance', () => {
   it('should listen to balance changes', async (done) => {
     const listener = (
       account: string,
-      balance: Balances,
-      change: Balances
+      balances: Balances,
+      changes: Balances
     ): void => {
       expect(account).toBe(bob.address)
-      expect(balance.free.toNumber()).toBe(BALANCE)
-      expect(change.free.toNumber()).toBe(FEE)
+      expect(balances.free.toNumber()).toBe(BALANCE)
+      expect(changes.free.toNumber()).toBe(FEE)
       done()
     }
 

--- a/packages/core/src/balance/Balance.utils.spec.ts
+++ b/packages/core/src/balance/Balance.utils.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import BN from 'bn.js'
+import { BalanceOptions } from '@kiltprotocol/types'
 import {
   formatKiltBalance,
   convertToTxUnit,
@@ -14,11 +15,11 @@ import {
 const TESTVALUE = new BN('123456789000')
 const TESTVALUE_2 = new BN('123456789000000')
 describe('formatKiltBalance', () => {
-  const alterExistingOptions = {
+  const alterExistingOptions: BalanceOptions = {
     decimals: 17,
     withUnit: 'KIL',
   }
-  const addingOptions = {
+  const addingOptions: BalanceOptions = {
     // When enables displays the full unit - micro KILT
     withSiFull: false,
   }

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -5,21 +5,13 @@
 
 import BN from 'bn.js'
 import { formatBalance } from '@polkadot/util'
+import { BalanceOptions } from '@kiltprotocol/types'
 
 export const KILT_COIN = new BN(1)
 
-// Exported options from polkadot/util
-export interface Options {
-  decimals?: number
-  forceUnit?: string
-  withSi?: boolean
-  withSiFull?: boolean
-  withUnit?: boolean | string
-}
-
 export function formatKiltBalance(
   amount: BN,
-  additionalOptions?: Options
+  additionalOptions?: BalanceOptions
 ): string {
   const options = {
     decimals: 15,

--- a/packages/core/src/balance/index.ts
+++ b/packages/core/src/balance/index.ts
@@ -1,5 +1,5 @@
-import BalanceUtils, { Options } from './Balance.utils'
+import BalanceUtils from './Balance.utils'
 import * as Balance from './Balance.chain'
 
-export { Balance, BalanceUtils, Options }
+export { Balance, BalanceUtils }
 export default Balance

--- a/packages/types/src/Balance.ts
+++ b/packages/types/src/Balance.ts
@@ -1,0 +1,13 @@
+/**
+ * @packageDocumentation
+ * @module IBalance
+ */
+
+import BN from 'bn.js'
+
+export type Balances = {
+  free: BN
+  reserved: BN
+  miscFrozen: BN
+  feeFrozen: BN
+}

--- a/packages/types/src/Balance.ts
+++ b/packages/types/src/Balance.ts
@@ -11,3 +11,12 @@ export type Balances = {
   miscFrozen: BN
   feeFrozen: BN
 }
+
+// Extracted options from polkadot/util
+export interface BalanceOptions {
+  decimals?: number
+  forceUnit?: string
+  withSi?: boolean
+  withSiFull?: boolean
+  withUnit?: boolean | string
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ export * as SubscriptionPromise from './SubscriptionPromise'
 
 export * from './AttestedClaim'
 export * from './Attestation'
+export * from './Balance'
 export * from './CType'
 export * from './CTypeMetadata'
 export * from './Claim'


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1201

Adding locked, reserved and free balances. 
Unable to add bonded, staked and vesting as pallets are not implemented. 

## How to test:

Run yarn test && yarn test:integration

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
