### PR TITLE
refactor: Removing encryption from message constructor

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -153,7 +153,10 @@ async function doAttestation(
   )
 
   // The message can be encrypted as follows
-  const reqAttestationEnc = reqAttestation.encrypt()
+  const reqAttestationEnc = reqAttestation.encrypt(
+    claimer,
+    attester.getPublicIdentity()
+  )
 
   // claimer sends [[encrypted]] to the attester
 
@@ -181,7 +184,10 @@ async function doAttestation(
   )
 
   // And send a message back
-  const submitAttestationEnc = submitAttestation.encrypt()
+  const submitAttestationEnc = submitAttestation.encrypt(
+    attester,
+    claimer.getPublicIdentity()
+  )
 
   // ------------------------- CLAIMER -----------------------------------------
   Kilt.Message.ensureHashAndSignature(submitAttestationEnc, attester.address)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,14 +170,14 @@ const identity = Kilt.Identity.buildFromMnemonic(
 const tx = await ctype.store()
 
 // either sign and send in one step
-  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity)
+await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity)
 // signAndSubmitTx can be passed SubscriptionPromise.Options, to control resolve and reject criteria:
-  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
-    resolveOn: Kilt.BlockchainUtils.IS_READY, // resolve once tx is in the tx pool
-    rejectOn: Kilt.BlockchainUtils.IS_ERROR,  // only reject when IS_ERROR criteria is matched
-    timeout: 10_000, // Promise timeout in ms
-    tip: 10_000_000. // Amount of Femto-KILT to tip the validator
-  })
+await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
+  resolveOn: Kilt.BlockchainUtils.IS_READY, // resolve once tx is in the tx pool
+  rejectOn: Kilt.BlockchainUtils.IS_ERROR, // only reject when IS_ERROR criteria is matched
+  timeout: 10_000, // Promise timeout in ms
+  tip: 10_000_000, // Amount of Femto-KILT to tip the validator
+})
 
 // or step by step
 const chain = Kilt.connect()
@@ -189,13 +189,13 @@ Please note that the **same CTYPE can only be stored once** on the blockchain.
 
 If a transaction fails with an by re-signing recoverable error (e.g. multi device nonce collision),
 BlockchainUtils.signAndSubmitTx has the ability to re-sign and re-send the failed tx upt to 2 times, if the appropriate flag is set:
-```typescript
-  await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
-    resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
-    reSign: true,
-  })
-```
 
+```typescript
+await Kilt.BlockchainUtils.signAndSubmitTx(tx, identity, {
+  resolveOn: Kilt.BlockchainUtils.IS_FINALIZED,
+  reSign: true,
+})
+```
 
 At the end of the process, the `CType` object should match the CType below.
 This can be saved anywhere, for example on a CTYPE registry service:
@@ -312,7 +312,7 @@ const messageBody: MessageBody = {
 }
 const message = new Kilt.Message(
   messageBody,
-  claimer,
+  claimer.getPublicIdentity(),
   attester.getPublicIdentity()
 )
 ```
@@ -339,7 +339,7 @@ Message {
 The message can be encrypted as follows:
 
 ```typescript
-const encrypted = message.encrypt()
+const encrypted = message.encrypt(claime, attester.getPublicIdentity())
 ```
 
 The messaging system is transport agnostic.
@@ -441,7 +441,7 @@ const messageBodyBack: MessageBody = {
 }
 const messageBack = new Kilt.Message(
   messageBodyBack,
-  attester,
+  attester.getPublicIdentity(),
   claimer.getPublicIdentity()
 )
 ```
