### PR TITLE
feat: move signandsubmit

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -73,7 +73,7 @@ async function setup(): Promise<{
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
     await ctype.store().then((tx) =>
-      Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, attester, {
+      Kilt.BlockchainUtils.signAndSubmitTx(tx, attester, {
         resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
         reSign: true,
       })

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,6 +182,16 @@ await Kilt.BlockchainUtils.submitSignedTx(tx)
 
 Please note that the **same CTYPE can only be stored once** on the blockchain.
 
+If a transaction fails with an by re-signing recoverable error (like nonce collision),
+BlockchainUtils.signAndSubmitTx has the ability to re-sign and re-send the failed tx if the appropriate flag is set:
+```typescript
+  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
+    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
+    reSign: true,
+  })
+```
+
+
 At the end of the process, the `CType` object should match the CType below.
 This can be saved anywhere, for example on a CTYPE registry service:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,7 +182,7 @@ await Kilt.BlockchainUtils.submitSignedTx(tx)
 
 Please note that the **same CTYPE can only be stored once** on the blockchain.
 
-If a transaction fails with an by re-signing recoverable error (like nonce collision),
+If a transaction fails with an by re-signing recoverable error (e.g. nonce collision),
 BlockchainUtils.signAndSubmitTx has the ability to re-sign and re-send the failed tx if the appropriate flag is set:
 ```typescript
   await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,9 +168,16 @@ const identity = Kilt.Identity.buildFromMnemonic(
   { signingKeyPairType: 'ed25519' }
 )
 const tx = await ctype.store(identity)
+
+// either sign and send in one step
 await Kilt.BlockchainUtils.submitSignedTx(tx, {
   resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
 })
+
+// or step by step
+const chain = Kilt.connect()
+const signed = chain.signTx(identity, tx)
+await chain.submitSignedTxWithReSigns(tx)
 ```
 
 Please note that the **same CTYPE can only be stored once** on the blockchain.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,17 +167,17 @@ const identity = Kilt.Identity.buildFromMnemonic(
   // using ed25519 as key type because this is how the endowed identity is set up
   { signingKeyPairType: 'ed25519' }
 )
-const tx = await ctype.store(identity)
+const tx = await ctype.store()
 
 // either sign and send in one step
-await Kilt.BlockchainUtils.submitSignedTx(tx, {
-  resolveOn: Kilt.BlockchainUtils.IS_IN_BLOCK,
-})
+  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
+    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
+  })
 
 // or step by step
 const chain = Kilt.connect()
 const signed = chain.signTx(identity, tx)
-await chain.submitSignedTxWithReSigns(tx)
+await Kilt.BlockchainUtils.submitSignedTx(tx)
 ```
 
 Please note that the **same CTYPE can only be stored once** on the blockchain.

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -55,8 +55,8 @@ async function main(): Promise<void> {
 
   /* or manually step by step */
   // const chain = Kilt.connect()
-  // chain.signTx(identity, tx)  tx = await ctype.store()
-  // await chain.submitSignedTxWithReSigns(tx,identity)
+  // chain.signTx(identity, tx)
+  // await Kilt.BlockchainUtils.submitSignedTx(tx)
 
   /* At the end of the process, the `CType` object should contain the following. */
   console.log(ctype)

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -54,11 +54,9 @@ async function main(): Promise<void> {
   })
 
   /* or manually step by step */
-  const chain = Kilt.connect()
-
-  chain.signTx(identity, tx)
-
-  await chain.submitSignedTxWithReSigns(tx)
+  // const chain = Kilt.connect()
+  // chain.signTx(identity, tx)  tx = await ctype.store()
+  // await chain.submitSignedTxWithReSigns(tx)
 
   /* At the end of the process, the `CType` object should contain the following. */
   console.log(ctype)

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -54,7 +54,7 @@ async function main(): Promise<void> {
   })
 
   /* or manually step by step */
-  const chain = Kilt.ChainHelpers.BlockchainApiConnection.getConnectionOrConnect()
+  const chain = Kilt.connect()
 
   chain.signTx(identity, tx)
 

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -58,9 +58,7 @@ async function main(): Promise<void> {
 
   chain.signTx(identity, tx)
 
-  await Kilt.BlockchainUtils.submitSignedTx(tx, {
-    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
-  })
+  await chain.submitSignedTxWithReSigns(tx)
 
   /* At the end of the process, the `CType` object should contain the following. */
   console.log(ctype)

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -47,9 +47,19 @@ async function main(): Promise<void> {
     { signingKeyPairType: 'ed25519' }
   )
   tx = await ctype.store()
-  await Kilt.ChainHelpers.Blockchain.signAndSubmitTx(tx, identity, {
+  /* This transaction has to be signed and sent to the Blockchain, either automatically like this */
+  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
     resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
     reSign: true,
+  })
+
+  /* or manually step by step */
+  const chain = Kilt.ChainHelpers.BlockchainApiConnection.getConnectionOrConnect()
+
+  chain.signTx(identity, tx)
+
+  await Kilt.BlockchainUtils.submitSignedTx(tx, {
+    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
   })
 
   /* At the end of the process, the `CType` object should contain the following. */

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
   /* or manually step by step */
   // const chain = Kilt.connect()
   // chain.signTx(identity, tx)  tx = await ctype.store()
-  // await chain.submitSignedTxWithReSigns(tx)
+  // await chain.submitSignedTxWithReSigns(tx,identity)
 
   /* At the end of the process, the `CType` object should contain the following. */
   console.log(ctype)

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -16,7 +16,7 @@ import type {
   IRequestAttestationForClaim,
 } from '@kiltprotocol/types'
 import Message from '@kiltprotocol/messaging'
-import { Blockchain } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 
 export interface IRevocationHandle {
   claimHash: IAttestation['claimHash']
@@ -75,7 +75,7 @@ export async function issueAttestation(
   )
 
   const tx = await attestation.store()
-  await Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
+  await BlockchainUtils.signAndSubmitTx(tx, attester, { reSign: true })
 
   const revocationHandle = { claimHash: attestation.claimHash }
   return {
@@ -120,5 +120,5 @@ export async function revokeAttestation(
     attester,
     delegationTreeTraversalSteps
   )
-  Blockchain.signAndSubmitTx(tx, attester, { reSign: true })
+  BlockchainUtils.signAndSubmitTx(tx, attester, { reSign: true })
 }

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -22,10 +22,8 @@ import type {
   IBlockchainApi,
   BlockchainStats,
   SubscriptionPromise,
-  ReSignOpts,
 } from '@kiltprotocol/types'
 import { submitSignedTx } from './Blockchain.utils'
-import { getConnectionOrConnect } from '../blockchainApiConnection/BlockchainApiConnection'
 
 const log = ConfigService.LoggingFactory.getLogger('Blockchain')
 
@@ -37,31 +35,6 @@ export default class Blockchain implements IBlockchainApi {
     const json = queryResult.toJSON()
     if (json instanceof Array) return json
     return []
-  }
-
-  /**
-   * [STATIC] [ASYNC] Signs and submits the SubmittableExtrinsic with optional resolution and rejection criteria.
-   *
-   * @param tx The generated unsigned SubmittableExtrinsic to submit.
-   * @param identity The [[Identity]] used to sign and potentially re-sign the tx.
-   * @param opts Partial optional criteria for resolving/rejecting the promise.
-   * @param opts.reSign Optional flag for re-attempting to send recoverably failed Tx.
-   * @returns Promise result of executing the extrinsic, of type ISubmittableResult.
-   *
-   */
-  public static async signAndSubmitTx(
-    tx: SubmittableExtrinsic,
-    identity: IIdentity,
-    {
-      reSign = false,
-      ...opts
-    }: Partial<SubscriptionPromise.Options> & Partial<ReSignOpts> = {}
-  ): Promise<ISubmittableResult> {
-    const chain = await getConnectionOrConnect()
-    const signedTx = await chain.signTx(identity, tx)
-    return reSign
-      ? chain.submitSignedTxWithReSign(signedTx, identity, opts)
-      : submitSignedTx(signedTx, opts)
   }
 
   public api: ApiPromise
@@ -111,7 +84,7 @@ export default class Blockchain implements IBlockchainApi {
   }
 
   /**
-   * [ASYNC] Submits a signed SubmittableExtrinsic with exported function [[submitSignedTx]].
+   * [ASYNC] Submits a signed SubmittableExtrinsic with imported function [[submitSignedTx]].
    * Handles recoverable errors if identity is provided by re-signing and re-sending the tx up to two times.
    * Uses [[parseSubscriptionOptions]] to provide complete potentially defaulted options to the called [[submitSignedTx]].
    *

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -3,11 +3,7 @@
  */
 
 import type { IAttestedClaim, IClaim } from '@kiltprotocol/types'
-import {
-  Blockchain,
-  BlockchainUtils,
-  ExtrinsicErrors,
-} from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
 import Attestation from '../attestation/Attestation'
 import { revoke } from '../attestation/Attestation.chain'
 import AttestedClaim from '../attestedclaim/AttestedClaim'
@@ -42,7 +38,7 @@ describe('handling attestations that do not exist', () => {
   it('Attestation.revoke', async () => {
     return expect(
       Attestation.revoke('0x012012012', alice, 0).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, alice, {
+        BlockchainUtils.signAndSubmitTx(tx, alice, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -66,7 +62,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     // console.log(`verify stored: ${await DriversLicense.verifyStored()}`)
     if (!ctypeExists) {
       await DriversLicense.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, attester, {
+        BlockchainUtils.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -102,7 +98,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attester.getPublicIdentity()
     )
     await attestation.store().then((tx) =>
-      Blockchain.signAndSubmitTx(tx, attester, {
+      BlockchainUtils.signAndSubmitTx(tx, attester, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -132,7 +128,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     await expect(
       attestation.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, bobbyBroke, {
+        BlockchainUtils.signAndSubmitTx(tx, bobbyBroke, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -172,7 +168,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
     await expect(
       attestation.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, attester, {
+        BlockchainUtils.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -198,7 +194,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await attestation.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, attester, {
+        BlockchainUtils.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -210,7 +206,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible to attest the same claim twice', async () => {
       await expect(
         attClaim.attestation.store().then((tx) =>
-          Blockchain.signAndSubmitTx(tx, attester, {
+          BlockchainUtils.signAndSubmitTx(tx, attester, {
             resolveOn: BlockchainUtils.IS_IN_BLOCK,
             reSign: true,
           })
@@ -239,7 +235,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should not be possible for the claimer to revoke an attestation', async () => {
       await expect(
         revoke(attClaim.getHash(), 0).then((tx) =>
-          Blockchain.signAndSubmitTx(tx, claimer, {
+          BlockchainUtils.signAndSubmitTx(tx, claimer, {
             resolveOn: BlockchainUtils.IS_IN_BLOCK,
             reSign: true,
           })
@@ -251,7 +247,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     it('should be possible for the attester to revoke an attestation', async () => {
       await expect(attClaim.verify()).resolves.toBeTruthy()
       await revoke(attClaim.getHash(), 0).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, attester, {
+        BlockchainUtils.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -264,7 +260,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     beforeAll(async () => {
       if (!(await CtypeOnChain(IsOfficialLicenseAuthority))) {
         await IsOfficialLicenseAuthority.store().then((tx) =>
-          Blockchain.signAndSubmitTx(tx, faucet, {
+          BlockchainUtils.signAndSubmitTx(tx, faucet, {
             resolveOn: BlockchainUtils.IS_IN_BLOCK,
             reSign: true,
           })
@@ -294,7 +290,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         faucet.getPublicIdentity()
       )
       await licenseAuthorizationGranted.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, faucet, {
+        BlockchainUtils.signAndSubmitTx(tx, faucet, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -322,7 +318,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attester.getPublicIdentity()
       )
       await LicenseGranted.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, attester, {
+        BlockchainUtils.signAndSubmitTx(tx, attester, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import BN from 'bn.js/'
-import { Blockchain, BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import {
   getBalances,
   listenToBalanceChanges,
@@ -64,7 +64,7 @@ describe('when there is a dev chain with a faucet', () => {
     listenToBalanceChanges(ident.address, funny)
     const balanceBefore = await getBalances(faucet.address)
     await makeTransfer(ident.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, faucet, {
+      BlockchainUtils.signAndSubmitTx(tx, faucet, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -96,7 +96,7 @@ describe('When there are haves and have-nots', () => {
 
   it('can transfer tokens from the rich to the poor', async () => {
     await makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, richieRich, {
+      BlockchainUtils.signAndSubmitTx(tx, richieRich, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -109,7 +109,7 @@ describe('When there are haves and have-nots', () => {
     const originalBalance = await getBalances(stormyD.address)
     await expect(
       makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, bobbyBroke, {
+        BlockchainUtils.signAndSubmitTx(tx, bobbyBroke, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -127,7 +127,7 @@ describe('When there are haves and have-nots', () => {
     const RichieBalance = await getBalances(richieRich.address)
     await expect(
       makeTransfer(bobbyBroke.address, RichieBalance.free).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, richieRich, {
+        BlockchainUtils.signAndSubmitTx(tx, richieRich, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -145,13 +145,13 @@ describe('When there are haves and have-nots', () => {
     const listener = jest.fn()
     listenToBalanceChanges(faucet.address, listener)
     await makeTransfer(richieRich.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, faucet, {
+      BlockchainUtils.signAndSubmitTx(tx, faucet, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
     )
     await makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, faucet, {
+      BlockchainUtils.signAndSubmitTx(tx, faucet, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -170,13 +170,13 @@ describe('When there are haves and have-nots', () => {
     listenToBalanceChanges(faucet.address, listener)
     await Promise.all([
       makeTransfer(richieRich.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, faucet, {
+        BlockchainUtils.signAndSubmitTx(tx, faucet, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
       ),
       makeTransfer(stormyD.address, MIN_TRANSACTION).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, faucet, {
+        BlockchainUtils.signAndSubmitTx(tx, faucet, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -6,7 +6,7 @@ import type { SignerPayload } from '@polkadot/types/interfaces/extrinsics/types'
 import BN from 'bn.js/'
 import { SDKErrors } from '@kiltprotocol/utils'
 import type { IBlockchainApi } from '@kiltprotocol/types'
-import { Blockchain, BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { makeTransfer } from '../balance/Balance.chain'
 import Identity from '../identity/Identity'
 import { wannabeFaucet, wannabeCharlie, WS_ADDRESS } from './utils'
@@ -27,7 +27,7 @@ describe('Chain returns specific errors, that we check for', () => {
     testIdentity = Identity.buildFromURI(Identity.generateMnemonic())
     charlie = wannabeCharlie
     const tx = await makeTransfer(testIdentity.address, new BN(10000), 0)
-    await Blockchain.signAndSubmitTx(tx, faucet, {
+    await BlockchainUtils.signAndSubmitTx(tx, faucet, {
       resolveOn: BlockchainUtils.IS_FINALIZED,
       reSign: true,
     })

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -3,11 +3,7 @@
  */
 
 import type { ICType } from '@kiltprotocol/types'
-import {
-  Blockchain,
-  BlockchainUtils,
-  ExtrinsicErrors,
-} from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
 import { Identity } from '..'
 import CType from '../ctype/CType'
 import { getOwner } from '../ctype/CType.chain'
@@ -46,7 +42,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     const bobbyBroke = Identity.buildFromMnemonic(Identity.generateMnemonic())
     await expect(
       ctype.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, bobbyBroke, {
+        BlockchainUtils.signAndSubmitTx(tx, bobbyBroke, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -58,7 +54,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
   it('should be possible to create a claim type', async () => {
     const ctype = makeCType()
     await ctype.store().then((tx) =>
-      Blockchain.signAndSubmitTx(tx, ctypeCreator, {
+      BlockchainUtils.signAndSubmitTx(tx, ctypeCreator, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -74,14 +70,14 @@ describe('When there is an CtypeCreator and a verifier', () => {
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
     await ctype.store().then((tx) =>
-      Blockchain.signAndSubmitTx(tx, ctypeCreator, {
+      BlockchainUtils.signAndSubmitTx(tx, ctypeCreator, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
     )
     await expect(
       ctype.store().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, ctypeCreator, {
+        BlockchainUtils.signAndSubmitTx(tx, ctypeCreator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -5,7 +5,7 @@
 import type { ICType } from '@kiltprotocol/types'
 import { Permission } from '@kiltprotocol/types'
 import { UUID } from '@kiltprotocol/utils'
-import { Blockchain, BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { AttestedClaim, Identity } from '..'
 import Attestation from '../attestation/Attestation'
 import { config, disconnect } from '../kilt'
@@ -38,7 +38,7 @@ async function writeRoot(
     delegator.address
   )
   await root.store().then((tx) =>
-    Blockchain.signAndSubmitTx(tx, delegator, {
+    BlockchainUtils.signAndSubmitTx(tx, delegator, {
       resolveOn: BlockchainUtils.IS_IN_BLOCK,
       reSign: true,
     })
@@ -63,7 +63,7 @@ async function addDelegation(
   await delegation
     .store(delegee.signStr(delegation.generateHash()))
     .then((tx) =>
-      Blockchain.signAndSubmitTx(tx, delegator, {
+      BlockchainUtils.signAndSubmitTx(tx, delegator, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -83,7 +83,7 @@ beforeAll(async () => {
 
   if (!(await CtypeOnChain(DriversLicense))) {
     await DriversLicense.store().then((tx) =>
-      Blockchain.signAndSubmitTx(tx, attester, {
+      BlockchainUtils.signAndSubmitTx(tx, attester, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -135,7 +135,7 @@ describe('and attestation rights have been delegated', () => {
       attester.getPublicIdentity()
     )
     await attestation.store().then((tx) =>
-      Blockchain.signAndSubmitTx(tx, attester, {
+      BlockchainUtils.signAndSubmitTx(tx, attester, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -150,7 +150,7 @@ describe('and attestation rights have been delegated', () => {
 
     // revoke attestation through root
     await attClaim.attestation.revoke(root, 1).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, root, {
+      BlockchainUtils.signAndSubmitTx(tx, root, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -179,7 +179,7 @@ describe('revocation', () => {
     )
     await expect(
       delegationA.revoke(delegator).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, delegator, {
+        BlockchainUtils.signAndSubmitTx(tx, delegator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -197,7 +197,7 @@ describe('revocation', () => {
     )
     await expect(
       delegationRoot.revoke().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, firstDelegee, {
+        BlockchainUtils.signAndSubmitTx(tx, firstDelegee, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -207,7 +207,7 @@ describe('revocation', () => {
 
     await expect(
       delegationA.revoke(firstDelegee).then((tx) =>
-        Blockchain.signAndSubmitTx(tx, firstDelegee, {
+        BlockchainUtils.signAndSubmitTx(tx, firstDelegee, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })
@@ -230,7 +230,7 @@ describe('revocation', () => {
     )
     await expect(
       delegationRoot.revoke().then((tx) =>
-        Blockchain.signAndSubmitTx(tx, delegator, {
+        BlockchainUtils.signAndSubmitTx(tx, delegator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
         })

--- a/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
@@ -3,11 +3,7 @@
  */
 
 import BN from 'bn.js'
-import {
-  Blockchain,
-  BlockchainUtils,
-  ExtrinsicErrors,
-} from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils, ExtrinsicErrors } from '@kiltprotocol/chain-helpers'
 import { Attestation } from '..'
 import { makeTransfer } from '../balance/Balance.chain'
 import Identity from '../identity'
@@ -27,7 +23,7 @@ it('records an unknown extrinsic error when transferring less than the existenti
   const to = Identity.buildFromMnemonic('')
   await expect(
     makeTransfer(to.address, new BN(1)).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, alice, {
+      BlockchainUtils.signAndSubmitTx(tx, alice, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
       })
@@ -47,7 +43,7 @@ it('records an extrinsic error when ctype does not exist', async () => {
   })
   const tx = await attestation.store()
   await expect(
-    Blockchain.signAndSubmitTx(tx, alice, {
+    BlockchainUtils.signAndSubmitTx(tx, alice, {
       resolveOn: BlockchainUtils.IS_IN_BLOCK,
       reSign: true,
     })

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -7,7 +7,7 @@ import { GenericAccountIndex as AccountIndex } from '@polkadot/types/generic/Acc
 import type { AccountData, AccountInfo } from '@polkadot/types/interfaces'
 import BN from 'bn.js/'
 import TYPE_REGISTRY from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
-import { Blockchain } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import type { Balances } from '@kiltprotocol/types'
 import Identity from '../identity/Identity'
 import {
@@ -78,7 +78,7 @@ describe('Balance', () => {
 
   it('should make transfer', async () => {
     const status = await makeTransfer(bob.address, new BN(100)).then((tx) =>
-      Blockchain.signAndSubmitTx(tx, alice, { reSign: true })
+      BlockchainUtils.signAndSubmitTx(tx, alice, { reSign: true })
     )
     expect(status).toBeInstanceOf(SubmittableResult)
     expect(status.isFinalized).toBeTruthy()
@@ -94,7 +94,7 @@ describe('Balance', () => {
       bob.address,
       amount,
       exponent
-    ).then((tx) => Blockchain.signAndSubmitTx(tx, alice, { reSign: true }))
+    ).then((tx) => BlockchainUtils.signAndSubmitTx(tx, alice, { reSign: true }))
     expect(blockchainApi.tx.balances.transfer).toHaveBeenCalledWith(
       bob.address,
       expectedAmount

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -13,7 +13,7 @@ import type {
   ICTypeSchema,
   CompressedCTypeSchema,
 } from '@kiltprotocol/types'
-import { Blockchain } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import Claim from '../claim/Claim'
 import Identity from '../identity/Identity'
 import requestForAttestation from '../requestforattestation/RequestForAttestation'
@@ -106,7 +106,7 @@ describe('CType', () => {
     const ctype = CType.fromSchema(ctypeModel, identityAlice.address)
 
     const tx = await ctype.store()
-    const result = await Blockchain.signAndSubmitTx(tx, identityAlice, {
+    const result = await BlockchainUtils.signAndSubmitTx(tx, identityAlice, {
       reSign: true,
     })
     expect(result).toBeInstanceOf(SubmittableResult)
@@ -169,8 +169,8 @@ describe('CType', () => {
       SDKErrors.ERROR_ADDRESS_INVALID(invalidAddressCtype.owner!, 'CType owner')
     )
     expect(() => CType.fromCType(faultyAddressTypeCType)).toThrowError(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       SDKErrors.ERROR_ADDRESS_INVALID(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         faultyAddressTypeCType.owner!,
         'CType owner'
       )

--- a/packages/core/src/delegation/DelegationRootNode.spec.ts
+++ b/packages/core/src/delegation/DelegationRootNode.spec.ts
@@ -4,7 +4,7 @@
 
 import { Crypto } from '@kiltprotocol/utils'
 import {
-  Blockchain,
+  BlockchainUtils,
   BlockchainApiConnection,
 } from '@kiltprotocol/chain-helpers'
 import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
@@ -55,7 +55,7 @@ describe('Delegation', () => {
     await rootDelegation
       .store()
       .then((tx) =>
-        Blockchain.signAndSubmitTx(tx, identityAlice, { reSign: true })
+        BlockchainUtils.signAndSubmitTx(tx, identityAlice, { reSign: true })
       )
 
     const rootNode = await DelegationRootNode.query(ROOT_IDENTIFIER)
@@ -120,7 +120,7 @@ describe('Delegation', () => {
     const revokeStatus = await aDelegationRootNode
       .revoke()
       .then((tx) =>
-        Blockchain.signAndSubmitTx(tx, identityAlice, { reSign: true })
+        BlockchainUtils.signAndSubmitTx(tx, identityAlice, { reSign: true })
       )
     expect(blockchain.api.tx.delegation.revokeRoot).toBeCalledWith(
       'myRootId',

--- a/packages/core/src/did/Did.spec.ts
+++ b/packages/core/src/did/Did.spec.ts
@@ -7,7 +7,7 @@ import { SDKErrors } from '@kiltprotocol/utils'
 import TYPE_REGISTRY, {
   mockChainQueryReturn,
 } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
-import { Blockchain } from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { Did, IDid } from '..'
 import Identity from '../identity/Identity'
 import {
@@ -89,7 +89,7 @@ describe('DID', () => {
     const did = Did.fromIdentity(alice, 'http://myDID.kilt.io')
     const tx = await did.store()
     await expect(
-      Blockchain.signAndSubmitTx(tx, alice, { reSign: true })
+      BlockchainUtils.signAndSubmitTx(tx, alice, { reSign: true })
     ).resolves.toHaveProperty('isFinalized', true)
   })
 

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -7,10 +7,7 @@ import {
   Attester,
   Verifier,
 } from '@kiltprotocol/actors-api'
-import {
-  BlockchainUtils,
-  SubscriptionPromise,
-} from '@kiltprotocol/chain-helpers'
+import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import * as ChainHelpers from '@kiltprotocol/chain-helpers'
 import * as Utils from '@kiltprotocol/utils'
 
@@ -25,7 +22,6 @@ export {
   Attester,
   Verifier,
   BlockchainUtils,
-  SubscriptionPromise,
   ChainHelpers,
   Utils,
 }
@@ -40,7 +36,6 @@ export default {
   Attester,
   Verifier,
   BlockchainUtils,
-  SubscriptionPromise,
   ChainHelpers,
   Utils,
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1247

Moves `signAndSubmitTx` as exported function to `BlockchainUtils`
added additional instruction for step by step signing and submitting in getting started guide
removed `SubscriptionPromise` from direct sdk-js package export, this is accessible in `ChainHelpers`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
