### PR TITLE
feat: adding types usage for imports

### DIFF
--- a/packages/actors_api/src/actors/Attester.spec.ts
+++ b/packages/actors_api/src/actors/Attester.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { CType, Identity, SDKErrors } from '@kiltprotocol/core'
-import { ICType, IClaim, IMessage } from '@kiltprotocol/types'
+import type { ICType, IClaim, IMessage } from '@kiltprotocol/types'
 import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
 import Message from '@kiltprotocol/messaging'
 import { Attester, Claimer } from '..'

--- a/packages/actors_api/src/actors/Claimer.spec.ts
+++ b/packages/actors_api/src/actors/Claimer.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { CType, Identity, SDKErrors } from '@kiltprotocol/core'
-import {
+import type {
   IClaim,
   ICType,
   IRequestClaimsForCTypes,
@@ -14,7 +14,7 @@ import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchain
 import Message from '@kiltprotocol/messaging'
 import { Attester, Claimer, Verifier } from '..'
 import Credential from '../credential/Credential'
-import { ClaimerAttestationSession } from './Claimer'
+import type { ClaimerAttestationSession } from './Claimer'
 
 jest.mock(
   '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/BlockchainApiConnection'

--- a/packages/actors_api/src/actors/Claimer.ts
+++ b/packages/actors_api/src/actors/Claimer.ts
@@ -9,7 +9,7 @@ import {
   RequestForAttestation,
   SDKErrors,
 } from '@kiltprotocol/core'
-import {
+import type {
   IClaim,
   IMessage,
   IRequestAttestationForClaim,

--- a/packages/actors_api/src/actors/Verifier.spec.ts
+++ b/packages/actors_api/src/actors/Verifier.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { CType, Identity } from '@kiltprotocol/core'
-import { IClaim, ICType } from '@kiltprotocol/types'
+import type { IClaim, ICType } from '@kiltprotocol/types'
 import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
 import Message from '@kiltprotocol/messaging'
 import { Attester, Claimer, Verifier } from '..'

--- a/packages/actors_api/src/actors/Verifier.ts
+++ b/packages/actors_api/src/actors/Verifier.ts
@@ -5,7 +5,7 @@
 
 import { AttestedClaim, CType, SDKErrors, Identity } from '@kiltprotocol/core'
 import { ConfigService } from '@kiltprotocol/config'
-import {
+import type {
   IPublicIdentity,
   IAttestedClaim,
   IRequestForAttestation,

--- a/packages/actors_api/src/credential/Credential.spec.ts
+++ b/packages/actors_api/src/credential/Credential.spec.ts
@@ -9,7 +9,7 @@ import {
   Identity,
   RequestForAttestation,
 } from '@kiltprotocol/core'
-import { ICType } from '@kiltprotocol/types'
+import type { ICType } from '@kiltprotocol/types'
 import Credential from './Credential'
 
 describe('Credential', () => {

--- a/packages/actors_api/src/credential/Credential.ts
+++ b/packages/actors_api/src/credential/Credential.ts
@@ -11,7 +11,7 @@
  */
 
 import { AttestedClaim } from '@kiltprotocol/core'
-import { IAttestation, IRequestForAttestation } from '@kiltprotocol/types'
+import type { IAttestation, IRequestForAttestation } from '@kiltprotocol/types'
 
 export interface ICredential {
   readonly reqForAtt: IRequestForAttestation

--- a/packages/actors_api/src/index.ts
+++ b/packages/actors_api/src/index.ts
@@ -2,6 +2,6 @@ import * as Attester from './actors/Attester'
 import * as Claimer from './actors/Claimer'
 import * as Verifier from './actors/Verifier'
 import Credential from './credential/Credential'
-import * as types from './types'
+import type * as types from './types'
 
 export { Verifier, Claimer, Attester, Credential, types }

--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -5,8 +5,8 @@
 /* eslint-disable dot-notation */
 import { SDKErrors } from '@kiltprotocol/utils'
 import { Text } from '@polkadot/types'
-import { SignerPayload } from '@polkadot/types/interfaces/types'
-import { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
+import type { SignerPayload } from '@polkadot/types/interfaces/types'
+import type { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
 import BN from 'bn.js'
 import { Keyring } from '@polkadot/keyring'
 import type {

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -8,10 +8,10 @@
  */
 
 import type { ApiPromise } from '@polkadot/api'
-import { Header } from '@polkadot/types/interfaces/types'
-import { AnyJson, Codec } from '@polkadot/types/types'
+import type { Header } from '@polkadot/types/interfaces/types'
+import type { AnyJson, Codec } from '@polkadot/types/types'
 import { Text } from '@polkadot/types'
-import { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
+import type { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
 import BN from 'bn.js'
 import { SDKErrors } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -7,7 +7,7 @@
  * @module Blockchain
  */
 
-import { ApiPromise } from '@polkadot/api'
+import type { ApiPromise } from '@polkadot/api'
 import { Header } from '@polkadot/types/interfaces/types'
 import { AnyJson, Codec } from '@polkadot/types/types'
 import { Text } from '@polkadot/types'
@@ -135,7 +135,7 @@ export default class Blockchain implements IBlockchainApi {
    * [ASYNC] Retrieves the Nonce for Transaction signing for the specified account and increments the in accountNonces mapped Index.
    *
    * @param accountAddress The address of the identity that we retrieve the nonce for.
-   * @returns {@link https://github.com/indutny/bn.js/ | BN} representation of the Tx nonce for the identity.
+   * @returns Representation of the Tx nonce for the identity.
    *
    */
   public async getNonce(accountAddress: string): Promise<BN> {

--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import { SubscriptionPromise } from '@kiltprotocol/types'
+import type { SubscriptionPromise } from '@kiltprotocol/types'
 import { makeSubscriptionPromise } from './SubscriptionPromise'
 
 const RESOLVE = 'resolve'

--- a/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -8,7 +8,7 @@
  */
 
 import { ApiPromise, WsProvider } from '@polkadot/api'
-import { RegistryTypes } from '@polkadot/types/types'
+import type { RegistryTypes } from '@polkadot/types/types'
 import { ConfigService } from '@kiltprotocol/config'
 import Blockchain from '../blockchain/Blockchain'
 

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -46,7 +46,7 @@
 
 import Blockchain from '../../blockchain/Blockchain'
 import { ApiPromise, SubmittableResult } from '@polkadot/api'
-import {
+import type {
   AccountInfoWithProviders,
   ExtrinsicStatus,
   Index,

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -1,6 +1,6 @@
 import { Option, TypeRegistry, U8aFixed, U64, Vec, U8 } from '@polkadot/types'
-import { Codec } from '@polkadot/types/types'
-import { Constructor } from '@polkadot/util/types'
+import type { Codec } from '@polkadot/types/types'
+import type { Constructor } from '@polkadot/util/types'
 import { CUSTOM_TYPES } from '../BlockchainApiConnection'
 
 const TYPE_REGISTRY = new TypeRegistry()

--- a/packages/chain-helpers/src/errorhandling/ErrorHandler.spec.ts
+++ b/packages/chain-helpers/src/errorhandling/ErrorHandler.spec.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { Tuple } from '@polkadot/types'
+import type { Tuple } from '@polkadot/types'
 import type { ISubmittableResult } from '@kiltprotocol/types'
 import { ErrorHandler, PalletIndex } from '.'
 import { ExtrinsicError, ExtrinsicErrors } from './ExtrinsicError'

--- a/packages/chain-helpers/src/errorhandling/ErrorHandler.ts
+++ b/packages/chain-helpers/src/errorhandling/ErrorHandler.ts
@@ -6,7 +6,7 @@
  * @preferred
  */
 
-import { EventRecord } from '@polkadot/types/interfaces'
+import type { EventRecord } from '@polkadot/types/interfaces'
 import type { ISubmittableResult } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
 import { errorForPallet, ExtrinsicError } from './ExtrinsicError'

--- a/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
+++ b/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
@@ -5,7 +5,7 @@
  * @module ErrorHandler
  */
 
-import { ModuleError } from './ErrorHandler'
+import type { ModuleError } from './ErrorHandler'
 
 /**
  * @internal

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -2,7 +2,7 @@
  * @group integration/attestation
  */
 
-import { IAttestedClaim, IClaim } from '@kiltprotocol/types'
+import type { IAttestedClaim, IClaim } from '@kiltprotocol/types'
 import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
 import Attestation from '../attestation/Attestation'
 import { revoke } from '../attestation/Attestation.chain'

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -2,10 +2,10 @@
  * @group integration/blockchain
  */
 
-import { SignerPayload } from '@polkadot/types/interfaces/extrinsics/types'
+import type { SignerPayload } from '@polkadot/types/interfaces/extrinsics/types'
 import BN from 'bn.js/'
 import { SDKErrors } from '@kiltprotocol/utils'
-import { IBlockchainApi } from '@kiltprotocol/types'
+import type { IBlockchainApi } from '@kiltprotocol/types'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { makeTransfer } from '../balance/Balance.chain'
 import Identity from '../identity/Identity'

--- a/packages/core/src/__integrationtests__/ChainConnectivity.spec.ts
+++ b/packages/core/src/__integrationtests__/ChainConnectivity.spec.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Header } from '@polkadot/types/interfaces/types'
+import type { Header } from '@polkadot/types/interfaces/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { WS_ADDRESS } from './utils'
 import { config, disconnect } from '../kilt'

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -2,7 +2,7 @@
  * @group integration/ctype
  */
 
-import { ICType } from '@kiltprotocol/types'
+import type { ICType } from '@kiltprotocol/types'
 import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
 import { Identity } from '..'
 import CType from '../ctype/CType'

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -2,7 +2,8 @@
  * @group integration/delegation
  */
 
-import { Permission, ICType } from '@kiltprotocol/types'
+import type { ICType } from '@kiltprotocol/types'
+import { Permission } from '@kiltprotocol/types'
 import { UUID } from '@kiltprotocol/utils'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { AttestedClaim, Identity } from '..'

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -5,7 +5,7 @@
 import { Option, Struct } from '@polkadot/types'
 import type { IAttestation, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { DecoderUtils } from '@kiltprotocol/utils'
-import { AccountId, Hash } from '@polkadot/types/interfaces'
+import type { AccountId, Hash } from '@polkadot/types/interfaces'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import Identity from '../identity/Identity'

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -10,7 +10,7 @@ import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import Identity from '../identity/Identity'
 import Attestation from './Attestation'
-import { DelegationNodeId } from '../delegation/DelegationDecoder'
+import type { DelegationNodeId } from '../delegation/DelegationDecoder'
 
 const log = ConfigService.LoggingFactory.getLogger('Attestation')
 

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/attestation
  */
 
-import {
+import type {
   IAttestation,
   CompressedAttestation,
   ICType,

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -11,8 +11,8 @@
  * @preferred
  */
 
-import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
-import {
+import type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
+import type {
   IPublicIdentity,
   IAttestation,
   IRequestForAttestation,

--- a/packages/core/src/attestation/Attestation.utils.ts
+++ b/packages/core/src/attestation/Attestation.utils.ts
@@ -3,7 +3,7 @@
  * @module AttestationUtils
  */
 
-import { IAttestation, CompressedAttestation } from '@kiltprotocol/types'
+import type { IAttestation, CompressedAttestation } from '@kiltprotocol/types'
 import { DataUtils, SDKErrors } from '@kiltprotocol/utils'
 
 /**

--- a/packages/core/src/attestedclaim/AttestedClaim.spec.ts
+++ b/packages/core/src/attestedclaim/AttestedClaim.spec.ts
@@ -2,7 +2,11 @@
  * @group unit/attestation
  */
 
-import { IClaim, CompressedAttestedClaim, ICType } from '@kiltprotocol/types'
+import type {
+  IClaim,
+  CompressedAttestedClaim,
+  ICType,
+} from '@kiltprotocol/types'
 import Attestation from '../attestation/Attestation'
 import Claim from '../claim/Claim'
 import CType from '../ctype/CType'

--- a/packages/core/src/attestedclaim/AttestedClaim.ts
+++ b/packages/core/src/attestedclaim/AttestedClaim.ts
@@ -9,7 +9,7 @@
  * @module AttestedClaim
  */
 
-import {
+import type {
   IAttestedClaim,
   CompressedAttestedClaim,
   IAttestation,

--- a/packages/core/src/attestedclaim/AttestedClaim.utils.ts
+++ b/packages/core/src/attestedclaim/AttestedClaim.utils.ts
@@ -3,7 +3,10 @@
  * @module AttestedClaimUtils
  */
 
-import { IAttestedClaim, CompressedAttestedClaim } from '@kiltprotocol/types'
+import type {
+  IAttestedClaim,
+  CompressedAttestedClaim,
+} from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import AttestationUtils from '../attestation/Attestation.utils'
 import RequestForAttestationUtils from '../requestforattestation/RequestForAttestation.utils'

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -8,7 +8,7 @@
  * @module Balance
  */
 
-import { UnsubscribePromise } from '@polkadot/api/types'
+import type { UnsubscribePromise } from '@polkadot/api/types'
 import BN from 'bn.js'
 import type {
   Balances,

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -4,11 +4,11 @@
 
 import { SubmittableResult } from '@polkadot/api'
 import { GenericAccountIndex as AccountIndex } from '@polkadot/types/generic/AccountIndex'
-import { AccountData, AccountInfo } from '@polkadot/types/interfaces'
+import type { AccountData, AccountInfo } from '@polkadot/types/interfaces'
 import BN from 'bn.js/'
 import TYPE_REGISTRY from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
-import { Balances } from '@kiltprotocol/types'
+import type { Balances } from '@kiltprotocol/types'
 import Identity from '../identity/Identity'
 import {
   getBalances,

--- a/packages/core/src/balance/Balance.utils.spec.ts
+++ b/packages/core/src/balance/Balance.utils.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import BN from 'bn.js'
-import { BalanceOptions } from '@kiltprotocol/types'
+import type { BalanceOptions } from '@kiltprotocol/types'
 import {
   formatKiltBalance,
   convertToTxUnit,

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -5,7 +5,7 @@
 
 import BN from 'bn.js'
 import { formatBalance } from '@polkadot/util'
-import { BalanceOptions } from '@kiltprotocol/types'
+import type { BalanceOptions } from '@kiltprotocol/types'
 
 export const KILT_COIN = new BN(1)
 

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import { IClaim, CompressedClaim, ICType } from '@kiltprotocol/types'
+import type { IClaim, CompressedClaim, ICType } from '@kiltprotocol/types'
 import CType from '../ctype/CType'
 import Identity from '../identity/Identity'
 import Claim from './Claim'

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -11,7 +11,7 @@
  * @module Claim
  */
 
-import {
+import type {
   IClaim,
   CompressedClaim,
   IPublicIdentity,

--- a/packages/core/src/claim/Claim.utils.spec.ts
+++ b/packages/core/src/claim/Claim.utils.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/claim
  */
 
-import { IClaim } from '@kiltprotocol/types'
+import type { IClaim } from '@kiltprotocol/types'
 import { hashClaimContents, toJsonLD } from './Claim.utils'
 
 const claim: IClaim = {

--- a/packages/core/src/claim/Claim.utils.ts
+++ b/packages/core/src/claim/Claim.utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { hexToBn } from '@polkadot/util'
-import {
+import type {
   IClaim,
   CompressedClaim,
   PartialClaim,

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -3,8 +3,8 @@
  * @module CType
  */
 
-import { Option } from '@polkadot/types'
-import { AccountId } from '@polkadot/types/interfaces'
+import type { Option } from '@polkadot/types'
+import type { AccountId } from '@polkadot/types/interfaces'
 import type {
   ICType,
   IPublicIdentity,

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -6,7 +6,7 @@ import { SubmittableResult } from '@polkadot/api'
 import { TypeRegistry } from '@polkadot/types'
 import { Option } from '@polkadot/types/codec'
 import { SDKErrors } from '@kiltprotocol/utils'
-import {
+import type {
   ICType,
   CompressedCType,
   CTypeSchemaWithoutId,

--- a/packages/core/src/ctype/CType.utils.spec.ts
+++ b/packages/core/src/ctype/CType.utils.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/ctype
  */
 
-import { ICType } from '@kiltprotocol/types'
+import type { ICType } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import {
   verifyClaimStructure,

--- a/packages/core/src/ctype/CType.utils.ts
+++ b/packages/core/src/ctype/CType.utils.ts
@@ -4,7 +4,7 @@
  */
 
 import Ajv from 'ajv'
-import {
+import type {
   ICType,
   IClaim,
   CompressedCType,

--- a/packages/core/src/ctype/CTypeMetadata.spec.ts
+++ b/packages/core/src/ctype/CTypeMetadata.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import { ICType, ICTypeMetadata } from '@kiltprotocol/types'
+import type { ICType, ICTypeMetadata } from '@kiltprotocol/types'
 import Identity from '../identity/Identity'
 import CType from './CType'
 import CTypeUtils from './CType.utils'

--- a/packages/core/src/ctype/CTypeMetadata.ts
+++ b/packages/core/src/ctype/CTypeMetadata.ts
@@ -3,7 +3,7 @@
  * @module CTypeMetadata
  */
 
-import { ICTypeMetadata } from '@kiltprotocol/types'
+import type { ICTypeMetadata } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import CTypeUtils from './CType.utils'
 import { MetadataModel } from './CTypeSchema'

--- a/packages/core/src/ctype/CTypeNested.spec.ts
+++ b/packages/core/src/ctype/CTypeNested.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/ctype
  */
 
-import { ICType, IClaim, IClaimContents } from '@kiltprotocol/types'
+import type { ICType, IClaim, IClaimContents } from '@kiltprotocol/types'
 import CType from './CType'
 import Identity from '../identity/Identity'
 import Claim from '../claim/Claim'

--- a/packages/core/src/delegation/Delegation.chain.ts
+++ b/packages/core/src/delegation/Delegation.chain.ts
@@ -8,7 +8,7 @@ import type { H256 } from '@polkadot/types/interfaces'
 import type { IDelegationBaseNode } from '@kiltprotocol/types'
 import { DecoderUtils } from '@kiltprotocol/utils'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import { CodecWithId, IChainDelegationNode } from './DelegationDecoder'
+import type { CodecWithId, IChainDelegationNode } from './DelegationDecoder'
 
 function decodeDelegatedAttestations(queryResult: Vec<H256>): string[] {
   DecoderUtils.assertCodecIsType(queryResult, ['Vec<Hash>'])

--- a/packages/core/src/delegation/Delegation.chain.ts
+++ b/packages/core/src/delegation/Delegation.chain.ts
@@ -3,9 +3,9 @@
  * @module DelegationBaseNode
  */
 
-import { Option, Vec } from '@polkadot/types'
-import { H256 } from '@polkadot/types/interfaces'
-import { IDelegationBaseNode } from '@kiltprotocol/types'
+import type { Option, Vec } from '@polkadot/types'
+import type { H256 } from '@polkadot/types/interfaces'
+import type { IDelegationBaseNode } from '@kiltprotocol/types'
 import { DecoderUtils } from '@kiltprotocol/utils'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { CodecWithId, IChainDelegationNode } from './DelegationDecoder'

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -11,11 +11,12 @@
 /**
  * Dummy comment needed for correct doc display, do not remove.
  */
-import { Option } from '@polkadot/types'
-import { IDelegationRootNode, Permission } from '@kiltprotocol/types'
-import { Struct } from '@polkadot/types/codec'
-import { AccountId, Hash } from '@polkadot/types/interfaces/runtime'
-import { u32 } from '@polkadot/types/primitive'
+import { Permission } from '@kiltprotocol/types'
+import type { Option } from '@polkadot/types'
+import type { IDelegationRootNode } from '@kiltprotocol/types'
+import type { Struct } from '@polkadot/types/codec'
+import type { AccountId, Hash } from '@polkadot/types/interfaces/runtime'
+import type { u32 } from '@polkadot/types/primitive'
 import { DecoderUtils } from '@kiltprotocol/utils'
 import { DelegationNode } from '..'
 

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -3,7 +3,7 @@
  * @module DelegationNode
  */
 
-import { Option } from '@polkadot/types'
+import type { Option } from '@polkadot/types'
 import type { IDelegationNode, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -3,7 +3,7 @@
  * @module DelegationNodeUtils
  */
 
-import { IAttestation, IDelegationNode } from '@kiltprotocol/types'
+import type { IAttestation, IDelegationNode } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import Identity from '../identity'
 import DelegationNode from './DelegationNode'

--- a/packages/core/src/delegation/DelegationRootNode.chain.ts
+++ b/packages/core/src/delegation/DelegationRootNode.chain.ts
@@ -3,7 +3,7 @@
  * @module DelegationRootNode
  */
 
-import { Option } from '@polkadot/types'
+import type { Option } from '@polkadot/types'
 import type {
   IDelegationRootNode,
   SubmittableExtrinsic,

--- a/packages/core/src/did/Did.chain.ts
+++ b/packages/core/src/did/Did.chain.ts
@@ -7,7 +7,7 @@ import { Option } from '@polkadot/types'
 import type { IPublicIdentity, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import Identity from '../identity/Identity'
-import { IDid } from './Did'
+import type { IDid } from './Did'
 import {
   decodeDid,
   getAddressFromIdentifier,

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -3,10 +3,10 @@
  * @module DIDUtils
  */
 
-import { Option, Struct, u8, Vec } from '@polkadot/types'
-import { IPublicIdentity } from '@kiltprotocol/types'
+import type { Option, Struct, u8, Vec } from '@polkadot/types'
+import type { IPublicIdentity } from '@kiltprotocol/types'
 import { Crypto, DecoderUtils, SDKErrors } from '@kiltprotocol/utils'
-import { Hash } from '@polkadot/types/interfaces'
+import type { Hash } from '@polkadot/types/interfaces'
 import { hexToString } from '@polkadot/util'
 import Identity from '../identity/Identity'
 import {

--- a/packages/core/src/identity/PublicIdentity.spec.ts
+++ b/packages/core/src/identity/PublicIdentity.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { U8aFixed } from '@polkadot/types'
-import { IPublicIdentity } from '@kiltprotocol/types'
+import type { IPublicIdentity } from '@kiltprotocol/types'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'

--- a/packages/core/src/identity/PublicIdentity.ts
+++ b/packages/core/src/identity/PublicIdentity.ts
@@ -5,7 +5,7 @@
  * @module PublicIdentity
  */
 
-import { IPublicIdentity } from '@kiltprotocol/types'
+import type { IPublicIdentity } from '@kiltprotocol/types'
 import Did, {
   IDENTIFIER_PREFIX,
   KEY_TYPE_ENCRYPTION,

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/quote
  */
 
-import {
+import type {
   IClaim,
   ICType,
   CompressedQuote,

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -10,7 +10,7 @@
  */
 
 import Ajv from 'ajv'
-import {
+import type {
   IQuote,
   IQuoteAgreement,
   IQuoteAttesterSigned,

--- a/packages/core/src/quote/Quote.utils.ts
+++ b/packages/core/src/quote/Quote.utils.ts
@@ -3,7 +3,7 @@
  * @module QuoteUtils
  */
 
-import {
+import type {
   CompressedCostBreakdown,
   CompressedQuote,
   CompressedQuoteAgreed,

--- a/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable dot-notation */
 import { hexToU8a } from '@polkadot/util'
-import {
+import type {
   IClaim,
   IClaimContents,
   CompressedAttestedClaim,

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -10,7 +10,7 @@
  * @module RequestForAttestation
  */
 
-import {
+import type {
   IRequestForAttestation,
   CompressedRequestForAttestation,
   Hash,

--- a/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
@@ -3,7 +3,7 @@
  * @module RequestForAttestationUtils
  */
 
-import {
+import type {
   IAttestedClaim,
   CompressedAttestedClaim,
   CompressedRequestForAttestation,

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/messaging
  */
 
-import {
+import type {
   IAttestedClaim,
   IClaim,
   IEncryptedMessage,

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -11,15 +11,15 @@
  */
 
 import { Identity } from '@kiltprotocol/core'
-import {
+import type {
   IPublicIdentity,
   CompressedMessageBody,
   IMessage,
   ISubmitClaimsForCTypes,
   IEncryptedMessage,
   MessageBody,
-  MessageBodyType,
 } from '@kiltprotocol/types'
+import { MessageBodyType } from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import { compressMessage, decompressMessage } from './Message.utils'
 

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -2,7 +2,7 @@
  * @group unit/messaging
  */
 
-import {
+import type {
   CompressedQuoteAttesterSigned,
   CompressedQuoteAgreed,
   ICType,

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -10,7 +10,7 @@ import {
   QuoteUtils,
   RequestForAttestationUtils,
 } from '@kiltprotocol/core'
-import {
+import type {
   IAttestedClaim,
   CompressedAttestedClaim,
   CompressedMessageBody,

--- a/packages/types/src/Attestation.ts
+++ b/packages/types/src/Attestation.ts
@@ -2,9 +2,9 @@
  * @packageDocumentation
  * @module IAttestation
  */
-import { ICType } from './CType'
-import { IDelegationBaseNode } from './Delegation'
-import { IPublicIdentity } from './PublicIdentity'
+import type { ICType } from './CType'
+import type { IDelegationBaseNode } from './Delegation'
+import type { IPublicIdentity } from './PublicIdentity'
 
 export interface IAttestation {
   claimHash: string

--- a/packages/types/src/AttestedClaim.ts
+++ b/packages/types/src/AttestedClaim.ts
@@ -3,8 +3,8 @@
  * @module IAttestedClaim
  */
 
-import { IAttestation, CompressedAttestation } from './Attestation'
-import {
+import type { IAttestation, CompressedAttestation } from './Attestation'
+import type {
   IRequestForAttestation,
   CompressedRequestForAttestation,
 } from './RequestForAttestation'

--- a/packages/types/src/Balance.ts
+++ b/packages/types/src/Balance.ts
@@ -3,7 +3,7 @@
  * @module IBalance
  */
 
-import BN from 'bn.js'
+import type BN from 'bn.js'
 
 export type Balances = {
   free: BN

--- a/packages/types/src/Blockchain.ts
+++ b/packages/types/src/Blockchain.ts
@@ -3,9 +3,9 @@
  * @module IBlockchain
  */
 
-import { ApiPromise } from '@polkadot/api'
-import { Header } from '@polkadot/types/interfaces/types'
-import BN from 'bn.js'
+import type { ApiPromise } from '@polkadot/api'
+import type { Header } from '@polkadot/types/interfaces/types'
+import type BN from 'bn.js'
 import type {
   IIdentity,
   ISubmittableResult,

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -3,7 +3,7 @@
  * @module ICType
  */
 
-import { IPublicIdentity } from './PublicIdentity'
+import type { IPublicIdentity } from './PublicIdentity'
 
 export interface ICTypeSchema {
   $id: string

--- a/packages/types/src/Claim.ts
+++ b/packages/types/src/Claim.ts
@@ -2,8 +2,8 @@
  * @packageDocumentation
  * @module IClaim
  */
-import { ICType } from './CType'
-import { IPublicIdentity } from './PublicIdentity'
+import type { ICType } from './CType'
+import type { IPublicIdentity } from './PublicIdentity'
 
 /**
  * The minimal partial claim from which a JSON-LD representation can be built.

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -2,8 +2,8 @@
  * @packageDocumentation
  * @module IDelegation
  */
-import { ICType } from './CType'
-import { IPublicIdentity } from './PublicIdentity'
+import type { ICType } from './CType'
+import type { IPublicIdentity } from './PublicIdentity'
 
 /* eslint-disable no-bitwise */
 export enum Permission {

--- a/packages/types/src/Identity.ts
+++ b/packages/types/src/Identity.ts
@@ -2,11 +2,11 @@
  * @packageDocumentation
  * @module IIdentity
  */
-import { KeyringPair } from '@polkadot/keyring/types'
-import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
-import { BoxKeyPair } from 'tweetnacl'
-import BN from 'bn.js'
-import { Index } from '@polkadot/types/interfaces'
+import type { KeyringPair } from '@polkadot/keyring/types'
+import type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
+import type { BoxKeyPair } from 'tweetnacl'
+import type BN from 'bn.js'
+import type { Index } from '@polkadot/types/interfaces'
 
 export interface IIdentity {
   readonly signKeyringPair: KeyringPair

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -3,19 +3,24 @@
  * @module IMessage
  */
 
-import { AnyJson } from '@polkadot/types/types'
-import { CompressedAttestation, IAttestation } from './Attestation'
-import { CompressedAttestedClaim, IAttestedClaim } from './AttestedClaim'
-import { CompressedClaim, IClaim, IClaimContents, PartialClaim } from './Claim'
-import { ICType } from './CType'
-import { IDelegationBaseNode, IDelegationNode } from './Delegation'
-import { IPublicIdentity } from './PublicIdentity'
-import { CompressedQuoteAgreed, IQuoteAgreement } from './Quote'
-import {
+import type { AnyJson } from '@polkadot/types/types'
+import type { CompressedAttestation, IAttestation } from './Attestation'
+import type { CompressedAttestedClaim, IAttestedClaim } from './AttestedClaim'
+import type {
+  CompressedClaim,
+  IClaim,
+  IClaimContents,
+  PartialClaim,
+} from './Claim'
+import type { ICType } from './CType'
+import type { IDelegationBaseNode, IDelegationNode } from './Delegation'
+import type { IPublicIdentity } from './PublicIdentity'
+import type { CompressedQuoteAgreed, IQuoteAgreement } from './Quote'
+import type {
   CompressedRequestForAttestation,
   IRequestForAttestation,
 } from './RequestForAttestation'
-import { CompressedTerms, ITerms } from './Terms'
+import type { CompressedTerms, ITerms } from './Terms'
 
 export enum MessageBodyType {
   REQUEST_TERMS = 'request-terms',

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -3,7 +3,7 @@
  * @module IQuote
  */
 
-import { ICType } from './CType'
+import type { ICType } from './CType'
 
 export interface ICostBreakdown {
   tax: Record<string, unknown>

--- a/packages/types/src/RequestForAttestation.ts
+++ b/packages/types/src/RequestForAttestation.ts
@@ -3,9 +3,9 @@
  * @module IRequestForAttestation
  */
 
-import { IAttestedClaim, CompressedAttestedClaim } from './AttestedClaim'
-import { IClaim, CompressedClaim } from './Claim'
-import { IDelegationBaseNode } from './Delegation'
+import type { IAttestedClaim, CompressedAttestedClaim } from './AttestedClaim'
+import type { IClaim, CompressedClaim } from './Claim'
+import type { IDelegationBaseNode } from './Delegation'
 
 export type Hash = string
 

--- a/packages/types/src/Terms.ts
+++ b/packages/types/src/Terms.ts
@@ -3,12 +3,15 @@
  * @module ITerms
  */
 
-import { IAttestedClaim, CompressedAttestedClaim } from './AttestedClaim'
-import { ICType } from './CType'
-import { IDelegationBaseNode } from './Delegation'
-import { IQuoteAttesterSigned, CompressedQuoteAttesterSigned } from './Quote'
-import { CompressedPartialClaim } from './Message'
-import { PartialClaim } from './Claim'
+import type { IAttestedClaim, CompressedAttestedClaim } from './AttestedClaim'
+import type { ICType } from './CType'
+import type { IDelegationBaseNode } from './Delegation'
+import type {
+  IQuoteAttesterSigned,
+  CompressedQuoteAttesterSigned,
+} from './Quote'
+import type { CompressedPartialClaim } from './Message'
+import type { PartialClaim } from './Claim'
 
 export interface ITerms {
   claim: PartialClaim

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,4 @@
-export type { ISubmittableResult } from '@polkadot/types/types'
+export { ISubmittableResult } from '@polkadot/types/types'
 export type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 
 export * as SubscriptionPromise from './SubscriptionPromise'

--- a/packages/utils/src/Crypto.spec.ts
+++ b/packages/utils/src/Crypto.spec.ts
@@ -4,7 +4,7 @@
 
 import * as string from '@polkadot/util/string'
 import { Keyring } from '@polkadot/keyring'
-import { KeyringPair } from '@polkadot/keyring/types'
+import type { KeyringPair } from '@polkadot/keyring/types'
 import nacl from 'tweetnacl'
 import * as Crypto from './Crypto'
 

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -8,7 +8,7 @@
  */
 
 import { decodeAddress, encodeAddress } from '@polkadot/keyring'
-import { KeyringPair } from '@polkadot/keyring/types'
+import type { KeyringPair } from '@polkadot/keyring/types'
 import {
   isString,
   stringToU8a,

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -7,7 +7,7 @@
 /**
  * Dummy comment needed for correct doc display, do not remove.
  */
-import { IPublicIdentity } from '@kiltprotocol/types'
+import type { IPublicIdentity } from '@kiltprotocol/types'
 import { checkAddress } from '@polkadot/util-crypto'
 import { SDKErrors } from '.'
 import { verify } from './Crypto'

--- a/packages/utils/src/Decode.ts
+++ b/packages/utils/src/Decode.ts
@@ -3,7 +3,7 @@
  * @module Decode
  */
 
-import { Codec } from '@polkadot/types/types'
+import type { Codec } from '@polkadot/types/types'
 
 /**
  * Dummy comment needed for correct doc display, do not remove.

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -5,7 +5,7 @@
  * @module SDKErrors
  */
 
-import { NonceHash } from '@kiltprotocol/types'
+import type { NonceHash } from '@kiltprotocol/types'
 
 export enum ErrorCode {
   ERROR_TRANSACTION_RECOVERABLE = 1000,

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -5,9 +5,9 @@
 
 import { decodeAddress } from '@polkadot/keyring'
 import { u8aToHex } from '@polkadot/util'
-import { AnyJson } from '@polkadot/types/types'
+import type { AnyJson } from '@polkadot/types/types'
 import { Did, ClaimUtils } from '@kiltprotocol/core'
-import { IAttestedClaim, ICType } from '@kiltprotocol/types'
+import type { IAttestedClaim, ICType } from '@kiltprotocol/types'
 import { signatureVerify } from '@polkadot/util-crypto'
 import {
   AttestedProof,

--- a/packages/vc-export/src/types.ts
+++ b/packages/vc-export/src/types.ts
@@ -2,9 +2,9 @@
  * @packageDocumentation
  * @module VCExportTypes
  */
-import { AnyJson } from '@polkadot/types/types'
-import { IDidDocumentPublicKey } from '@kiltprotocol/core'
-import { ICType } from '@kiltprotocol/types'
+import type { AnyJson } from '@polkadot/types/types'
+import type { IDidDocumentPublicKey } from '@kiltprotocol/core'
+import type { ICType } from '@kiltprotocol/types'
 
 /**
  * Constant for default context.


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1125


Throughout the SDK to use `import type`  typescripts for `types`

 
## How to test:


## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