@@ -505,7 +505,7 @@ const messageBodyForClaimer: MessageBody = {
 }
 const messageForClaimer = new Kilt.Message(
   messageBodyForClaimer,
-  verifier,
+  verifier.getPublicIdentity(),
   claimer.getPublicIdentity()
 )
 ```
@@ -525,7 +525,7 @@ const messageBodyForVerifier: MessageBody = {
 }
 const messageForVerifier = new Kilt.Message(
   messageBodyForVerifier,
-  claimer,
+  claimer.getPublicIdentity(),
   verifier.getPublicIdentity()
 )
 ```

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -126,7 +126,7 @@ async function main(): Promise<void> {
 
     /* The Attester creates the attestation based on the IRequestForAttestation object she received: */
     const attestation = Kilt.Attestation.fromRequestAndPublicIdentity(
-      extractedRequestForAttestation.getPublicIdentity(),
+      extractedRequestForAttestation,
       attester.getPublicIdentity()
     )
 

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -104,7 +104,7 @@ async function main(): Promise<void> {
   }
   const message = new Kilt.Message(
     messageBody,
-    claimer,
+    claimer.getPublicIdentity(),
     attester.getPublicIdentity()
   )
 
@@ -112,7 +112,7 @@ async function main(): Promise<void> {
   console.log(message)
 
   /* The message can be encrypted as follows: */
-  const encrypted = message.encrypt()
+  const encrypted = message.encrypt(claimer, attester.getPublicIdentity())
 
   /* Therefore, **during decryption** both the **sender identity and the validity of the message are checked automatically**. */
   const decrypted = Kilt.Message.decrypt(encrypted, attester)
@@ -126,7 +126,7 @@ async function main(): Promise<void> {
 
     /* The Attester creates the attestation based on the IRequestForAttestation object she received: */
     const attestation = Kilt.Attestation.fromRequestAndPublicIdentity(
-      extractedRequestForAttestation,
+      extractedRequestForAttestation.getPublicIdentity(),
       attester.getPublicIdentity()
     )
 
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
     }
     const messageBack = new Kilt.Message(
       messageBodyBack,
-      attester,
+      attester.getPublicIdentity(),
       claimer.getPublicIdentity()
     )
 
@@ -184,7 +184,7 @@ async function main(): Promise<void> {
       }
       const messageForClaimer = new Kilt.Message(
         messageBodyForClaimer,
-        verifier,
+        verifier.getPublicIdentity(),
         claimer.getPublicIdentity()
       )
 
@@ -202,7 +202,7 @@ async function main(): Promise<void> {
       }
       const messageForVerifier = new Kilt.Message(
         messageBodyForVerifier,
-        claimer,
+        claimer.getPublicIdentity(),
         verifier.getPublicIdentity()
       )
 

--- a/packages/actors_api/src/actors/Attester.spec.ts
+++ b/packages/actors_api/src/actors/Attester.spec.ts
@@ -168,7 +168,11 @@ describe('Attester', () => {
       await expect(
         issueAttestation(
           attester,
-          new Message(messageBody, attester, claimer.getPublicIdentity()),
+          new Message(
+            messageBody,
+            attester.getPublicIdentity(),
+            claimer.getPublicIdentity()
+          ),
           claimer.getPublicIdentity()
         )
       ).rejects.toThrowError(

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -86,7 +86,7 @@ export async function issueAttestation(
         },
         type: Message.BodyType.SUBMIT_ATTESTATION_FOR_CLAIM,
       },
-      attester,
+      attester.getPublicIdentity(),
       claimer
     ),
     revocationHandle,

--- a/packages/actors_api/src/actors/Claimer.spec.ts
+++ b/packages/actors_api/src/actors/Claimer.spec.ts
@@ -147,7 +147,11 @@ describe('Claimer', () => {
         },
       ],
     }
-    const request = new Message(body, verifier, claimer.getPublicIdentity())
+    const request = new Message(
+      body,
+      verifier.getPublicIdentity(),
+      claimer.getPublicIdentity()
+    )
 
     const presentation = Claimer.createPresentation(
       claimer,

--- a/packages/actors_api/src/actors/Claimer.ts
+++ b/packages/actors_api/src/actors/Claimer.ts
@@ -64,7 +64,7 @@ export function createPresentation(
       type: Message.BodyType.SUBMIT_CLAIMS_FOR_CTYPES,
       content: attestedClaims,
     },
-    identity,
+    identity.getPublicIdentity(),
     verifier
   )
 }
@@ -122,7 +122,11 @@ export function requestAttestation(
   }
 
   return {
-    message: new Message(message, identity, attesterPublicIdentity),
+    message: new Message(
+      message,
+      identity.getPublicIdentity(),
+      attesterPublicIdentity
+    ),
     session: { requestForAttestation: request },
   }
 }

--- a/packages/actors_api/src/actors/Verifier.ts
+++ b/packages/actors_api/src/actors/Verifier.ts
@@ -110,7 +110,7 @@ export class PresentationRequestBuilder {
             }
           ),
         },
-        verifier,
+        verifier.getPublicIdentity(),
         claimer
       ),
     }

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -34,10 +34,13 @@ describe('Messaging', () => {
         type: Message.BodyType.REQUEST_CLAIMS_FOR_CTYPES,
         content: [{ cTypeHash: '0x12345678' }],
       },
+      identityAlice.getPublicIdentity(),
+      identityBob.getPublicIdentity()
+    )
+    const encryptedMessage = message.encrypt(
       identityAlice,
       identityBob.getPublicIdentity()
     )
