### PR TITLE
refactor: rename message to ciphertext also in normal Message

### DIFF
--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -160,6 +160,11 @@ export default class Message implements IMessage {
   public senderAddress: IMessage['senderAddress']
   public senderBoxPublicKey: IMessage['senderBoxPublicKey']
 
+  private ciphertext: string
+  private nonce: string
+  private hash: string
+  private signature: string
+
   /**
    * Constructs a message which should be encrypted with [[Message.encrypt]] before sending to the receiver.
    *
@@ -186,18 +191,13 @@ export default class Message implements IMessage {
       JSON.stringify(body),
       receiver.boxPublicKeyAsHex
     )
-    this.message = encryptedMessage.box
+    this.ciphertext = encryptedMessage.box
     this.nonce = encryptedMessage.nonce
 
-    const hashInput: string = this.message + this.nonce + this.createdAt
+    const hashInput: string = this.ciphertext + this.nonce + this.createdAt
     this.hash = Crypto.hashStr(hashInput)
     this.signature = sender.signStr(this.hash)
   }
-
-  private message: string
-  private nonce: string
-  private hash: string
-  private signature: string
 
   /**
    * Encrypts the [[Message]] symmetrically as a string. This can be reversed with [[Message.decrypt]].
@@ -208,7 +208,7 @@ export default class Message implements IMessage {
     return {
       messageId: this.messageId,
       receivedAt: this.receivedAt,
-      ciphertext: this.message,
+      ciphertext: this.ciphertext,
       nonce: this.nonce,
       createdAt: this.createdAt,
       hash: this.hash,


### PR DESCRIPTION
## relates to KILTProtocol/ticket#1193
This PR renames `message` to `ciphertext` also in the normal Message object

## How to test:
- Tests should run through

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
