### PR TITLE
fix: different versions of BN from Polkadot causes issues

### DIFF
--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -31,7 +31,7 @@
     "@polkadot/api": "^3.11.1",
     "@polkadot/keyring": "^5.9.2",
     "@polkadot/types": "^3.11.1",
-    "bn.js": "^5.2.0",
+    "bn.js": "^4.11.9",
     "typescript-logging": "^0.6.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@polkadot/util": "^5.9.2",
     "@polkadot/util-crypto": "^5.9.2",
     "ajv": "^6.12.5",
-    "bn.js": "^5.2.0",
+    "bn.js": "^4.11.9",
     "tweetnacl": "^1.0.3",
     "typescript-logging": "^0.6.4"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,7 +24,7 @@
     "@polkadot/api": "^3.11.1",
     "@polkadot/keyring": "^5.9.2",
     "@polkadot/types": "^3.11.1",
-    "bn.js": "^5.2.0",
+    "bn.js": "^4.11.9",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,7 +816,7 @@ __metadata:
     "@polkadot/api": ^3.11.1
     "@polkadot/keyring": ^5.9.2
     "@polkadot/types": ^3.11.1
-    bn.js: ^5.2.0
+    bn.js: ^4.11.9
     rimraf: ^3.0.2
     typescript: ^3.9.7
     typescript-logging: ^0.6.4
@@ -850,7 +850,7 @@ __metadata:
     "@polkadot/util-crypto": ^5.9.2
     "@types/uuid": ^8.0.0
     ajv: ^6.12.5
-    bn.js: ^5.2.0
+    bn.js: ^4.11.9
     rimraf: ^3.0.2
     tslib: ^2.0.0
     tweetnacl: ^1.0.3
@@ -893,7 +893,7 @@ __metadata:
     "@polkadot/api": ^3.11.1
     "@polkadot/keyring": ^5.9.2
     "@polkadot/types": ^3.11.1
-    bn.js: ^5.2.0
+    bn.js: ^4.11.9
     rimraf: ^3.0.2
     ts-node: ^8.10.2
     tweetnacl: ^1.0.3
@@ -2042,13 +2042,6 @@ __metadata:
   version: 4.11.9
   resolution: "bn.js@npm:4.11.9"
   checksum: 31630d3560b28931010980886a0f657b37ce818ba237867cd838e89a1a0b71044fb4977aa56376616997b372bbb3f55d3bb25e5378c48c1d24a47bfb4235b60e
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "bn.js@npm:5.2.0"
-  checksum: 7a73bdbba63013a7f9953fbbd6ea3351e4cf36d6fdbb5adf7969fcd65255b9c04f2994b0132d89d74ffe608a0eb5a48322526bee20c0e03e71e502603b420f63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1211

Downgraded to version 4.11.9 to match polkadots current implementation of BN.

No changes to SDK

When updating the polkadot-js version we should take care of matching the appropriate bn.js version.

## How to test:

Run through all the tests

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
