### PR TITLE
feat: optional tip for signing tx

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -69,7 +69,7 @@ async function setup(): Promise<{
   const ctype = new Kilt.CType(rawCtype)
 
   // Store ctype on blockchain
-  // signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria or activate re-sign-re-send options.
+  // signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria, set tip value, or activate re-sign-re-send capabilities.
   // ! This costs tokens !
   // Also note, that the completely same ctype can only be stored once on the blockchain.
   try {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -175,7 +175,8 @@ const tx = await ctype.store()
   await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
     resolveOn: Kilt.BlockchainUtils.IS_READY, // resolve once tx is in the tx pool
     rejectOn: Kilt.BlockchainUtils.IS_ERROR,  // only reject when IS_ERROR criteria is matched
-    timeout: 10_000,
+    timeout: 10_000, // Promise timeout in ms
+    tip: 10_000_000. // Amount of Femto-KILT to tip the validator
   })
 
 // or step by step

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -50,16 +50,17 @@ async function main(): Promise<void> {
   /* This transaction has to be signed and sent to the Blockchain, either automatically like this */
   await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity)
 
-  /* signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria or activate re-sign-re-send options:
+  /* signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria, set tip value, or activate re-sign-re-send capabilities:
   // await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
   //   resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
   //   rejectOn: Kilt.BlockchainUtils.IS_ERROR,
   //   reSign: true,
+  //   tip: 10_000_000,
   // })
 
   /* or manually step by step */
   // const chain = Kilt.connect()
-  // chain.signTx(identity, tx)
+  // chain.signTx(identity, tx, 10_000)
   // await Kilt.BlockchainUtils.submitSignedTx(tx)
 
   /* At the end of the process, the `CType` object should contain the following. */

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -9,7 +9,7 @@
 
 import type { ApiPromise } from '@polkadot/api'
 import type { Header } from '@polkadot/types/interfaces/types'
-import type { AnyJson, Codec } from '@polkadot/types/types'
+import type { AnyJson, AnyNumber, Codec } from '@polkadot/types/types'
 import { Text } from '@polkadot/types'
 import type { SignerPayloadJSON } from '@polkadot/types/types/extrinsic'
 import BN from 'bn.js'