-    const encryptedMessage = message.encrypt()
 
     const decryptedMessage = Message.decrypt(encryptedMessage, identityBob)
     expect(JSON.stringify(message.body)).toEqual(
@@ -160,7 +163,7 @@ describe('Messaging', () => {
     Message.ensureOwnerIsSender(
       new Message(
         requestAttestationBody,
-        identityAlice,
+        identityAlice.getPublicIdentity(),
         identityBob.getPublicIdentity()
       )
     )
@@ -168,7 +171,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(
           requestAttestationBody,
-          identityBob,
+          identityBob.getPublicIdentity(),
           identityAlice.getPublicIdentity()
         )
       )
@@ -191,7 +194,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(
           submitAttestationBody,
-          identityAlice,
+          identityAlice.getPublicIdentity(),
           identityBob.getPublicIdentity()
         )
       )
@@ -199,7 +202,7 @@ describe('Messaging', () => {
     Message.ensureOwnerIsSender(
       new Message(
         submitAttestationBody,
-        identityBob,
+        identityBob.getPublicIdentity(),
         identityAlice.getPublicIdentity()
       )
     )
@@ -217,7 +220,7 @@ describe('Messaging', () => {
     Message.ensureOwnerIsSender(
       new Message(
         submitClaimsForCTypeBody,
-        identityAlice,
+        identityAlice.getPublicIdentity(),
         identityBob.getPublicIdentity()
       )
     )
@@ -225,7 +228,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(
           submitClaimsForCTypeBody,
-          identityBob,
+          identityBob.getPublicIdentity(),
           identityAlice.getPublicIdentity()
         )
       )
@@ -247,9 +250,9 @@ describe('Messaging', () => {
       }
       encrypted = new Message(
         messageBody,
-        identityAlice,
+        identityAlice.getPublicIdentity(),
         identityBob.getPublicIdentity()
-      ).encrypt()
+      ).encrypt(identityAlice, identityBob.getPublicIdentity())
       encryptedHash = encrypted.hash
     })
 
@@ -268,9 +271,9 @@ describe('Messaging', () => {
             ...messageBody.content,
           ],
         },
-        identityAlice,
+        identityAlice.getPublicIdentity(),
         identityBob.getPublicIdentity()
-      ).encrypt()
+      ).encrypt(identityAlice, identityBob.getPublicIdentity())
       const { ciphertext: msg, nonce, createdAt } = encrypted2
 
       // check correct encrypted but with message from encrypted2

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -164,7 +164,7 @@ export default class Message implements IMessage {
    * Constructs a message which should be encrypted with [[Message.encrypt]] before sending to the receiver.
    *
    * @param body The body of the message.
-   * @param sender The [[Identity]] of the sender.
+   * @param sender The [[PublicIdentity]] of the sender.
    * @param receiver The [[PublicIdentity]] of the receiver.
    */
   public constructor(

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -160,11 +160,6 @@ export default class Message implements IMessage {
   public senderAddress: IMessage['senderAddress']
   public senderBoxPublicKey: IMessage['senderBoxPublicKey']
 
-  private ciphertext: string
-  private nonce: string
-  private hash: string
-  private signature: string
-
   /**
    * Constructs a message which should be encrypted with [[Message.encrypt]] before sending to the receiver.
    *
@@ -174,7 +169,7 @@ export default class Message implements IMessage {
    */
   public constructor(
     body: MessageBody | CompressedMessageBody,
-    sender: Identity,
+    sender: IPublicIdentity,
     receiver: IPublicIdentity
   ) {
     if (Array.isArray(body)) {
@@ -185,34 +180,38 @@ export default class Message implements IMessage {
     this.createdAt = Date.now()
     this.receiverAddress = receiver.address
     this.senderAddress = sender.address
-    this.senderBoxPublicKey = sender.getBoxPublicKey()
-
-    const encryptedMessage: Crypto.EncryptedAsymmetricString = sender.encryptAsymmetricAsStr(
-      JSON.stringify(body),
-      receiver.boxPublicKeyAsHex
-    )
-    this.ciphertext = encryptedMessage.box
-    this.nonce = encryptedMessage.nonce
-
-    const hashInput: string = this.ciphertext + this.nonce + this.createdAt
-    this.hash = Crypto.hashStr(hashInput)
-    this.signature = sender.signStr(this.hash)
+    this.senderBoxPublicKey = sender.boxPublicKeyAsHex
   }
 
   /**
    * Encrypts the [[Message]] symmetrically as a string. This can be reversed with [[Message.decrypt]].
    *
+   * @param sender The [[Identity]] of the sender.
+   * @param receiver The [[PublicIdentity]] of the receiver.
    * @returns The encrypted version of the original [[Message]], see [[IEncryptedMessage]].
    */
-  public encrypt(): IEncryptedMessage {
+  public encrypt(
+    sender: Identity,
+    receiver: IPublicIdentity
+  ): IEncryptedMessage {
+    const encryptedMessage: Crypto.EncryptedAsymmetricString = sender.encryptAsymmetricAsStr(
+      JSON.stringify(this.body),
+      receiver.boxPublicKeyAsHex
+    )
+    const ciphertext = encryptedMessage.box
+    const { nonce } = encryptedMessage
+
+    const hashInput: string = ciphertext + nonce + this.createdAt
+    const hash = Crypto.hashStr(hashInput)
+    const signature = sender.signStr(hash)
     return {
       messageId: this.messageId,
       receivedAt: this.receivedAt,
-      ciphertext: this.ciphertext,
-      nonce: this.nonce,
+      ciphertext,
+      nonce,
       createdAt: this.createdAt,
-      hash: this.hash,
-      signature: this.signature,
+      hash,
+      signature,
       receiverAddress: this.receiverAddress,
       senderAddress: this.senderAddress,
       senderBoxPublicKey: this.senderBoxPublicKey,


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1268

Separate message objects
Message constructor creates a message object. Removed encryption and changed sender from `Identity` to `IPublicIdentity`
Encrypt and decrypt are methods for the message object. Takes sender `Identity` and receiver `PublicIdentity`

## How to test:

`yarn test`

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
