### PR TITLE
fix: outdated docs, unrequired identity

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -69,15 +69,13 @@ async function setup(): Promise<{
   const ctype = new Kilt.CType(rawCtype)
 
   // Store ctype on blockchain
+  // signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria or activate re-sign-re-send options.
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {
-    await ctype.store().then((tx) =>
-      Kilt.BlockchainUtils.signAndSubmitTx(tx, attester, {
-        resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
-        reSign: true,
-      })
-    )
+    await ctype
+      .store()
+      .then((tx) => Kilt.BlockchainUtils.signAndSubmitTx(tx, attester))
   } catch (e) {
     console.log(
       'Error while storing CType. Probably either insufficient funds or ctype does already exist.',

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -48,10 +48,14 @@ async function main(): Promise<void> {
   )
   tx = await ctype.store()
   /* This transaction has to be signed and sent to the Blockchain, either automatically like this */
-  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
-    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
-    reSign: true,
-  })
+  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity)
+
+  /* signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria or activate re-sign-re-send options:
+  // await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
+  //   resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
+  //   rejectOn: Kilt.BlockchainUtils.IS_ERROR,
+  //   reSign: true,
+  // })
 
   /* or manually step by step */
   // const chain = Kilt.connect()

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -75,7 +75,7 @@ export async function issueAttestation(
   )
 
   const tx = await attestation.store()
