### PR TITLE
feat: tx workflow revamp

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -73,7 +73,7 @@ async function setup(): Promise<{
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
     await ctype.store(attester).then((tx) =>
-      Kilt.BlockchainUtils.submitTxWithReSign(tx, attester, {
+      Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, attester, {
         resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
       })
     )

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -74,7 +74,8 @@ async function setup(): Promise<{
   try {
     await ctype.store().then((tx) =>
       Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, attester, {
-        resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
+        resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
+        reSign: true,
       })
     )
   } catch (e) {

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -72,7 +72,7 @@ async function setup(): Promise<{
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store(attester).then((tx) =>
+    await ctype.store().then((tx) =>
       Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, attester, {
         resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
       })

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -46,9 +46,10 @@ async function main(): Promise<void> {
     // using ed25519 as key type because this is how the endowed identity is set up
     { signingKeyPairType: 'ed25519' }
   )
-  tx = await ctype.store(identity)
-  await Kilt.BlockchainUtils.submitSignedTx(tx, {
+  tx = await ctype.store()
+  await Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, identity, {
     resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
+    reSign: true,
   })
 
   /* At the end of the process, the `CType` object should contain the following. */
@@ -125,7 +126,7 @@ async function main(): Promise<void> {
     console.log(attestation)
 
     /* Now the Attester can store the attestation on the blockchain, which also costs tokens: */
-    tx = await attestation.store(attester)
+    tx = await attestation.store()
     await Kilt.BlockchainUtils.submitSignedTx(tx, {
       resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
     })

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
   )
   tx = await ctype.store()
   await Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, identity, {
-    resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
+    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
     reSign: true,
   })
 

--- a/packages/actors_api/package.json
+++ b/packages/actors_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/actors-api",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -17,7 +17,7 @@ import type {
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import Message from '@kiltprotocol/messaging'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain } from '@kiltprotocol/chain-helpers'
 
 export interface IRevocationHandle {
   claimHash: IAttestation['claimHash']
@@ -76,8 +76,8 @@ export async function issueAttestation(
   )
 
   await attestation
-    .store(attester)
-    .then((tx) => BlockchainUtils.submitTxWithReSign(tx, attester))
+    .store()
+    .then((tx) => Blockchain.signAndSubmitTx(tx, attester, { reSign: true }))
 
   const revocationHandle = { claimHash: attestation.claimHash }
   return {
@@ -122,6 +122,6 @@ export async function revokeAttestation(
     attester,
     delegationTreeTraversalSteps
   ).then((tx: SubmittableExtrinsic) =>
-    BlockchainUtils.submitTxWithReSign(tx, attester)
+    Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
   )
 }

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -14,7 +14,6 @@ import type {
   IAttestation,
   IMessage,
   IRequestAttestationForClaim,
-  SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import Message from '@kiltprotocol/messaging'
 import { Blockchain } from '@kiltprotocol/chain-helpers'

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -75,7 +75,7 @@ export async function issueAttestation(
   )
 
   const tx = await attestation.store()
-  Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
+  await Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
 
   const revocationHandle = { claimHash: attestation.claimHash }
   return {

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -75,9 +75,8 @@ export async function issueAttestation(
     attester.getPublicIdentity()
   )
 
-  await attestation
-    .store()
-    .then((tx) => Blockchain.signAndSubmitTx(tx, attester, { reSign: true }))
+  const tx = await attestation.store()
+  Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
 
   const revocationHandle = { claimHash: attestation.claimHash }
   return {
@@ -117,11 +116,10 @@ export async function revokeAttestation(
     attestation
   )
 
-  await Attestation.revoke(
+  const tx = await Attestation.revoke(
     revocationHandle.claimHash,
     attester,
     delegationTreeTraversalSteps
-  ).then((tx: SubmittableExtrinsic) =>
-    Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
   )
+  Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
 }

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/chain-helpers",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -309,7 +309,7 @@ describe('Tx logic', () => {
         .mockImplementation(async (id, Tx) => {
           return Tx
         })
-      await expect(chain.submitTxWithReSign(tx, alice)).rejects.toThrow(
+      await expect(chain.submitSignedTxWithReSign(tx, alice)).rejects.toThrow(
         SDKErrors.ERROR_TRANSACTION_RECOVERABLE()
       )
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/config",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/core",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -3,7 +3,11 @@
  */
 
 import type { IAttestedClaim, IClaim } from '@kiltprotocol/types'
-import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
+import {
+  Blockchain,
+  BlockchainUtils,
+  ExtrinsicErrors,
+} from '@kiltprotocol/chain-helpers'
 import Attestation from '../attestation/Attestation'
 import { revoke } from '../attestation/Attestation.chain'
 import AttestedClaim from '../attestedclaim/AttestedClaim'
@@ -38,8 +42,9 @@ describe('handling attestations that do not exist', () => {
   it('Attestation.revoke', async () => {
     return expect(
       Attestation.revoke('0x012012012', alice, 0).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, alice, {
+        Blockchain.signAndSubmitTx(tx, alice, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrow()
@@ -60,9 +65,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`ctype exists: ${ctypeExists}`)
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
-      await DriversLicense.store(attester).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, attester, {
+      await DriversLicense.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     }
@@ -95,9 +101,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       request,
       attester.getPublicIdentity()
     )
-    await attestation.store(attester).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, attester, {
+    await attestation.store().then((tx) =>
+      Blockchain.signAndSubmitTx(tx, attester, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
     const aClaim = AttestedClaim.fromRequestAndAttestation(request, attestation)
@@ -124,9 +131,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     const bobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
 
     await expect(
-      attestation.store(bobbyBroke).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, bobbyBroke, {
+      attestation.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, bobbyBroke, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrow()
@@ -163,9 +171,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
     await expect(
-      attestation.store(attester).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, attester, {
+      attestation.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrowErrorWithCode(
@@ -188,9 +197,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request,
         attester.getPublicIdentity()
       )
-      await attestation.store(attester).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, attester, {
+      await attestation.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
       attClaim = AttestedClaim.fromRequestAndAttestation(request, attestation)
@@ -199,9 +209,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     it('should not be possible to attest the same claim twice', async () => {
       await expect(
-        attClaim.attestation.store(attester).then((tx) =>
-          BlockchainUtils.submitTxWithReSign(tx, attester, {
+        attClaim.attestation.store().then((tx) =>
+          Blockchain.signAndSubmitTx(tx, attester, {
             resolveOn: BlockchainUtils.IS_IN_BLOCK,
+            reSign: true,
           })
         )
       ).rejects.toThrowErrorWithCode(
@@ -227,9 +238,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
-        revoke(attClaim.getHash(), claimer, 0).then((tx) =>
-          BlockchainUtils.submitTxWithReSign(tx, claimer, {
+        revoke(attClaim.getHash(), 0).then((tx) =>
+          Blockchain.signAndSubmitTx(tx, claimer, {
             resolveOn: BlockchainUtils.IS_IN_BLOCK,
+            reSign: true,
           })
         )
       ).rejects.toThrowError('not permitted')
@@ -238,9 +250,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
-      await revoke(attClaim.getHash(), attester, 0).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, attester, {
+      await revoke(attClaim.getHash(), 0).then((tx) =>
+        Blockchain.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
       await expect(attClaim.verify()).resolves.toBeFalsy()
@@ -250,9 +263,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   describe('when there is another Ctype that works as a legitimation', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
-        await IsOfficialLicenseAuthority.store(faucet).then((tx) =>
-          BlockchainUtils.submitTxWithReSign(tx, faucet, {
+        await IsOfficialLicenseAuthority.store().then((tx) =>
+          Blockchain.signAndSubmitTx(tx, faucet, {
             resolveOn: BlockchainUtils.IS_IN_BLOCK,
+            reSign: true,
           })
         )
       }
@@ -279,9 +293,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request1,
         faucet.getPublicIdentity()
       )
-      await licenseAuthorizationGranted.store(faucet).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, faucet, {
+      await licenseAuthorizationGranted.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, faucet, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
       // make request including legitimation
@@ -306,9 +321,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         request2,
         attester.getPublicIdentity()
       )
-      await LicenseGranted.store(attester).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, attester, {
+      await LicenseGranted.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
       const license = AttestedClaim.fromRequestAndAttestation(

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import BN from 'bn.js/'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain, BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import {
   getBalances,
   listenToBalanceChanges,
@@ -63,9 +63,10 @@ describe('when there is a dev chain with a faucet', () => {
     const funny = jest.fn()
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalances(faucet.address)
-    await makeTransfer(faucet, ident.address, MIN_TRANSACTION).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, faucet, {
+    await makeTransfer(ident.address, MIN_TRANSACTION).then((tx) =>
+      Blockchain.signAndSubmitTx(tx, faucet, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
     const [balanceAfter, balanceIdent] = await Promise.all([
@@ -94,11 +95,11 @@ describe('When there are haves and have-nots', () => {
   })
 
   it('can transfer tokens from the rich to the poor', async () => {
-    await makeTransfer(richieRich, stormyD.address, MIN_TRANSACTION).then(
-      (tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, richieRich, {
-          resolveOn: BlockchainUtils.IS_IN_BLOCK,
-        })
+    await makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
+      Blockchain.signAndSubmitTx(tx, richieRich, {
+        resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
+      })
     )
     const balanceTo = await getBalances(stormyD.address)
     expect(balanceTo.free.toNumber()).toBe(MIN_TRANSACTION.toNumber())
@@ -107,9 +108,10 @@ describe('When there are haves and have-nots', () => {
   it('should not accept transactions from identity with zero balance', async () => {
     const originalBalance = await getBalances(stormyD.address)
     await expect(
-      makeTransfer(bobbyBroke, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, bobbyBroke, {
+      makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
+        Blockchain.signAndSubmitTx(tx, bobbyBroke, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrowError('1010: Invalid Transaction')
@@ -124,11 +126,11 @@ describe('When there are haves and have-nots', () => {
   xit('should not accept transactions when sender cannot pay gas, but will keep gas fee', async () => {
     const RichieBalance = await getBalances(richieRich.address)
     await expect(
-      makeTransfer(richieRich, bobbyBroke.address, RichieBalance.free).then(
-        (tx) =>
-          BlockchainUtils.submitTxWithReSign(tx, richieRich, {
-            resolveOn: BlockchainUtils.IS_IN_BLOCK,
-          })
+      makeTransfer(bobbyBroke.address, RichieBalance.free).then((tx) =>
+        Blockchain.signAndSubmitTx(tx, richieRich, {
+          resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
+        })
       )
     ).rejects.toThrowError()
     const [newBalance, zeroBalance] = await Promise.all([
@@ -142,14 +144,16 @@ describe('When there are haves and have-nots', () => {
   it('should be able to make a new transaction once the last is ready', async () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
-    await makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, faucet, {
-        resolveOn: BlockchainUtils.IS_IN_BLOCK,
+    await makeTransfer(richieRich.address, MIN_TRANSACTION).then((tx) =>
+      Blockchain.signAndSubmitTx(tx, faucet, {
+        resolveOn: BlockchainUtils.IS_READY,
+        reSign: true,
       })
     )
-    await makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, faucet, {
+    await makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
+      Blockchain.signAndSubmitTx(tx, faucet, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
 
@@ -165,14 +169,16 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
-      makeTransfer(faucet, richieRich.address, MIN_TRANSACTION).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, faucet, {
+      makeTransfer(richieRich.address, MIN_TRANSACTION).then((tx) =>
+        Blockchain.signAndSubmitTx(tx, faucet, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       ),
-      makeTransfer(faucet, stormyD.address, MIN_TRANSACTION).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, faucet, {
+      makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
+        Blockchain.signAndSubmitTx(tx, faucet, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       ),
     ])

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -146,7 +146,7 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(richieRich.address, MIN_TRANSACTION).then((tx) =>
       Blockchain.signAndSubmitTx(tx, faucet, {
-        resolveOn: BlockchainUtils.IS_READY,
+        resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
     )

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -6,7 +6,7 @@ import type { SignerPayload } from '@polkadot/types/interfaces/extrinsics/types'
 import BN from 'bn.js/'
 import { SDKErrors } from '@kiltprotocol/utils'
 import type { IBlockchainApi } from '@kiltprotocol/types'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain, BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { makeTransfer } from '../balance/Balance.chain'
 import Identity from '../identity/Identity'
 import { wannabeFaucet, wannabeCharlie, WS_ADDRESS } from './utils'
@@ -26,14 +26,10 @@ describe('Chain returns specific errors, that we check for', () => {
     faucet = wannabeFaucet
     testIdentity = Identity.buildFromURI(Identity.generateMnemonic())
     charlie = wannabeCharlie
-    const tx = await makeTransfer(
-      faucet,
-      testIdentity.address,
-      new BN(10000),
-      0
-    )
-    await BlockchainUtils.submitTxWithReSign(tx, charlie, {
+    const tx = await makeTransfer(testIdentity.address, new BN(10000), 0)
+    await Blockchain.signAndSubmitTx(tx, faucet, {
       resolveOn: BlockchainUtils.IS_FINALIZED,
+      reSign: true,
     })
   }, 40000)
 
@@ -75,7 +71,7 @@ describe('Chain returns specific errors, that we check for', () => {
         version: blockchain.api.extrinsicVersion,
       }
     )
-    await BlockchainUtils.submitSignedTxRaw(
+    await BlockchainUtils.dispatchTx(
       tx,
       BlockchainUtils.parseSubscriptionOptions({
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
@@ -94,7 +90,7 @@ describe('Chain returns specific errors, that we check for', () => {
     )
 
     await expect(
-      BlockchainUtils.submitSignedTxRaw(
+      BlockchainUtils.dispatchTx(
         errorTx,
         BlockchainUtils.parseSubscriptionOptions({
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
@@ -143,7 +139,7 @@ describe('Chain returns specific errors, that we check for', () => {
       }
     )
     expect(
-      BlockchainUtils.submitSignedTxRaw(
+      BlockchainUtils.dispatchTx(
         tx,
         BlockchainUtils.parseSubscriptionOptions({
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
@@ -162,7 +158,7 @@ describe('Chain returns specific errors, that we check for', () => {
       errorSigner.toPayload()
     )
 
-    await BlockchainUtils.submitSignedTxRaw(
+    await BlockchainUtils.dispatchTx(
       errorTx,
       BlockchainUtils.parseSubscriptionOptions({
         resolveOn: BlockchainUtils.IS_IN_BLOCK,

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -3,7 +3,11 @@
  */
 
 import type { ICType } from '@kiltprotocol/types'
-import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
+import {
+  Blockchain,
+  BlockchainUtils,
+  ExtrinsicErrors,
+} from '@kiltprotocol/chain-helpers'
 import { Identity } from '..'
 import CType from '../ctype/CType'
 import { getOwner } from '../ctype/CType.chain'
@@ -41,9 +45,10 @@ describe('When there is an CtypeCreator and a verifier', () => {
     const ctype = makeCType()
     const bobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
     await expect(
-      ctype.store(bobbyBroke).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, bobbyBroke, {
+      ctype.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, bobbyBroke, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrowError()
@@ -52,9 +57,10 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should be possible to create a claim type', async () => {
     const ctype = makeCType()
-    await ctype.store(ctypeCreator).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, ctypeCreator, {
+    await ctype.store().then((tx) =>
+      Blockchain.signAndSubmitTx(tx, ctypeCreator, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
     await Promise.all([
@@ -67,15 +73,17 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
-    await ctype.store(ctypeCreator).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, ctypeCreator, {
+    await ctype.store().then((tx) =>
+      Blockchain.signAndSubmitTx(tx, ctypeCreator, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
     await expect(
-      ctype.store(ctypeCreator).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, ctypeCreator, {
+      ctype.store().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, ctypeCreator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrowErrorWithCode(

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -5,7 +5,7 @@
 import type { ICType } from '@kiltprotocol/types'
 import { Permission } from '@kiltprotocol/types'
 import { UUID } from '@kiltprotocol/utils'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain, BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { AttestedClaim, Identity } from '..'
 import Attestation from '../attestation/Attestation'
 import { config, disconnect } from '../kilt'
@@ -37,9 +37,10 @@ async function writeRoot(
     ctypeHash,
     delegator.address
   )
-  await root.store(delegator).then((tx) =>
-    BlockchainUtils.submitTxWithReSign(tx, delegator, {
+  await root.store().then((tx) =>
+    Blockchain.signAndSubmitTx(tx, delegator, {
       resolveOn: BlockchainUtils.IS_IN_BLOCK,
+      reSign: true,
     })
   )
   return root
@@ -60,10 +61,11 @@ async function addDelegation(
     parentNode.id
   )
   await delegation
-    .store(delegator, delegee.signStr(delegation.generateHash()))
+    .store(delegee.signStr(delegation.generateHash()))
     .then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, delegator, {
+      Blockchain.signAndSubmitTx(tx, delegator, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
   return delegation
@@ -80,9 +82,10 @@ beforeAll(async () => {
   attester = wannabeAlice
 
   if (!(await CtypeOnChain(DriversLicense))) {
-    await DriversLicense.store(attester).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, attester, {
+    await DriversLicense.store().then((tx) =>
+      Blockchain.signAndSubmitTx(tx, attester, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
   }
@@ -131,9 +134,10 @@ describe('and attestation rights have been delegated', () => {
       request,
       attester.getPublicIdentity()
     )
-    await attestation.store(attester).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, attester, {
+    await attestation.store().then((tx) =>
+      Blockchain.signAndSubmitTx(tx, attester, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
 
@@ -146,8 +150,9 @@ describe('and attestation rights have been delegated', () => {
 
     // revoke attestation through root
     await attClaim.attestation.revoke(root, 1).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, root, {
+      Blockchain.signAndSubmitTx(tx, root, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
     await expect(attClaim.verify()).resolves.toBeFalsy()
@@ -174,8 +179,9 @@ describe('revocation', () => {
     )
     await expect(
       delegationA.revoke(delegator).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, delegator, {
+        Blockchain.signAndSubmitTx(tx, delegator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).resolves.not.toThrow()
@@ -190,9 +196,10 @@ describe('revocation', () => {
       firstDelegee
     )
     await expect(
-      delegationRoot.revoke(firstDelegee).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, firstDelegee, {
+      delegationRoot.revoke().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, firstDelegee, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).rejects.toThrow()
@@ -200,8 +207,9 @@ describe('revocation', () => {
 
     await expect(
       delegationA.revoke(firstDelegee).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, firstDelegee, {
+        Blockchain.signAndSubmitTx(tx, firstDelegee, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).resolves.not.toThrow()
@@ -221,9 +229,10 @@ describe('revocation', () => {
       secondDelegee
     )
     await expect(
-      delegationRoot.revoke(delegator).then((tx) =>
-        BlockchainUtils.submitTxWithReSign(tx, delegator, {
+      delegationRoot.revoke().then((tx) =>
+        Blockchain.signAndSubmitTx(tx, delegator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          reSign: true,
         })
       )
     ).resolves.not.toThrow()

--- a/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
@@ -3,7 +3,11 @@
  */
 
 import BN from 'bn.js'
-import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
+import {
+  Blockchain,
+  BlockchainUtils,
+  ExtrinsicErrors,
+} from '@kiltprotocol/chain-helpers'
 import { Attestation } from '..'
 import { makeTransfer } from '../balance/Balance.chain'
 import Identity from '../identity'
@@ -22,9 +26,10 @@ beforeAll(async () => {
 it('records an unknown extrinsic error when transferring less than the existential amount to new identity', async () => {
   const to = Identity.buildFromMnemonic('')
   await expect(
-    makeTransfer(alice, to.address, new BN(1)).then((tx) =>
-      BlockchainUtils.submitTxWithReSign(tx, alice, {
+    makeTransfer(to.address, new BN(1)).then((tx) =>
+      Blockchain.signAndSubmitTx(tx, alice, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        reSign: true,
       })
     )
   ).rejects.toThrowErrorWithCode(ExtrinsicErrors.UNKNOWN_ERROR.code)
@@ -40,10 +45,11 @@ it('records an extrinsic error when ctype does not exist', async () => {
     owner: alice.address,
     revoked: false,
   })
-  const tx = await attestation.store(alice)
+  const tx = await attestation.store()
   await expect(
-    BlockchainUtils.submitTxWithReSign(tx, alice, {
+    Blockchain.signAndSubmitTx(tx, alice, {
       resolveOn: BlockchainUtils.IS_IN_BLOCK,
+      reSign: true,
     })
   ).rejects.toThrowErrorWithCode(
     ExtrinsicErrors.CType.ERROR_CTYPE_NOT_FOUND.code

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -8,7 +8,6 @@ import { DecoderUtils } from '@kiltprotocol/utils'
 import type { AccountId, Hash } from '@polkadot/types/interfaces'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import Identity from '../identity/Identity'
 import Attestation from './Attestation'
 import type { DelegationNodeId } from '../delegation/DelegationDecoder'
 
@@ -16,12 +15,10 @@ const log = ConfigService.LoggingFactory.getLogger('Attestation')
 
 /**
  * @param attestation
- * @param identity
  * @internal
  */
 export async function store(
-  attestation: IAttestation,
-  identity: Identity
+  attestation: IAttestation
 ): Promise<SubmittableExtrinsic> {
   const txParams = {
     claimHash: attestation.claimHash,
@@ -37,7 +34,7 @@ export async function store(
     txParams.ctypeHash,
     txParams.delegationId
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }
 
 /**
@@ -92,13 +89,11 @@ export async function query(claimHash: string): Promise<Attestation | null> {
 
 /**
  * @param claimHash
- * @param identity
  * @param maxDepth
  * @internal
  */
 export async function revoke(
   claimHash: string,
-  identity: Identity,
   maxDepth: number
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
@@ -107,5 +102,5 @@ export async function revoke(
     claimHash,
     maxDepth
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -58,7 +58,7 @@ export default class Attestation implements IAttestation {
     identity: Identity,
     maxDepth: number
   ): Promise<SubmittableExtrinsic> {
-    return revoke(claimHash, identity, maxDepth)
+    return revoke(claimHash, maxDepth)
   }
 
   /**
@@ -175,8 +175,8 @@ export default class Attestation implements IAttestation {
    * });
    * ```
    */
-  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
-    return store(this, identity)
+  public async store(): Promise<SubmittableExtrinsic> {
+    return store(this)
   }
 
   /**
@@ -195,7 +195,7 @@ export default class Attestation implements IAttestation {
     identity: Identity,
     maxDepth: number
   ): Promise<SubmittableExtrinsic> {
-    return revoke(this.claimHash, identity, maxDepth)
+    return revoke(this.claimHash, maxDepth)
   }
 
   /**

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -17,7 +17,6 @@ import type {
 } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 
-import Identity from '../identity/Identity'
 import BalanceUtils from './Balance.utils'
 
 /**
@@ -104,7 +103,6 @@ export async function listenToBalanceChanges(
  * Transfer Kilt [amount] tokens to [toAccountAddress] using the given [[Identity]].
  * <B>Note that the value of the transferred currency and the balance amount reported by the chain is in Femto-Kilt (1e-15), and must be translated to Kilt-Coin</B>.
  *
- * @param identity Identity to use for token transfer.
  * @param accountAddressTo Address of the receiver account.
  * @param amount Amount of Units to transfer.
  * @param exponent Magnitude of the amount. Default magnitude of Femto-Kilt.
@@ -127,7 +125,6 @@ export async function listenToBalanceChanges(
  * ```
  */
 export async function makeTransfer(
-  identity: Identity,
   accountAddressTo: IPublicIdentity['address'],
   amount: BN,
   exponent = -15
@@ -141,5 +138,5 @@ export async function makeTransfer(
       ? amount
       : BalanceUtils.convertToTxUnit(amount, cleanExponent)
   )
-  return blockchain.signTx(identity, transfer)
+  return transfer
 }

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -7,7 +7,7 @@ import { GenericAccountIndex as AccountIndex } from '@polkadot/types/generic/Acc
 import type { AccountData, AccountInfo } from '@polkadot/types/interfaces'
 import BN from 'bn.js/'
 import TYPE_REGISTRY from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain } from '@kiltprotocol/chain-helpers'
 import type { Balances } from '@kiltprotocol/types'
 import Identity from '../identity/Identity'
 import {
@@ -77,11 +77,9 @@ describe('Balance', () => {
   })
 
   it('should make transfer', async () => {
-    const status = await makeTransfer(
-      alice,
-      bob.address,
-      new BN(100)
-    ).then((tx) => BlockchainUtils.submitTxWithReSign(tx, alice))
+    const status = await makeTransfer(bob.address, new BN(100)).then((tx) =>
+      Blockchain.signAndSubmitTx(tx, alice, { reSign: true })
+    )
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
   })
@@ -93,11 +91,10 @@ describe('Balance', () => {
       (exponent >= 0 ? 1 : -1) * Math.floor(Math.abs(exponent))
     )
     const status = await makeTransfer(
-      alice,
       bob.address,
       amount,
       exponent
-    ).then((tx) => BlockchainUtils.submitTxWithReSign(tx, alice))
+    ).then((tx) => Blockchain.signAndSubmitTx(tx, alice, { reSign: true }))
     expect(blockchainApi.tx.balances.transfer).toHaveBeenCalledWith(
       bob.address,
       expectedAmount

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -13,23 +13,18 @@ import type {
 import { DecoderUtils } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import Identity from '../identity/Identity'
 
 const log = ConfigService.LoggingFactory.getLogger('CType')
 
 /**
  * @param ctype
- * @param identity
  * @internal
  */
-export async function store(
-  ctype: ICType,
-  identity: Identity
-): Promise<SubmittableExtrinsic> {
+export async function store(ctype: ICType): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   log.debug(() => `Create tx for 'ctype.add'`)
   const tx: SubmittableExtrinsic = blockchain.api.tx.ctype.add(ctype.hash)
-  return blockchain.signTx(identity, tx)
+  return tx
 }
 
 /**

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -13,7 +13,7 @@ import type {
   ICTypeSchema,
   CompressedCTypeSchema,
 } from '@kiltprotocol/types'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain } from '@kiltprotocol/chain-helpers'
 import Claim from '../claim/Claim'
 import Identity from '../identity/Identity'
 import requestForAttestation from '../requestforattestation/RequestForAttestation'
@@ -105,8 +105,10 @@ describe('CType', () => {
   it('stores ctypes', async () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
-    const tx = await ctype.store(identityAlice)
-    const result = await BlockchainUtils.submitTxWithReSign(tx, identityAlice)
+    const tx = await ctype.store()
+    const result = await Blockchain.signAndSubmitTx(tx, identityAlice, {
+      reSign: true,
+    })
     expect(result).toBeInstanceOf(SubmittableResult)
     expect(result.isFinalized).toBeTruthy()
     expect(result.isCompleted).toBeTruthy()

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -17,7 +17,6 @@ import type {
   CTypeSchemaWithoutId,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
-import Identity from '../identity/Identity'
 import { store } from './CType.chain'
 import CTypeUtils from './CType.utils'
 
@@ -89,12 +88,10 @@ export default class CType implements ICType {
   /**
    * [ASYNC] Stores the [[CType]] on the blockchain.
    *
-   * @param identity The identity which submits the blockchain transaction to store the [[CType]].
-   *
    * @returns A promise of a SubmittableExtrinsic.
    */
-  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
-    return store(this, identity)
+  public async store(): Promise<SubmittableExtrinsic> {
+    return store(this)
   }
 
   /**

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -7,7 +7,6 @@ import type { Option } from '@polkadot/types'
 import type { IDelegationNode, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import Identity from '../identity/Identity'
 import DelegationBaseNode from './Delegation'
 import { fetchChildren, getChildIds } from './Delegation.chain'
 import {
@@ -22,13 +21,11 @@ const log = ConfigService.LoggingFactory.getLogger('DelegationBaseNode')
 
 /**
  * @param delegation
- * @param identity
  * @param signature
  * @internal
  */
 export async function store(
   delegation: IDelegationNode,
-  identity: Identity,
   signature: string
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
@@ -43,7 +40,7 @@ export async function store(
     permissionsAsBitset(delegation),
     signature
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }
 
 /**
@@ -79,14 +76,12 @@ export async function query(
  * Revokes part of a delegation tree at specified node, also revoking all nodes below.
  *
  * @param delegationId The id of the node in the delegation tree at which to revoke.
- * @param identity An identity which is authorized to revoke. Either the owner of the current node or of one of the parents.
  * @param maxDepth How many nodes may be traversed upwards in the hierarchy when searching for a node owned by `identity`. Each traversal will add to the transaction fee. Therefore a higher number will increase the fees locked until the transaction is complete. A number lower than the actual required traversals will result in a failed extrinsic (node will not be revoked).
  * @param maxRevocations How many delegation nodes may be revoked during the process. Each revocation adds to the transaction fee. A higher number will require more fees to be locked while an insufficiently high number will lead to premature abortion of the revocation process, leaving some nodes unrevoked. Revocations will first be performed on child nodes, therefore the current node is only revoked when this is accurate.
  * @returns A signed SubmittableExtrinsic ready to be dispatched.
  */
 export async function revoke(
   delegationId: IDelegationNode['id'],
-  identity: Identity,
   maxDepth: number,
   maxRevocations: number
 ): Promise<SubmittableExtrinsic> {
@@ -96,7 +91,7 @@ export async function revoke(
     maxDepth,
     maxRevocations
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }
 
 /**

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -130,16 +130,12 @@ export default class DelegationNode extends DelegationBaseNode
   /**
    * [ASYNC] Stores the delegation node on chain.
    *
-   * @param identity Account used to store the delegation node.
    * @param signature Signature of the delegate to ensure it is done under the delegate's permission.
    * @returns Promise containing a SubmittableExtrinsic.
    */
-  public async store(
-    identity: Identity,
-    signature: string
-  ): Promise<SubmittableExtrinsic> {
+  public async store(signature: string): Promise<SubmittableExtrinsic> {
     log.info(`:: store(${this.id})`)
-    return store(this, identity, signature)
+    return store(this, signature)
   }
 
   /**
@@ -171,7 +167,7 @@ export default class DelegationNode extends DelegationBaseNode
     log.debug(
       `:: revoke(${this.id}) with maxRevocations=${revocationCount} and maxDepth = ${steps} through delegation node ${node?.id} and identity ${identity.address}`
     )
-    return revoke(this.id, identity, steps, revocationCount)
+    return revoke(this.id, steps, revocationCount)
   }
 
   public async getChildren(): Promise<DelegationNode[]> {

--- a/packages/core/src/delegation/DelegationRootNode.chain.ts
+++ b/packages/core/src/delegation/DelegationRootNode.chain.ts
@@ -9,7 +9,6 @@ import type {
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import Identity from '../identity/Identity'
 import {
   decodeRootDelegation,
   IChainDelegationRoot,
@@ -19,19 +18,17 @@ import DelegationRootNode from './DelegationRootNode'
 
 /**
  * @param delegation
- * @param identity
  * @internal
  */
 export async function store(
-  delegation: IDelegationRootNode,
-  identity: Identity
+  delegation: IDelegationRootNode
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.createRoot(
     delegation.id,
     delegation.cTypeHash
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }
 
 /**
@@ -71,7 +68,6 @@ export async function query(
  */
 export async function revoke(
   delegation: IDelegationRootNode,
-  identity: Identity,
   maxRevocations: number
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
@@ -79,5 +75,5 @@ export async function revoke(
     delegation.id,
     maxRevocations
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }

--- a/packages/core/src/delegation/DelegationRootNode.spec.ts
+++ b/packages/core/src/delegation/DelegationRootNode.spec.ts
@@ -4,8 +4,8 @@
 
 import { Crypto } from '@kiltprotocol/utils'
 import {
+  Blockchain,
   BlockchainApiConnection,
-  BlockchainUtils,
 } from '@kiltprotocol/chain-helpers'
 import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
 import { Identity } from '..'
@@ -53,8 +53,10 @@ describe('Delegation', () => {
       identityAlice.address
     )
     await rootDelegation
-      .store(identityAlice)
-      .then((tx) => BlockchainUtils.submitTxWithReSign(tx, identityAlice))
+      .store()
+      .then((tx) =>
+        Blockchain.signAndSubmitTx(tx, identityAlice, { reSign: true })
+      )
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
     if (rootNode) {
@@ -116,8 +118,10 @@ describe('Delegation', () => {
       'myAccount'
     )
     const revokeStatus = await aDelegationRootNode
-      .revoke(identityAlice)
-      .then((tx) => BlockchainUtils.submitTxWithReSign(tx, identityAlice))
+      .revoke()
+      .then((tx) =>
+        Blockchain.signAndSubmitTx(tx, identityAlice, { reSign: true })
+      )
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith(
       'myRootId',
       1

--- a/packages/core/src/delegation/DelegationRootNode.ts
+++ b/packages/core/src/delegation/DelegationRootNode.ts
@@ -15,7 +15,6 @@ import type {
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
-import Identity from '../identity/Identity'
 import DelegationBaseNode from './Delegation'
 import DelegationNode from './DelegationNode'
 import { getChildren } from './DelegationNode.chain'
@@ -69,12 +68,11 @@ export default class DelegationRootNode extends DelegationBaseNode
   /**
    * Stores the delegation root node on chain.
    *
-   * @param identity The account used to store the delegation root node.
    * @returns Promise containing the SubmittableExtrinsic.
    */
-  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
+  public async store(): Promise<SubmittableExtrinsic> {
     log.debug(`:: store(${this.id})`)
-    return store(this, identity)
+    return store(this)
   }
 
   public async verify(): Promise<boolean> {
@@ -82,10 +80,10 @@ export default class DelegationRootNode extends DelegationBaseNode
     return node !== null && !node.revoked
   }
 
-  public async revoke(identity: Identity): Promise<SubmittableExtrinsic> {
+  public async revoke(): Promise<SubmittableExtrinsic> {
     const childCount = await this.subtreeNodeCount()
     log.debug(`:: revoke(${this.id})`)
-    return revoke(this, identity, childCount + 1)
+    return revoke(this, childCount + 1)
   }
 
   public async getChildren(): Promise<DelegationNode[]> {

--- a/packages/core/src/did/Did.chain.ts
+++ b/packages/core/src/did/Did.chain.ts
@@ -6,7 +6,6 @@
 import { Option } from '@polkadot/types'
 import type { IPublicIdentity, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import Identity from '../identity/Identity'
 import type { IDid } from './Did'
 import {
   decodeDid,
@@ -48,31 +47,24 @@ export async function queryByAddress(
 }
 
 /**
- * @param identity
  * @internal
  */
-export async function remove(
-  identity: Identity
-): Promise<SubmittableExtrinsic> {
+export async function remove(): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const tx: SubmittableExtrinsic = blockchain.api.tx.did.remove()
-  return blockchain.signTx(identity, tx)
+  return tx
 }
 
 /**
  * @param did
- * @param identity
  * @internal
  */
-export async function store(
-  did: IDid,
-  identity: Identity
-): Promise<SubmittableExtrinsic> {
+export async function store(did: IDid): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const tx: SubmittableExtrinsic = blockchain.api.tx.did.add(
     did.publicBoxKey,
     did.publicSigningKey,
     did.documentStore
   )
-  return blockchain.signTx(identity, tx)
+  return tx
 }

--- a/packages/core/src/did/Did.spec.ts
+++ b/packages/core/src/did/Did.spec.ts
@@ -7,7 +7,7 @@ import { SDKErrors } from '@kiltprotocol/utils'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { Blockchain } from '@kiltprotocol/chain-helpers'
 import { Did, IDid } from '..'
 import Identity from '../identity/Identity'
 import {
@@ -87,9 +87,9 @@ describe('DID', () => {
   it('store did', async () => {
     const alice = Identity.buildFromURI('//Alice')
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
-    const tx = await did.store(alice)
+    const tx = await did.store()
     await expect(
-      BlockchainUtils.submitTxWithReSign(tx, alice)
+      Blockchain.signAndSubmitTx(tx, alice, { reSign: true })
     ).resolves.toHaveProperty('isFinalized', true)
   })
 

--- a/packages/core/src/did/Did.ts
+++ b/packages/core/src/did/Did.ts
@@ -123,12 +123,11 @@ export default class Did implements IDid {
   /**
    * [ASYNC] Stores the [[Did]] object on-chain.
    *
-   * @param identity The identity used to store the [[Did]] object on-chain.
    * @returns A promise containing the SubmittableExtrinsic (transaction status).
    */
-  public async store(identity: Identity): Promise<SubmittableExtrinsic> {
+  public async store(): Promise<SubmittableExtrinsic> {
     log.debug(`Create tx for 'did.add'`)
-    return store(this, identity)
+    return store(this)
   }
 
   /**
@@ -154,14 +153,11 @@ export default class Did implements IDid {
   /**
    * [STATIC] Removes the [[Did]] object attached to a given [[Identity]] from the chain.
    *
-   * @param identity The identity for which to delete the [[Did]].
    * @returns A promise containing a SubmittableExtrinsic (submittable transaction).
    */
-  public static async remove(
-    identity: Identity
-  ): Promise<SubmittableExtrinsic> {
+  public static async remove(): Promise<SubmittableExtrinsic> {
     log.debug(`Create tx for 'did.remove'`)
-    return remove(identity)
+    return remove()
   }
 
   /**

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kiltprotocol/messaging",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "description": "",
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/sdk-js",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/types",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/types/src/Blockchain.ts
+++ b/packages/types/src/Blockchain.ts
@@ -13,12 +13,12 @@ import type {
   SubscriptionPromise,
 } from '.'
 
+export type ReSignOpts = { reSign: boolean }
 export type BlockchainStats = {
   chain: string
   nodeName: string
   nodeVersion: string
 }
-
 export interface IBlockchainApi {
   api: ApiPromise
 
@@ -28,15 +28,10 @@ export interface IBlockchainApi {
     identity: IIdentity,
     tx: SubmittableExtrinsic
   ): Promise<SubmittableExtrinsic>
-  submitTxWithReSign(
+  submitSignedTxWithReSign(
     tx: SubmittableExtrinsic,
     identity?: IIdentity,
-    opts?: SubscriptionPromise.Options
-  ): Promise<ISubmittableResult>
-  submitTx(
-    identity: IIdentity,
-    tx: SubmittableExtrinsic,
-    opts?: SubscriptionPromise.Options
+    opts?: Partial<SubscriptionPromise.Options>
   ): Promise<ISubmittableResult>
   getNonce(accountAddress: string): Promise<BN>
   reSignTx(

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/utils",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/vc-export",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1184

Kilt Object functions that prepare Transactions for the chain do not sign the SubmittableExtrinsic anymore, this has to be done by hand or with our all purpose `Blockchain.signAndSubmitTx`, with which unsigned SubmittableExtrinsic can be dispatched with additional optional resolve/reject criteria and the posibility to apply nonce collision recovery logic with the `reSign` flag.

Updated tx workflow: [Sign and Submit Workflow](https://hackmd.io/mnMZBi-wQm6bgflXkCKHbw?view)
## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
