### PR TITLE
chore: bump version, fix devpublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ yarn-error.log*
 !.yarn/releases
 !.yarn/plugins
 !.yarn/sdks
-!.yarn/versions
+.yarn/versions
 .pnp.*
 
 # testing

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "typedoc-plugin-external-module-name": "^4.0.6",
     "typescript": "^3.9.7"
   },
-  "version": "0.20.0"
+  "version": "0.20.1-1"
 }

--- a/packages/actors_api/package.json
+++ b/packages/actors_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/actors-api",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/chain-helpers",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/config",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/core",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kiltprotocol/messaging",
-    "version": "0.20.1",
+    "version": "0.20.1-1",
     "description": "",
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/sdk-js",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/types",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/utils",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiltprotocol/vc-export",
-  "version": "0.20.1",
+  "version": "0.20.1-1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1224

Adds `.yarn/versions/` dir to `.gitignore`

bumps version for devpublish to succeed