@@ -67,17 +67,20 @@ export default class Blockchain implements IBlockchainApi {
    *
    * @param identity The [[Identity]] to sign the tx with.
    * @param tx The unsigned SubmittableExtrinsic.
+   * @param tip The amount of Femto-KILT to tip the validator.
    * @returns Signed SubmittableExtrinsic.
    *
    */
   public async signTx(
     identity: IIdentity,
-    tx: SubmittableExtrinsic
+    tx: SubmittableExtrinsic,
+    tip?: AnyNumber
   ): Promise<SubmittableExtrinsic> {
     const nonce = await this.getNonce(identity.address)
     const signed: SubmittableExtrinsic = await identity.signSubmittableExtrinsic(
       tx,
-      nonce
+      nonce,
+      tip
     )
 
     return signed

--- a/packages/chain-helpers/src/blockchain/Blockchain.utils.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.utils.ts
@@ -155,6 +155,7 @@ export async function submitSignedTx(
  * @param identity The [[Identity]] used to sign and potentially re-sign the tx.
  * @param opts Partial optional criteria for resolving/rejecting the promise.
  * @param opts.reSign Optional flag for re-attempting to send recoverably failed Tx.
+ * @param opts.tip Optional amount of Femto-KILT to tip the validator.
  * @returns Promise result of executing the extrinsic, of type ISubmittableResult.
  *
  */
@@ -163,11 +164,12 @@ export async function signAndSubmitTx(
   identity: IIdentity,
   {
     reSign = false,
+    tip,
     ...opts
   }: Partial<SubscriptionPromise.Options> & Partial<ReSignOpts> = {}
 ): Promise<ISubmittableResult> {
   const chain = await getConnectionOrConnect()
-  const signedTx = await chain.signTx(identity, tx)
+  const signedTx = await chain.signTx(identity, tx, tip)
   return reSign
     ? chain.submitSignedTxWithReSign(signedTx, identity, opts)
     : submitSignedTx(signedTx, opts)

--- a/packages/core/src/delegation/Delegation.ts
+++ b/packages/core/src/delegation/Delegation.ts
@@ -101,7 +101,6 @@ export default abstract class DelegationBaseNode
   /**
    * Revokes this delegation node on chain.
    *
-   * @param address The address of the identity used to revoke the delegation.
    * @returns Promise containing a unsigned submittable transaction.
    */
   public abstract revoke(address: string): Promise<SubmittableExtrinsic>

--- a/packages/core/src/delegation/Delegation.ts
+++ b/packages/core/src/delegation/Delegation.ts
@@ -101,6 +101,7 @@ export default abstract class DelegationBaseNode
   /**
    * Revokes this delegation node on chain.
    *
+   * @param address The address of the identity used to revoke the delegation.
    * @returns Promise containing a unsigned submittable transaction.
    */
   public abstract revoke(address: string): Promise<SubmittableExtrinsic>

--- a/packages/core/src/identity/Identity.ts
+++ b/packages/core/src/identity/Identity.ts
@@ -27,13 +27,13 @@ import {
 } from '@polkadot/util-crypto/mnemonic'
 import { hexToU8a } from '@polkadot/util/hex'
 import * as u8aUtil from '@polkadot/util/u8a'
-import type BN from 'bn.js'
 // see node_modules/@polkadot/util-crypto/nacl/keypair/fromSeed.js
 // as util-crypto is providing a wrapper only for signing keypair
 // and not for box keypair, we use TweetNaCl directly
 import nacl from 'tweetnacl'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 import type { IIdentity, SubmittableExtrinsic } from '@kiltprotocol/types'
+import { AnyNumber } from '@polkadot/types/types'
 import PublicIdentity from './PublicIdentity'
 
 type BoxPublicKey =
@@ -409,6 +409,7 @@ export default class Identity implements IIdentity {
    *
    * @param submittableExtrinsic - A chain transaction.
    * @param nonce - The nonce of the address operating the transaction.
+   * @param tip - (Optional) The amount of Femto-KILT to tip the validator.
    * @returns The signed SubmittableExtrinsic.
    * @example ```javascript
    * const alice = Identity.buildFromMnemonic('car dog ...');
@@ -418,10 +419,12 @@ export default class Identity implements IIdentity {
    */
   public async signSubmittableExtrinsic(
     submittableExtrinsic: SubmittableExtrinsic,
-    nonce: number | Index | BN
+    nonce: AnyNumber | Index,
+    tip?: AnyNumber
   ): Promise<SubmittableExtrinsic> {
     return submittableExtrinsic.signAsync(this.signKeyringPair, {
       nonce,
+      tip,
     })
   }
 

--- a/packages/types/src/Blockchain.ts
+++ b/packages/types/src/Blockchain.ts
@@ -5,6 +5,7 @@
 
 import type { ApiPromise } from '@polkadot/api'
 import type { Header } from '@polkadot/types/interfaces/types'
+import { AnyNumber } from '@polkadot/types/types'
 import type BN from 'bn.js'
 import type {
   IIdentity,
@@ -13,7 +14,7 @@ import type {
   SubscriptionPromise,
 } from '.'
 
-export type ReSignOpts = { reSign: boolean }
+export type ReSignOpts = { reSign: boolean; tip: AnyNumber }
 export type BlockchainStats = {
   chain: string
   nodeName: string
@@ -26,7 +27,8 @@ export interface IBlockchainApi {
   listenToBlocks(listener: (header: Header) => void): Promise<() => void>
   signTx(
     identity: IIdentity,
-    tx: SubmittableExtrinsic
+    tx: SubmittableExtrinsic,
+    tip?: AnyNumber
   ): Promise<SubmittableExtrinsic>
   submitSignedTxWithReSign(
     tx: SubmittableExtrinsic,

--- a/packages/types/src/Identity.ts
+++ b/packages/types/src/Identity.ts
@@ -5,8 +5,8 @@
 import type { KeyringPair } from '@polkadot/keyring/types'
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import type { BoxKeyPair } from 'tweetnacl'
-import type BN from 'bn.js'
 import type { Index } from '@polkadot/types/interfaces'
+import { AnyNumber } from '@polkadot/types/types'
 
 export interface IIdentity {
   readonly signKeyringPair: KeyringPair
@@ -18,6 +18,7 @@ export interface IIdentity {
   serviceAddress?: string
   signSubmittableExtrinsic(
     submittableExtrinsic: SubmittableExtrinsic,
-    nonce: number | Index | BN
+    nonce: AnyNumber | Index,
+    tip?: AnyNumber
   ): Promise<SubmittableExtrinsic>
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1225

Adds the ability to provide AnyNumber as tip for the validator when signing the tx.

Apart from tip, Polkadot-JS can take multiple different SignerOptions:

```
export interface SignerOptions {
    blockHash: Uint8Array | string;
    era?: IExtrinsicEra | number;
    nonce: AnyNumber | Codec;
    signer?: Signer;
    tip?: AnyNumber;
}
```
Besides the implemented optional passable options, are any other possible options of interest for us?


## Checklist:

- [ x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
