### PR TITLE
feat: use types repo

### DIFF
--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@kiltprotocol/config": "workspace:*",
+    "@kiltprotocol/type-definitions": "0.1.3",
     "@kiltprotocol/types": "workspace:*",
     "@kiltprotocol/utils": "workspace:*",
     "@polkadot/api": "^3.11.1",

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@kiltprotocol/config": "workspace:*",
-    "@kiltprotocol/type-definitions": "0.1.3",
+    "@kiltprotocol/type-definitions": "0.1.4",
     "@kiltprotocol/types": "workspace:*",
     "@kiltprotocol/utils": "workspace:*",
     "@polkadot/api": "^3.11.1",

--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -16,7 +16,7 @@ import type {
   SubscriptionPromise,
 } from '@kiltprotocol/types'
 import { getConnectionOrConnect } from '../blockchainApiConnection/BlockchainApiConnection'
-import TYPE_REGISTRY from '../blockchainApiConnection/__mocks__/BlockchainQuery'
+import TYPE_REGISTRY from '../blockchainApiConnection/TypeRegistry'
 import Blockchain from './Blockchain'
 import {
   EXTRINSIC_FAILED,

--- a/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -7,50 +7,12 @@
  * @module BlockchainApiConnection
  */
 
+import { types as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
 import { ApiPromise, WsProvider } from '@polkadot/api'
-import type { RegistryTypes } from '@polkadot/types/types'
 import { ConfigService } from '@kiltprotocol/config'
 import Blockchain from '../blockchain/Blockchain'
 
 let instance: Promise<Blockchain> | null
-
-export const CUSTOM_TYPES: RegistryTypes = {
-  Balance: 'u128',
-  PublicSigningKey: 'Hash',
-  PublicBoxKey: 'Hash',
-  Signature: 'MultiSignature',
-  Address: 'AccountId',
-  LookupSource: 'AccountId',
-  BlockNumber: 'u64',
-  Index: 'u64',
-  RefCount: 'u32',
-  AccountInfo: 'AccountInfoWithProviders',
-  Permissions: 'u32',
-  DelegationNodeId: 'Hash',
-  DelegationNode: {
-    rootId: 'DelegationNodeId',
-    parent: 'Option<DelegationNodeId>',
-    owner: 'AccountId',
-    permissions: 'Permissions',
-    revoked: 'bool',
-  },
-  DelegationRoot: {
-    ctypeHash: 'Hash',
-    owner: 'AccountId',
-    revoked: 'bool',
-  },
-  Attestation: {
-    ctypeHash: 'Hash',
-    attester: 'AccountId',
-    delegationId: 'Option<DelegationNodeId>',
-    revoked: 'bool',
-  },
-  DidRecord: {
-    signKey: 'Hash',
-    boxKey: 'Hash',
-    docRef: 'Option<Vec<u8>>',
-  },
-}
 
 /**
  * Builds a new blockchain connection instance.

--- a/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -11,8 +11,12 @@ import { types as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { ConfigService } from '@kiltprotocol/config'
 import Blockchain from '../blockchain/Blockchain'
+import { TypeRegistry } from '@polkadot/types'
 
 let instance: Promise<Blockchain> | null
+
+export const typesRegistry = new TypeRegistry()
+typesRegistry.register(CUSTOM_TYPES)
 
 /**
  * Builds a new blockchain connection instance.
@@ -25,8 +29,8 @@ export async function buildConnection(
 ): Promise<Blockchain> {
   const provider = new WsProvider(host)
   const api: ApiPromise = await ApiPromise.create({
+    registry: typesRegistry,
     provider,
-    types: CUSTOM_TYPES,
   })
   return new Blockchain(api)
 }

--- a/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -7,16 +7,12 @@
  * @module BlockchainApiConnection
  */
 
-import { types9 as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { ConfigService } from '@kiltprotocol/config'
-import { TypeRegistry } from '@polkadot/types'
 import Blockchain from '../blockchain/Blockchain'
+import TYPE_REGISTRY from './TypeRegistry'
 
 let instance: Promise<Blockchain> | null
-
-export const typesRegistry = new TypeRegistry()
-typesRegistry.register(CUSTOM_TYPES)
 
 /**
  * Builds a new blockchain connection instance.
@@ -29,7 +25,7 @@ export async function buildConnection(
 ): Promise<Blockchain> {
   const provider = new WsProvider(host)
   const api: ApiPromise = await ApiPromise.create({
-    registry: typesRegistry,
+    registry: TYPE_REGISTRY,
     provider,
   })
   return new Blockchain(api)

--- a/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -7,11 +7,11 @@
  * @module BlockchainApiConnection
  */
 
-import { types as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
+import { types9 as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { ConfigService } from '@kiltprotocol/config'
-import Blockchain from '../blockchain/Blockchain'
 import { TypeRegistry } from '@polkadot/types'
+import Blockchain from '../blockchain/Blockchain'
 
 let instance: Promise<Blockchain> | null
 

--- a/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
@@ -1,4 +1,4 @@
-import { types9 as KILT_TYPES } from '@kiltprotocol/type-definitions'
+import { types8 as KILT_TYPES } from '@kiltprotocol/type-definitions'
 import { TypeRegistry } from '@polkadot/types'
 
 const TYPE_REGISTRY = new TypeRegistry()

--- a/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
@@ -1,8 +1,7 @@
 import { types8 as KILT_TYPES } from '@kiltprotocol/type-definitions'
 import { TypeRegistry } from '@polkadot/types'
-import { Registry } from '@polkadot/types/types'
 
-const TYPE_REGISTRY: Registry = new TypeRegistry()
+const TYPE_REGISTRY = new TypeRegistry()
 TYPE_REGISTRY.register(KILT_TYPES)
 
 export default TYPE_REGISTRY

--- a/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
@@ -1,7 +1,8 @@
 import { types8 as KILT_TYPES } from '@kiltprotocol/type-definitions'
 import { TypeRegistry } from '@polkadot/types'
+import { Registry } from '@polkadot/types/types'
 
-const TYPE_REGISTRY = new TypeRegistry()
+const TYPE_REGISTRY: Registry = new TypeRegistry()
 TYPE_REGISTRY.register(KILT_TYPES)
 
 export default TYPE_REGISTRY

--- a/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
@@ -1,0 +1,8 @@
+import { types9 as KILT_TYPES } from '@kiltprotocol/type-definitions'
+import { TypeRegistry } from '@polkadot/types'
+
+const TYPE_REGISTRY = new TypeRegistry()
+TYPE_REGISTRY.register(KILT_TYPES)
+
+export default TYPE_REGISTRY
+export { KILT_TYPES, TYPE_REGISTRY }

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -57,9 +57,11 @@ import type {
   ISubmittableResult,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
-import TYPE_REGISTRY, { mockChainQueryReturn } from './BlockchainQuery'
+import { mockChainQueryReturn } from './BlockchainQuery'
 
 const BlockchainApiConnection = jest.requireActual('../BlockchainApiConnection')
+const TYPE_REGISTRY = BlockchainApiConnection.typesRegistry
+
 const accumulator = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 async function getConnectionOrConnect(): Promise<Blockchain> {

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainApiConnection.ts
@@ -58,9 +58,9 @@ import type {
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import { mockChainQueryReturn } from './BlockchainQuery'
+import TYPE_REGISTRY from '../TypeRegistry'
 
 const BlockchainApiConnection = jest.requireActual('../BlockchainApiConnection')
-const TYPE_REGISTRY = BlockchainApiConnection.typesRegistry
 
 const accumulator = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -1,9 +1,7 @@
 import { Option, U8aFixed, U64, Vec, U8 } from '@polkadot/types'
 import type { Codec } from '@polkadot/types/types'
 import type { Constructor } from '@polkadot/util/types'
-
-const TYPE_REGISTRY = jest.requireActual('../BlockchainApiConnection')
-  .typesRegistry
+import TYPE_REGISTRY from '../TypeRegistry'
 
 const chainProperties = TYPE_REGISTRY.createType('ChainProperties', {
   ss58Format: 38,

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -1,17 +1,14 @@
-import { Option, TypeRegistry, U8aFixed, U64, Vec, U8 } from '@polkadot/types'
+import { Option, U8aFixed, U64, Vec, U8 } from '@polkadot/types'
 import type { Codec } from '@polkadot/types/types'
 import type { Constructor } from '@polkadot/util/types'
-import { types as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
 
-const TYPE_REGISTRY = new TypeRegistry()
-TYPE_REGISTRY.register({
-  ...CUSTOM_TYPES,
-})
+const TYPE_REGISTRY = jest.requireActual('../BlockchainApiConnection')
+  .typesRegistry
+
 const chainProperties = TYPE_REGISTRY.createType('ChainProperties', {
   ss58Format: 38,
 })
 TYPE_REGISTRY.setChainProperties(chainProperties)
-export default TYPE_REGISTRY
 
 const AccountId = TYPE_REGISTRY.getOrThrow('AccountId')
 

--- a/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/__mocks__/BlockchainQuery.ts
@@ -1,7 +1,7 @@
 import { Option, TypeRegistry, U8aFixed, U64, Vec, U8 } from '@polkadot/types'
 import type { Codec } from '@polkadot/types/types'
 import type { Constructor } from '@polkadot/util/types'
-import { CUSTOM_TYPES } from '../BlockchainApiConnection'
+import { types as CUSTOM_TYPES } from '@kiltprotocol/type-definitions'
 
 const TYPE_REGISTRY = new TypeRegistry()
 TYPE_REGISTRY.register({

--- a/packages/chain-helpers/src/blockchainApiConnection/index.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/index.ts
@@ -1,1 +1,4 @@
+import TypeRegistry, { KILT_TYPES } from './TypeRegistry'
+
 export * as BlockchainApiConnection from './BlockchainApiConnection'
+export { TypeRegistry, KILT_TYPES }

--- a/packages/chain-helpers/src/index.ts
+++ b/packages/chain-helpers/src/index.ts
@@ -1,5 +1,9 @@
 import { ExtrinsicError, ExtrinsicErrors, PalletIndex } from './errorhandling'
-import { BlockchainApiConnection } from './blockchainApiConnection'
+import {
+  BlockchainApiConnection,
+  KILT_TYPES,
+  TypeRegistry,
+} from './blockchainApiConnection'
 import { Blockchain, BlockchainUtils, SubscriptionPromise } from './blockchain'
 
 export {
@@ -10,4 +14,6 @@ export {
   ExtrinsicErrors,
   PalletIndex,
   BlockchainApiConnection,
+  TypeRegistry,
+  KILT_TYPES,
 }

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -6,8 +6,11 @@ import { SubmittableResult } from '@polkadot/api'
 import { GenericAccountIndex as AccountIndex } from '@polkadot/types/generic/AccountIndex'
 import type { AccountData, AccountInfo } from '@polkadot/types/interfaces'
 import BN from 'bn.js/'
-import TYPE_REGISTRY from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import {
+  TypeRegistry as TYPE_REGISTRY,
+  BlockchainUtils,
+} from '@kiltprotocol/chain-helpers'
+
 import type { Balances } from '@kiltprotocol/types'
 import Identity from '../identity/Identity'
 import {

--- a/packages/core/src/did/Did.spec.ts
+++ b/packages/core/src/did/Did.spec.ts
@@ -4,10 +4,11 @@
 
 import { U8aFixed } from '@polkadot/types'
 import { SDKErrors } from '@kiltprotocol/utils'
-import TYPE_REGISTRY, {
-  mockChainQueryReturn,
-} from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
-import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
+import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
+import {
+  BlockchainUtils,
+  TypeRegistry as TYPE_REGISTRY,
+} from '@kiltprotocol/chain-helpers'
 import { Did, IDid } from '..'
 import Identity from '../identity/Identity'
 import {

--- a/packages/core/src/identity/PublicIdentity.spec.ts
+++ b/packages/core/src/identity/PublicIdentity.spec.ts
@@ -4,9 +4,8 @@
 
 import { U8aFixed } from '@polkadot/types'
 import type { IPublicIdentity } from '@kiltprotocol/types'
-import TYPE_REGISTRY, {
-  mockChainQueryReturn,
-} from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
+import { TypeRegistry as TYPE_REGISTRY } from '@kiltprotocol/chain-helpers'
+import { mockChainQueryReturn } from '@kiltprotocol/chain-helpers/lib/blockchainApiConnection/__mocks__/BlockchainQuery'
 import PublicIdentity, { IURLResolver } from './PublicIdentity'
 import Kilt from '../kilt/Kilt'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,6 +818,7 @@ __metadata:
   resolution: "@kiltprotocol/chain-helpers@workspace:packages/chain-helpers"
   dependencies:
     "@kiltprotocol/config": "workspace:*"
+    "@kiltprotocol/type-definitions": 0.1.3
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/api": ^3.11.1
@@ -899,6 +900,13 @@ __metadata:
     webpack-cli: ^4.5.0
   languageName: unknown
   linkType: soft
+
+"@kiltprotocol/type-definitions@npm:0.1.3":
+  version: 0.1.3
+  resolution: "@kiltprotocol/type-definitions@npm:0.1.3"
+  checksum: 095d2b614bc757b8478654d0bc4e1fea61c28816580919ea9e520c794b8ed94ee54262de3f984354b0b7bdf8961bc80c2c055e81da8560f56256c015bb955251
+  languageName: node
+  linkType: hard
 
 "@kiltprotocol/types@workspace:*, @kiltprotocol/types@workspace:packages/types":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,7 +818,7 @@ __metadata:
   resolution: "@kiltprotocol/chain-helpers@workspace:packages/chain-helpers"
   dependencies:
     "@kiltprotocol/config": "workspace:*"
-    "@kiltprotocol/type-definitions": 0.1.3
+    "@kiltprotocol/type-definitions": 0.1.4
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/api": ^3.11.1
@@ -901,10 +901,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kiltprotocol/type-definitions@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kiltprotocol/type-definitions@npm:0.1.3"
-  checksum: 095d2b614bc757b8478654d0bc4e1fea61c28816580919ea9e520c794b8ed94ee54262de3f984354b0b7bdf8961bc80c2c055e81da8560f56256c015bb955251
+"@kiltprotocol/type-definitions@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@kiltprotocol/type-definitions@npm:0.1.4"
+  checksum: 872b03bf3cf2bed0b67005fb20c4bb2a7d1a490af7ce69ce8cad351bc9f593cc05507e6fe00d1f56d057b6babec420eadeb2cfbc62b1c027eb063d18e4b7a48f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1307

Imports the types repo in the sdk so we don't have to copy-paste type definitions and maintain them in two different places.
Also exports the types registry used by the API which allows you to create SCALE (chain) types without connecting to the blockchain.

Currently does not provide a mechanism to choose with which types you want to use the sdk (wasn't possible before, not sure we need it). This means that the sdk would likely only ever work with the latest chain version. 

## How to test:

Run against latest develop chain. Will still fail most likely because integration is not fixed, but this shouldn't fail due to types issues.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
