### PR TITLE
refactor: encrypted message body naming

### DIFF
--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -75,9 +75,9 @@ describe('Messaging', () => {
     const encryptedMessageWrongContent: IEncryptedMessage = JSON.parse(
       JSON.stringify(encryptedMessage)
     ) as IEncryptedMessage
-    encryptedMessageWrongContent.message = '1234'
+    encryptedMessageWrongContent.ciphertext = '1234'
     const hashStrWrongContent: string = Crypto.hashStr(
-      encryptedMessageWrongContent.message +
+      encryptedMessageWrongContent.ciphertext +
         encryptedMessageWrongContent.nonce +
         encryptedMessageWrongContent.createdAt
     )
@@ -101,7 +101,7 @@ describe('Messaging', () => {
       createdAt: ts,
       receiverAddress: encryptedMessage.receiverAddress,
       senderAddress: encryptedMessage.senderAddress,
-      message: encryptedWrongBody.box,
+      ciphertext: encryptedWrongBody.box,
       nonce: encryptedWrongBody.nonce,
       hash: hashStrBadContent,
       signature: identityAlice.signStr(hashStrBadContent),
@@ -272,14 +272,14 @@ describe('Messaging', () => {
         identityAlice,
         identityBob.getPublicIdentity()
       ).encrypt()
-      const { message: msg, nonce, createdAt } = encrypted2
+      const { ciphertext: msg, nonce, createdAt } = encrypted2
 
       // check correct encrypted but with message from encrypted2
       expect(() =>
         Message.ensureHashAndSignature(
           {
             ...encrypted,
-            message: msg,
+            ciphertext: msg,
           },
           identityBob.address
         )

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -87,7 +87,7 @@ export default class Message implements IMessage {
   ): void {
     if (
       Crypto.hashStr(
-        encrypted.message + encrypted.nonce + encrypted.createdAt
+        encrypted.ciphertext + encrypted.nonce + encrypted.createdAt
       ) !== encrypted.hash
     ) {
       throw SDKErrors.ERROR_NONCE_HASH_INVALID(
@@ -121,7 +121,7 @@ export default class Message implements IMessage {
     Message.ensureHashAndSignature(encrypted, encrypted.senderAddress)
 
     const ea: Crypto.EncryptedAsymmetricString = {
-      box: encrypted.message,
+      box: encrypted.ciphertext,
       nonce: encrypted.nonce,
     }
     const decoded: string | false = receiver.decryptAsymmetricAsStr(
@@ -203,7 +203,7 @@ export default class Message implements IMessage {
     return {
       messageId: this.messageId,
       receivedAt: this.receivedAt,
-      message: this.message,
+      ciphertext: this.message,
       nonce: this.nonce,
       createdAt: this.createdAt,
       hash: this.hash,

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -81,7 +81,7 @@ export type IEncryptedMessage = Pick<
   | 'messageId'
   | 'receivedAt'
 > & {
-  message: string
+  ciphertext: string
   nonce: string
   hash: string
   signature: string


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1193

Changes the property key of the encrypted message body from `message` to `ciphertext` for clarity.
https://en.wikipedia.org/wiki/Ciphertext

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