-  await BlockchainUtils.signAndSubmitTx(tx, attester, { reSign: true })
+  await BlockchainUtils.signAndSubmitTx(tx, attester)
 
   const revocationHandle = { claimHash: attestation.claimHash }
   return {
@@ -117,8 +117,7 @@ export async function revokeAttestation(
 
   const tx = await Attestation.revoke(
     revocationHandle.claimHash,
-    attester,
     delegationTreeTraversalSteps
   )
-  BlockchainUtils.signAndSubmitTx(tx, attester, { reSign: true })
+  BlockchainUtils.signAndSubmitTx(tx, attester)
 }

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -1,7 +1,7 @@
 /**
  * Blockchain bridges that connects the SDK and the KILT Blockchain.
  *
- * Communicates with the chain via WebSockets and can [[listenToBlocks]]. It exposes the [[submitTx]] function that performs a transaction.
+ * Communicates with the chain via WebSockets and can [[listenToBlocks]]. It exposes the [[signTx]] function that performs the necessary tx signing.
  *
  * @packageDocumentation
  * @module Blockchain

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -16,7 +16,7 @@
  *   false
  * )
  * const transfer = blockchain.api.tx.balances.transfer(alice.address, amount) // returns a mock SubmittableExtrinsic that has a send() method
- * const result = await blockchain.submitTx(alice, transfer)                   // calls transfer.send() internally
+ * const result = await BlockchainUtils.signAndSubmitTx(alice, transfer)       // calls transfer.send() internally
  * ```
  * You can also queue results with
  * ```

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -37,7 +37,7 @@ describe('handling attestations that do not exist', () => {
 
   it('Attestation.revoke', async () => {
     return expect(
-      Attestation.revoke('0x012012012', alice, 0).then((tx) =>
+      Attestation.revoke('0x012012012', 0).then((tx) =>
         BlockchainUtils.signAndSubmitTx(tx, alice, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -149,7 +149,7 @@ describe('and attestation rights have been delegated', () => {
     await expect(attClaim.verify()).resolves.toBeTruthy()
 
     // revoke attestation through root
-    await attClaim.attestation.revoke(root, 1).then((tx) =>
+    await attClaim.attestation.revoke(1).then((tx) =>
       BlockchainUtils.signAndSubmitTx(tx, root, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
         reSign: true,
@@ -178,7 +178,7 @@ describe('revocation', () => {
       firstDelegee
     )
     await expect(
-      delegationA.revoke(delegator).then((tx) =>
+      delegationA.revoke(delegator.address).then((tx) =>
         BlockchainUtils.signAndSubmitTx(tx, delegator, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,
@@ -206,7 +206,7 @@ describe('revocation', () => {
     await expect(delegationRoot.verify()).resolves.toBe(true)
 
     await expect(
-      delegationA.revoke(firstDelegee).then((tx) =>
+      delegationA.revoke(firstDelegee.address).then((tx) =>
         BlockchainUtils.signAndSubmitTx(tx, firstDelegee, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
           reSign: true,

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -18,7 +18,6 @@ import type {
   IRequestForAttestation,
   CompressedAttestation,
 } from '@kiltprotocol/types'
-import Identity from '../identity/Identity'
 import { revoke, query, store } from './Attestation.chain'
 import AttestationUtils from './Attestation.utils'
 import DelegationRootNode from '../delegation/DelegationRootNode'
@@ -44,18 +43,17 @@ export default class Attestation implements IAttestation {
    * [STATIC] [ASYNC] Revokes an attestation. Also available as an instance method.
    *
    * @param claimHash - The hash of the claim that corresponds to the attestation to revoke.
-   * @param identity - The identity used to revoke the attestation (should be an attester identity, or have delegated rights).
-   * @param maxDepth - The number of levels to walk up the delegation hirarchy until the delegation node of identity is found.
-   * @returns A promise containing the SubmittableExtrinsic (submittable transaction).
+   * @param maxDepth - The number of levels to walk up the delegation hierarchy until the delegation node is found.
+   * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
    * @example ```javascript
-   * Attestation.revoke('0xd8024cdc147c4fa9221cd177', attesterIdentity, 3).then(() => {
-   *   // the attestation was successfully revoked
+   * Attestation.revoke('0xd8024cdc147c4fa9221cd177', 3).then(() => {
+   *   // the attestation revocation tx was created, sign and send it!
+   *   BlockchainUtils.signAndSendTx(tx, identity);
    * });
    * ```
    */
   public static async revoke(
     claimHash: string,
-    identity: Identity,
     maxDepth: number
   ): Promise<SubmittableExtrinsic> {
     return revoke(claimHash, maxDepth)
@@ -166,12 +164,11 @@ export default class Attestation implements IAttestation {
   /**
    * [ASYNC] Stores the attestation on chain.
    *
-   * @param identity - The identity used to store the attestation.
-   * @returns A promise containing the SubmittableExtrinsic (submittable transaction).
+   * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
    * @example ```javascript
    * // Use `store` to store an attestation on chain, and to create an `AttestedClaim` upon success:
-   * attestation.store(attester).then(() => {
-   *   // the attestation was successfully stored, so now we can for example create an AttestedClaim
+   * attestation.store().then(() => {
+   *   // the attestation store tx was successfully prepared, so now we can sign and send it and subsequently create an `AttestedClaim`.
    * });
    * ```
    */
@@ -182,19 +179,16 @@ export default class Attestation implements IAttestation {
   /**
    * [ASYNC] Revokes the attestation. Also available as a static method.
    *
-   * @param identity - The identity used to revoke the attestation (should be an attester identity, or have delegated rights).
-   * @param maxDepth - The number of levels to walk up the delegation hirarchy until the delegation node of identity is found.
-   * @returns A promise containing the SubmittableExtrinsic (submittable transaction).
+   * @param maxDepth - The number of levels to walk up the delegation hierarchy until the delegation node is found.
+   * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
    * @example ```javascript
-   * attestation.revoke(identity, 3).then(() => {
-   *   // the attestation was successfully revoked
+   * attestation.revoke(3).then((tx) => {
+   *   // the attestation revocation tx was created, sign and send it!
+   *   BlockchainUtils.signAndSendTx(tx, identity);
    * });
    * ```
    */
-  public async revoke(
-    identity: Identity,
-    maxDepth: number
-  ): Promise<SubmittableExtrinsic> {
+  public async revoke(maxDepth: number): Promise<SubmittableExtrinsic> {
     return revoke(this.claimHash, maxDepth)
   }
 

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -100,13 +100,13 @@ export async function listenToBalanceChanges(
 }
 
 /**
- * Transfer Kilt [amount] tokens to [toAccountAddress] using the given [[Identity]].
+ * Transfer Kilt [amount] tokens to [toAccountAddress].
  * <B>Note that the value of the transferred currency and the balance amount reported by the chain is in Femto-Kilt (1e-15), and must be translated to Kilt-Coin</B>.
  *
  * @param accountAddressTo Address of the receiver account.
  * @param amount Amount of Units to transfer.
  * @param exponent Magnitude of the amount. Default magnitude of Femto-Kilt.
- * @returns Promise containing the transaction status.
+ * @returns Promise containing unsigned SubmittableExtrinsic.
  *
  * @example
  * <BR>
@@ -116,8 +116,8 @@ export async function listenToBalanceChanges(
  * const address = ...
  * const amount: BN = new BN(42)
  * const blockchain = await sdk.getConnectionOrConnect()
- * sdk.Balance.makeTransfer(identity, address, amount)
- *   .then(tx => blockchain.sendTx(tx))
+ * sdk.Balance.makeTransfer(address, amount, 0) //
+ *   .then(tx => BlockchainUtils.signAndSendTx(tx, identity))
  *   .then(() => console.log('Successfully transferred ${amount.toNumber()} tokens'))
  *   .catch(err => {
  *     console.log('Transfer failed')

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -85,7 +85,7 @@ describe('Balance', () => {
   })
   it('should make transfer of amount with arbitrary exponent', async () => {
     const amount = new BN(10)
-    const exponent = -6
+    const exponent = -6.312513431
     const expectedAmount = BalanceUtils.convertToTxUnit(
       amount,
       (exponent >= 0 ? 1 : -1) * Math.floor(Math.abs(exponent))

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -88,7 +88,7 @@ export default class CType implements ICType {
   /**
    * [ASYNC] Stores the [[CType]] on the blockchain.
    *
-   * @returns A promise of a SubmittableExtrinsic.
+   * @returns A promise of a unsigned SubmittableExtrinsic.
    */
   public async store(): Promise<SubmittableExtrinsic> {
     return store(this)

--- a/packages/core/src/delegation/Delegation.ts
+++ b/packages/core/src/delegation/Delegation.ts
@@ -101,6 +101,7 @@ export default abstract class DelegationBaseNode
   /**
    * Revokes this delegation node on chain.
    *
+   * @param address The address of the identity used to revoke the delegation.
    * @returns Promise containing a unsigned submittable transaction.
    */
   public abstract revoke(address: string): Promise<SubmittableExtrinsic>

--- a/packages/core/src/delegation/Delegation.ts
+++ b/packages/core/src/delegation/Delegation.ts
@@ -101,12 +101,12 @@ export default abstract class DelegationBaseNode
   /**
    * Revokes this delegation node on chain.
    *
-   * @returns Promise containing a submittable transaction.
+   * @returns Promise containing a unsigned submittable transaction.
    */
-  public abstract revoke(identity: Identity): Promise<SubmittableExtrinsic>
+  public abstract revoke(address: string): Promise<SubmittableExtrinsic>
 
   /**
-   * Checks on chain whether a given identity is delegating to the current node.
+   * Checks on chain whether a identity with the given address is delegating to the current node.
    *
    * @param address The address of the identity.
    * @returns An object containing a `node` owned by the identity if it is delegating, plus the number of `steps` traversed. `steps` is 0 if the address is owner of the current node.

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -78,7 +78,7 @@ export async function query(
  * @param delegationId The id of the node in the delegation tree at which to revoke.
  * @param maxDepth How many nodes may be traversed upwards in the hierarchy when searching for a node owned by `identity`. Each traversal will add to the transaction fee. Therefore a higher number will increase the fees locked until the transaction is complete. A number lower than the actual required traversals will result in a failed extrinsic (node will not be revoked).
  * @param maxRevocations How many delegation nodes may be revoked during the process. Each revocation adds to the transaction fee. A higher number will require more fees to be locked while an insufficiently high number will lead to premature abortion of the revocation process, leaving some nodes unrevoked. Revocations will first be performed on child nodes, therefore the current node is only revoked when this is accurate.
- * @returns A unsigned SubmittableExtrinsic ready to be signed and dispatched.
+ * @returns An unsigned SubmittableExtrinsic ready to be signed and dispatched.
  */
 export async function revoke(
   delegationId: IDelegationNode['id'],

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -78,7 +78,7 @@ export async function query(
  * @param delegationId The id of the node in the delegation tree at which to revoke.
  * @param maxDepth How many nodes may be traversed upwards in the hierarchy when searching for a node owned by `identity`. Each traversal will add to the transaction fee. Therefore a higher number will increase the fees locked until the transaction is complete. A number lower than the actual required traversals will result in a failed extrinsic (node will not be revoked).
  * @param maxRevocations How many delegation nodes may be revoked during the process. Each revocation adds to the transaction fee. A higher number will require more fees to be locked while an insufficiently high number will lead to premature abortion of the revocation process, leaving some nodes unrevoked. Revocations will first be performed on child nodes, therefore the current node is only revoked when this is accurate.
- * @returns A signed SubmittableExtrinsic ready to be dispatched.
+ * @returns A unsigned SubmittableExtrinsic ready to be signed and dispatched.
  */
 export async function revoke(
   delegationId: IDelegationNode['id'],

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -11,7 +11,6 @@
 import type { IDelegationNode, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
-import Identity from '../identity/Identity'
 import DelegationBaseNode from './Delegation'
 import { getChildren, query, revoke, store } from './DelegationNode.chain'
 import permissionsAsBitset from './DelegationNode.utils'
@@ -78,7 +77,8 @@ export default class DelegationNode extends DelegationBaseNode
    *
    * // Store the signed hash on the Kilt chain...
    * const myIdentity: Identity = ...
-   * newDelegationNode.store(myIdentity, signature)
+   * tx = newDelegationNode.store(signature)
+   * BlockchainUtils.signAndSendTx(tx, myIdentity)
    * ```
    *
    * @returns The hash representation of this delegation **as a hex string**.
@@ -131,7 +131,7 @@ export default class DelegationNode extends DelegationBaseNode
    * [ASYNC] Stores the delegation node on chain.
    *
    * @param signature Signature of the delegate to ensure it is done under the delegate's permission.
-   * @returns Promise containing a SubmittableExtrinsic.
+   * @returns Promise containing a unsigned SubmittableExtrinsic.
    */
   public async store(signature: string): Promise<SubmittableExtrinsic> {
     log.info(`:: store(${this.id})`)
@@ -151,21 +151,21 @@ export default class DelegationNode extends DelegationBaseNode
   /**
    * [ASYNC] Revokes the delegation node on chain.
    *
-   * @param identity The identity used to revoke the delegation.
-   * @returns Promise containing a SubmittableExtrinsic.
+   * @param address The address of the identity used to revoke the delegation.
+   * @returns Promise containing an unsigned SubmittableExtrinsic.
    */
-  public async revoke(identity: Identity): Promise<SubmittableExtrinsic> {
-    const { steps, node } = await this.findAncestorOwnedBy(identity.address)
+  public async revoke(address: string): Promise<SubmittableExtrinsic> {
+    const { steps, node } = await this.findAncestorOwnedBy(address)
     if (!node) {
       throw SDKErrors.ERROR_UNAUTHORIZED(
-        `Identity with address ${identity.address} is not among the delegators and may not revoke this node`
+        `Identity with address ${address} is not among the delegators and may not revoke this node`
       )
     }
     const childCount = await this.subtreeNodeCount()
     // must revoke all children and self
     const revocationCount = childCount + 1
     log.debug(
-      `:: revoke(${this.id}) with maxRevocations=${revocationCount} and maxDepth = ${steps} through delegation node ${node?.id} and identity ${identity.address}`
+      `:: revoke(${this.id}) with maxRevocations=${revocationCount} and maxDepth = ${steps} through delegation node ${node?.id} and identity ${address}`
     )
     return revoke(this.id, steps, revocationCount)
   }

--- a/packages/core/src/delegation/DelegationRootNode.chain.ts
+++ b/packages/core/src/delegation/DelegationRootNode.chain.ts
@@ -62,9 +62,8 @@ export async function query(
  * Revokes a full delegation tree, also revoking all constituent nodes.
  *
  * @param delegation The [[DelegationRootNode]] node in the delegation tree at which to revoke.
- * @param identity The owner of the [[DelegationRootNode]], who is the only one authorized to revoke it.
  * @param maxRevocations The maximum number of revocations that may be performed. Should be set to the number of nodes (including the root node) in the tree. Higher numbers result in a larger amount locked during the transaction, as each revocation adds to the fee that is charged.
- * @returns Signed [[SubmittableExtrinsic]] ready to be dispatched.
+ * @returns unsigned [[SubmittableExtrinsic]] ready to be signed and dispatched.
  */
 export async function revoke(
   delegation: IDelegationRootNode,

--- a/packages/core/src/delegation/DelegationRootNode.ts
+++ b/packages/core/src/delegation/DelegationRootNode.ts
@@ -68,7 +68,7 @@ export default class DelegationRootNode extends DelegationBaseNode
   /**
    * Stores the delegation root node on chain.
    *
-   * @returns Promise containing the SubmittableExtrinsic.
+   * @returns Promise containing the unsigned SubmittableExtrinsic.
    */
   public async store(): Promise<SubmittableExtrinsic> {
     log.debug(`:: store(${this.id})`)

--- a/packages/core/src/did/Did.ts
+++ b/packages/core/src/did/Did.ts
@@ -153,7 +153,7 @@ export default class Did implements IDid {
   /**
    * [STATIC] Removes the [[Did]] object attached to a given [[Identity]] from the chain.
    *
-   * @returns A promise containing a SubmittableExtrinsic (submittable transaction).
+   * @returns A promise containing an unsigned SubmittableExtrinsic (submittable transaction).
    */
   public static async remove(): Promise<SubmittableExtrinsic> {
     log.debug(`Create tx for 'did.remove'`)

--- a/packages/core/src/did/Did.ts
+++ b/packages/core/src/did/Did.ts
@@ -123,7 +123,7 @@ export default class Did implements IDid {
   /**
    * [ASYNC] Stores the [[Did]] object on-chain.
    *
-   * @returns A promise containing the SubmittableExtrinsic (transaction status).
+   * @returns A promise containing the unsigned SubmittableExtrinsic (transaction status).
    */
   public async store(): Promise<SubmittableExtrinsic> {
     log.debug(`Create tx for 'did.add'`)

--- a/packages/core/src/identity/Identity.ts
+++ b/packages/core/src/identity/Identity.ts
@@ -413,8 +413,7 @@ export default class Identity implements IIdentity {
    * @example ```javascript
    * const alice = Identity.buildFromMnemonic('car dog ...');
    * const tx = await blockchain.api.tx.ctype.add(ctype.hash);
-   * const nonce = await blockchain.api.rpc.system.accountNextIndex(alice.address);
-   * alice.signSubmittableExtrinsic(tx, nonce);
+   * await blockchain.signTx(alice, tx); // calls signSubmittableExtrinsic internally
    * ```
    */
   public async signSubmittableExtrinsic(


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1249 fixes KILTProtocol/ticket#1248

Updated Docs and functions to account for removed parameter.
`Delegation.revoke` now takes only the necessary address.
More consistent tx workflow documentation and guidance.


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
