### PR TITLE
fix: update previous balance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ yarn-error.log*
 !.yarn/releases
 !.yarn/plugins
 !.yarn/sdks
-!.yarn/versions
+.yarn/versions
 .pnp.*
 
 # testing

--- a/package.json
+++ b/package.json
@@ -59,9 +59,5 @@
     "typedoc-plugin-external-module-name": "^4.0.6",
     "typescript": "^3.9.7"
   },
-<<<<<<< HEAD
   "version": "0.21.0-rc.7"
-=======
-  "version": "0.20.1-1"
->>>>>>> chore: bump version, fix devpublish (#380)
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,9 @@
     "typedoc-plugin-external-module-name": "^4.0.6",
     "typescript": "^3.9.7"
   },
+<<<<<<< HEAD
   "version": "0.21.0-rc.7"
+=======
+  "version": "0.20.1-1"
+>>>>>>> chore: bump version, fix devpublish (#380)
 }

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -76,7 +76,7 @@ export async function listenToBalanceChanges(
   ) => void
 ): Promise<UnsubscribePromise> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const previousBalances = await getBalances(accountAddress)
+  let previousBalances = await getBalances(accountAddress)
 
   return blockchain.api.query.system.account(
     accountAddress,
@@ -94,6 +94,8 @@ export async function listenToBalanceChanges(
         miscFrozen: new BN(miscFrozen),
         feeFrozen: new BN(feeFrozen),
       }
+      previousBalances = current
+
       listener(accountAddress, current, balancesChange)
     }
   )


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1255

Updating the previous recorded balance got removed accidentally in the last balances type refactoring.
Now updates `previousBalance`

