### PR TITLE
docs: add license to all source files and packages

### DIFF
--- a/.eslintrc-jsdoc.json
+++ b/.eslintrc-jsdoc.json
@@ -4,6 +4,7 @@
     "prettier/prettier": ["warn", {
       "semi": true
     }],
-    "@typescript-eslint/no-unused-vars": "off"
+    "@typescript-eslint/no-unused-vars": "off",
+    "license-header/header": "off"
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'prettier', 'jsdoc'],
+  plugins: ['@typescript-eslint', 'prettier', 'jsdoc', 'license-header'],
   rules: {
     'import/no-cycle': 2,
     'import/extensions': [
@@ -55,7 +55,7 @@ module.exports = {
         default: 'array-simple',
       },
     ],
-    '@typescript-eslint/ban-ts-comment' : 'warn',
+    '@typescript-eslint/ban-ts-comment': 'warn',
     'jsdoc/require-description': 'warn',
     'jsdoc/require-description-complete-sentence': 'warn',
     'jsdoc/no-types': 'warn',
@@ -77,6 +77,7 @@ module.exports = {
       },
     ],
     'jsdoc/check-alignment': 'off',
+    'license-header/header': ['error', './license-header.js'],
   },
   overrides: [
     {

--- a/license-header.js
+++ b/license-header.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "yarn workspaces foreach -p --no-private run clean",
     "clean:docs": "rm -rf docs/api",
     "version": "yarn workspaces foreach version",
+    "prepublish": "yarn workspaces foreach -p --no-private exec cp -f ../../LICENSE .",
     "publish": "yarn workspaces foreach -pt --no-private npm publish",
     "lint": "eslint packages --format=codeframe",
     "lint:fix": "yarn lint --fix",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsdoc": "^30.0.3",
     "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-license-header": "^0.2.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-tsc": "^1.2.0",
     "husky": "^4.2.5",

--- a/packages/actors_api/src/actors/Attester.spec.ts
+++ b/packages/actors_api/src/actors/Attester.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/actor
  */
 

--- a/packages/actors_api/src/actors/Attester.ts
+++ b/packages/actors_api/src/actors/Attester.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module Attester
  */

--- a/packages/actors_api/src/actors/Claimer.spec.ts
+++ b/packages/actors_api/src/actors/Claimer.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/actor
  */
 

--- a/packages/actors_api/src/actors/Claimer.ts
+++ b/packages/actors_api/src/actors/Claimer.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module Claimer
  */

--- a/packages/actors_api/src/actors/Verifier.spec.ts
+++ b/packages/actors_api/src/actors/Verifier.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/actor
  */
 

--- a/packages/actors_api/src/actors/Verifier.ts
+++ b/packages/actors_api/src/actors/Verifier.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module Verifier
  */

--- a/packages/actors_api/src/index.ts
+++ b/packages/actors_api/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import * as Attester from './actors/Attester'
 import * as Claimer from './actors/Claimer'
 import * as Verifier from './actors/Verifier'

--- a/packages/actors_api/src/types.ts
+++ b/packages/actors_api/src/types.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module ActorsTypes
  */

--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/blockchain
  */
 

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Blockchain bridges that connects the SDK and the KILT Blockchain.
  *
  * Communicates with the chain via WebSockets and can [[listenToBlocks]]. It exposes the [[signTx]] function that performs the necessary tx signing.

--- a/packages/chain-helpers/src/blockchain/Blockchain.utils.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module BlockchchainUtils
  * @typedef {SubscriptionPromise.Options} Options

--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/util
  */
 

--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module SubscriptionPromise
  */

--- a/packages/chain-helpers/src/blockchain/index.ts
+++ b/packages/chain-helpers/src/blockchain/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { default as Blockchain } from './Blockchain'
 export * as BlockchainUtils from './Blockchain.utils'
 export * as SubscriptionPromise from './SubscriptionPromise'

--- a/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/BlockchainApiConnection.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Blockchain Api Connection enables the building and accessing of the KILT [[Blockchain]] connection. In which it keeps one connection open and allows to reuse the connection for all [[Blockchain]] related tasks.
  *
  * Other modules can access the [[Blockchain]] as such: `const blockchain = await getConnectionOrConnect()`.

--- a/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/TypeRegistry.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { types10 as KILT_TYPES } from '@kiltprotocol/type-definitions'
 import { TypeRegistry } from '@polkadot/types'
 

--- a/packages/chain-helpers/src/blockchainApiConnection/index.ts
+++ b/packages/chain-helpers/src/blockchainApiConnection/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import TypeRegistry, { KILT_TYPES } from './TypeRegistry'
 
 export * as BlockchainApiConnection from './BlockchainApiConnection'

--- a/packages/chain-helpers/src/errorhandling/ErrorHandler.spec.ts
+++ b/packages/chain-helpers/src/errorhandling/ErrorHandler.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/errorhandling
  */
 

--- a/packages/chain-helpers/src/errorhandling/ErrorHandler.ts
+++ b/packages/chain-helpers/src/errorhandling/ErrorHandler.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * ErrorHandler helps spot and determine transaction errors.
  *
  * @packageDocumentation

--- a/packages/chain-helpers/src/errorhandling/ExtrinsicError.spec.ts
+++ b/packages/chain-helpers/src/errorhandling/ExtrinsicError.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/errorhandling
  */
 

--- a/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
+++ b/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * ExtrinsicErrors are KILT-specific errors, with associated codes and descriptions.
  *
  * @packageDocumentation

--- a/packages/chain-helpers/src/errorhandling/index.ts
+++ b/packages/chain-helpers/src/errorhandling/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * as ErrorHandler from './ErrorHandler'
 export * from './ExtrinsicError'

--- a/packages/chain-helpers/src/index.ts
+++ b/packages/chain-helpers/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { ExtrinsicError, ExtrinsicErrors, PalletIndex } from './errorhandling'
 import {
   BlockchainApiConnection,

--- a/packages/config/src/ConfigService.spec.ts
+++ b/packages/config/src/ConfigService.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/ConfigService
  */
 

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * The ConfigService is used for setting up the node address,
  * the logging level as well as storing custom configuration options.
  *

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import * as ConfigService from './ConfigService'
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/attestation
  */
 

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/balance
  */
 

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/blockchain
  */
 

--- a/packages/core/src/__integrationtests__/ChainConnectivity.spec.ts
+++ b/packages/core/src/__integrationtests__/ChainConnectivity.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/connectivity
  */
 

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/ctype
  */
 

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/delegation
  */
 

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/did
  */
 

--- a/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/errorhandler
  */
 

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module Attestation
  */

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/attestation
  */
 

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * An [[Attestation]] certifies a [[Claim]], sent by a claimer in the form of a [[RequestForAttestation]]. [[Attestation]]s are **written on the blockchain** and are **revocable**.
  * Note: once an [[Attestation]] is stored, it can be sent to and stored with the claimer as an [[AttestedClaim]] ("Credential").
  *

--- a/packages/core/src/attestation/Attestation.utils.ts
+++ b/packages/core/src/attestation/Attestation.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module AttestationUtils
  */

--- a/packages/core/src/attestation/index.ts
+++ b/packages/core/src/attestation/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { default } from './Attestation'
 export { default as AttestationUtils } from './Attestation.utils'

--- a/packages/core/src/attestedclaim/AttestedClaim.spec.ts
+++ b/packages/core/src/attestedclaim/AttestedClaim.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/attestation
  */
 

--- a/packages/core/src/attestedclaim/AttestedClaim.ts
+++ b/packages/core/src/attestedclaim/AttestedClaim.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * In KILT, an [[AttestedClaim]] is a **credential**, which a Claimer can store locally and share with Verifiers as they wish.
  *
  * Once a [[RequestForAttestation]] has been made, the [[Attestation]] can be built and the Attester submits it wrapped in an [[AttestedClaim]] object.

--- a/packages/core/src/attestedclaim/AttestedClaim.utils.ts
+++ b/packages/core/src/attestedclaim/AttestedClaim.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module AttestedClaimUtils
  */

--- a/packages/core/src/attestedclaim/index.ts
+++ b/packages/core/src/attestedclaim/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { default } from './AttestedClaim'
 export { default as AttestedClaimUtils } from './AttestedClaim.utils'

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Balance provides the accounts and balances of the KILT protocol.
  *
  *  * Checking Balances between accounts

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/balance
  */
 

--- a/packages/core/src/balance/Balance.utils.spec.ts
+++ b/packages/core/src/balance/Balance.utils.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/balance
  */
 

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module BalanceUtils
  */

--- a/packages/core/src/balance/index.ts
+++ b/packages/core/src/balance/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import BalanceUtils from './Balance.utils'
 import * as Balance from './Balance.chain'
 

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/claim
  */
 

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Claims are a core building block of the KILT SDK. A claim represents **something an entity claims about itself**. Once created, a claim can be used to create a [[RequestForAttestation]].
  *
  * A claim object has:

--- a/packages/core/src/claim/Claim.utils.spec.ts
+++ b/packages/core/src/claim/Claim.utils.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/claim
  */
 

--- a/packages/core/src/claim/Claim.utils.ts
+++ b/packages/core/src/claim/Claim.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module ClaimUtils
  */

--- a/packages/core/src/claim/index.ts
+++ b/packages/core/src/claim/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { default } from './Claim'
 export { default as ClaimUtils } from './Claim.utils'

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module CType
  */

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/ctype
  */
 

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * CTypes are the way the KILT protocol enables a Claimer or Attester or Verifier to create a [[Claim]] schema for creating specific credentials.
  *
  * * A CTYPE is a description of the [[Claim]] data structure, based on [JSON Schema](http://json-schema.org/).

--- a/packages/core/src/ctype/CType.utils.spec.ts
+++ b/packages/core/src/ctype/CType.utils.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/ctype
  */
 

--- a/packages/core/src/ctype/CType.utils.ts
+++ b/packages/core/src/ctype/CType.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module CTypeUtils
  */

--- a/packages/core/src/ctype/CTypeMetadata.spec.ts
+++ b/packages/core/src/ctype/CTypeMetadata.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/ctype
  */
 

--- a/packages/core/src/ctype/CTypeMetadata.ts
+++ b/packages/core/src/ctype/CTypeMetadata.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module CTypeMetadata
  */

--- a/packages/core/src/ctype/CTypeNested.spec.ts
+++ b/packages/core/src/ctype/CTypeNested.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/ctype
  */
 

--- a/packages/core/src/ctype/CTypeSchema.ts
+++ b/packages/core/src/ctype/CTypeSchema.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module CTypeSchema
  */

--- a/packages/core/src/ctype/index.ts
+++ b/packages/core/src/ctype/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import CType from './CType'
 import CTypeUtils from './CType.utils'
 import CTypeMetadata from './CTypeMetadata'

--- a/packages/core/src/delegation/Delegation.chain.ts
+++ b/packages/core/src/delegation/Delegation.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DelegationBaseNode
  */

--- a/packages/core/src/delegation/Delegation.spec.ts
+++ b/packages/core/src/delegation/Delegation.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/delegation
  */
 

--- a/packages/core/src/delegation/Delegation.ts
+++ b/packages/core/src/delegation/Delegation.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Delegations are the building blocks of top-down trust structures in KILT. An Attester can inherit trust through delegation from another attester ("top-down").
  * In order to model these trust hierarchies, a delegation is represented as a **node** in a **delegation tree**.
  *

--- a/packages/core/src/delegation/Delegation.utils.ts
+++ b/packages/core/src/delegation/Delegation.utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type { IDelegationBaseNode } from '@kiltprotocol/types'
 import { SDKErrors, DataUtils } from '@kiltprotocol/utils'
 import { isHex } from '@polkadot/util'

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * When [[DelegationNode]]s or [[DelegationRootNode]]s are written on the blockchain, they're encoded.
  * DelegationDecoder helps to decode them when they're queried from the chain.
  *

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DelegationNode
  */

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/delegation
  */
 

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Delegation nodes are used within the KILT protocol to construct the trust hierarchy.
  *
  * Starting from the root node, entities can delegate the right to issue attestations to Claimers for a certain CTYPE and also delegate the right to attest and to delegate further nodes.

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DelegationNodeUtils
  */

--- a/packages/core/src/delegation/DelegationRootNode.chain.ts
+++ b/packages/core/src/delegation/DelegationRootNode.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DelegationRootNode
  */

--- a/packages/core/src/delegation/DelegationRootNode.spec.ts
+++ b/packages/core/src/delegation/DelegationRootNode.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/delegation
  */
 

--- a/packages/core/src/delegation/DelegationRootNode.ts
+++ b/packages/core/src/delegation/DelegationRootNode.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * KILT enables top-down trust structures.
  * On the lowest level, a delegation structure is always a **tree**.
  * The root of this tree is DelegationRootNode.

--- a/packages/core/src/delegation/DelegationRootNode.utils.ts
+++ b/packages/core/src/delegation/DelegationRootNode.utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type { IDelegationRootNode } from '@kiltprotocol/types'
 import { DataUtils, SDKErrors } from '@kiltprotocol/utils'
 

--- a/packages/core/src/delegation/index.ts
+++ b/packages/core/src/delegation/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import DelegationBaseNode from './Delegation'
 import DelegationNode from './DelegationNode'
 import DelegationRootNode from './DelegationRootNode'

--- a/packages/core/src/did/Did.chain.ts
+++ b/packages/core/src/did/Did.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DID
  */

--- a/packages/core/src/did/Did.spec.ts
+++ b/packages/core/src/did/Did.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/did
  */
 

--- a/packages/core/src/did/Did.ts
+++ b/packages/core/src/did/Did.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * A Decentralized Identifier (DID) is a new type of identifier that is globally unique, resolvable with high availability, and cryptographically verifiable.
  * Although it's not mandatory in KILT, users can optionally create a DID and anchor it to the KILT blockchain.
  *

--- a/packages/core/src/did/Did.utils.ts
+++ b/packages/core/src/did/Did.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DIDUtils
  */

--- a/packages/core/src/did/index.ts
+++ b/packages/core/src/did/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import Did, {
   IDid,
   IDidDocument,

--- a/packages/core/src/identity/Identity.spec.ts
+++ b/packages/core/src/identity/Identity.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/identity
  */
 

--- a/packages/core/src/identity/Identity.ts
+++ b/packages/core/src/identity/Identity.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Identities are a core building block of the KILT SDK.
  * An Identity object represent an **entity** - be it a person, an organization, a machine or some other entity.
  *

--- a/packages/core/src/identity/PublicIdentity.spec.ts
+++ b/packages/core/src/identity/PublicIdentity.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/identity
  */
 

--- a/packages/core/src/identity/PublicIdentity.ts
+++ b/packages/core/src/identity/PublicIdentity.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * A [[PublicIdentity]] object exposes only public information such as the public address, but doesn't expose any secrets such as private keys.
  *
  * @packageDocumentation

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import Identity from './Identity'
 import PublicIdentity, { IURLResolver } from './PublicIdentity'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import Attestation, { AttestationUtils } from './attestation'
 import AttestedClaim, { AttestedClaimUtils } from './attestedclaim'
 import { Balance, BalanceUtils } from './balance'

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * KILT's core functionalities are exposed via connecting to its blockchain.
  *
  * To connect to the blockchain:

--- a/packages/core/src/kilt/index.ts
+++ b/packages/core/src/kilt/index.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './Kilt'

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/quote
  */
 

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * [[Quote]] constructs a framework for Attesters to make an offer for building a [[Claim]] on a [[CType]] in which it includes a price and other terms & conditions upon which a claimer can agree.
  *
  * A [[Quote]] object represents a legal **offer** for the closure of a contract attesting a [[Claim]] from the [[CType]] specified within the offer.

--- a/packages/core/src/quote/Quote.utils.ts
+++ b/packages/core/src/quote/Quote.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module QuoteUtils
  */

--- a/packages/core/src/quote/QuoteSchema.ts
+++ b/packages/core/src/quote/QuoteSchema.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module QuoteSchema
  */

--- a/packages/core/src/quote/index.ts
+++ b/packages/core/src/quote/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import * as Quote from './Quote'
 
 export default Quote

--- a/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/requestforattestation
  */
 

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Requests for attestation are a core building block of the KILT SDK.
  * A RequestForAttestation represents a [[Claim]] which needs to be validated. In practice, the RequestForAttestation is sent from a claimer to an attester.
  *

--- a/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module RequestForAttestationUtils
  */

--- a/packages/core/src/requestforattestation/index.ts
+++ b/packages/core/src/requestforattestation/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { default } from './RequestForAttestation'
 export { default as RequestForAttestationUtils } from './RequestForAttestation.utils'

--- a/packages/kilt-did/src/Did.chain.ts
+++ b/packages/kilt-did/src/Did.chain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module DID
  */

--- a/packages/kilt-did/src/Did.integration.spec.ts
+++ b/packages/kilt-did/src/Did.integration.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group integration/did
  */
 

--- a/packages/kilt-did/src/Did.utils.ts
+++ b/packages/kilt-did/src/Did.utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { SDKErrors, Crypto } from '@kiltprotocol/utils'
 import type { Codec, Registry } from '@polkadot/types/types'
 import type {

--- a/packages/kilt-did/src/index.ts
+++ b/packages/kilt-did/src/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * as chain from './Did.chain'
 export * as utils from './Did.utils'

--- a/packages/kilt-did/src/types.ts
+++ b/packages/kilt-did/src/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type { IIdentity, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { AnyNumber } from '@polkadot/types/types'
 import type {

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/messaging
  */
 

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * KILT participants can communicate via a 1:1 messaging system.
  *
  * All messages are **encrypted** with the encryption keys of the involved identities.

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/messaging
  */
 

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module MessageUtils
  */

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * from './Message'
 export { default } from './Message'
 export * from './Message.utils'

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import * as core from '@kiltprotocol/core'
 import * as Actors from '@kiltprotocol/actors-api'
 import Message, * as Messaging from '@kiltprotocol/messaging'

--- a/packages/sdk-js/webpack.config.js
+++ b/packages/sdk-js/webpack.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path')
 const TerserPlugin = require('terser-webpack-plugin')

--- a/packages/types/src/Attestation.ts
+++ b/packages/types/src/Attestation.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IAttestation
  */

--- a/packages/types/src/AttestedClaim.ts
+++ b/packages/types/src/AttestedClaim.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IAttestedClaim
  */

--- a/packages/types/src/Balance.ts
+++ b/packages/types/src/Balance.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IBalance
  */

--- a/packages/types/src/Blockchain.ts
+++ b/packages/types/src/Blockchain.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IBlockchain
  */

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module ICType
  */

--- a/packages/types/src/CTypeMetadata.ts
+++ b/packages/types/src/CTypeMetadata.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module ICTypeMetadata
  */

--- a/packages/types/src/Claim.ts
+++ b/packages/types/src/Claim.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IClaim
  */

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IDelegation
  */

--- a/packages/types/src/Identity.ts
+++ b/packages/types/src/Identity.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IIdentity
  */

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IMessage
  */

--- a/packages/types/src/PublicIdentity.ts
+++ b/packages/types/src/PublicIdentity.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IPublicIdentity
  */

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IQuote
  */

--- a/packages/types/src/RequestForAttestation.ts
+++ b/packages/types/src/RequestForAttestation.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module IRequestForAttestation
  */

--- a/packages/types/src/SubscriptionPromise.ts
+++ b/packages/types/src/SubscriptionPromise.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module ISubscriptionPromise
  */

--- a/packages/types/src/Terms.ts
+++ b/packages/types/src/Terms.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module ITerms
  */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export { ISubmittableResult } from '@polkadot/types/types'
 export type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 

--- a/packages/utils/src/Crypto.spec.ts
+++ b/packages/utils/src/Crypto.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/utils
  */
 

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Crypto provides KILT with the utility types and methods useful for cryptographic operations, such as signing/verifying, encrypting/decrypting and hashing.
  *
  * The utility types and methods are wrappers for existing Polkadot functions and imported throughout KILT's protocol for various cryptographic needs.

--- a/packages/utils/src/DataUtils.spec.ts
+++ b/packages/utils/src/DataUtils.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/utils
  */
 

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable import/prefer-default-export */
 /**
  * @packageDocumentation

--- a/packages/utils/src/Decode.spec.ts
+++ b/packages/utils/src/Decode.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/utils
  */
 

--- a/packages/utils/src/Decode.ts
+++ b/packages/utils/src/Decode.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module Decode
  */

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * SDKErrors are KILT-specific errors, with associated codes and descriptions.
  *
  * @packageDocumentation

--- a/packages/utils/src/UUID.spec.ts
+++ b/packages/utils/src/UUID.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/utils
  */
 

--- a/packages/utils/src/UUID.ts
+++ b/packages/utils/src/UUID.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Universally unique identifiers (UUIDs) are needed in KILT to uniquely identify specific information.
  *
  * UUIDs are used for example in [[RequestForAttestation]] to generate hashes.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 export * as Crypto from './Crypto'
 export * as jsonabc from './jsonabc'
 export * as UUID from './UUID'

--- a/packages/utils/src/jsonabc.js
+++ b/packages/utils/src/jsonabc.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 // Taken from https://github.com/ShivrajRath/jsonabc/blob/2ccf15f967f0e44e48fb7b163aebef43c0047166/index.js
 // Copied here, because the package defines a browser compatible script, but doesn't create it,
 // which leads to it failing in react-native. See https://github.com/ShivrajRath/jsonabc/issues/18

--- a/packages/vc-export/src/constants.ts
+++ b/packages/vc-export/src/constants.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Constant for default context.
  */
 export const DEFAULT_VERIFIABLECREDENTIAL_CONTEXT =

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/vc-export
  */
 

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module VCExport
  */

--- a/packages/vc-export/src/index.ts
+++ b/packages/vc-export/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import verification from './verificationUtils'
 import presentation from './presentationUtils'
 import { fromAttestedClaim } from './exportToVerifiableCredential'

--- a/packages/vc-export/src/presentationUtils.ts
+++ b/packages/vc-export/src/presentationUtils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module PresentationUtils
  */

--- a/packages/vc-export/src/types.ts
+++ b/packages/vc-export/src/types.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module VCExportTypes
  */

--- a/packages/vc-export/src/vc-js/context/index.ts
+++ b/packages/vc-export/src/vc-js/context/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import { KILT_CREDENTIAL_CONTEXT_URL } from '../../constants'
 import context from './context.json'
 

--- a/packages/vc-export/src/vc-js/documentLoader.ts
+++ b/packages/vc-export/src/vc-js/documentLoader.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type { RemoteDocument, Url } from 'jsonld/jsonld-spec'
 import vcjs from 'vc-js'
 import kiltContexts from './context'

--- a/packages/vc-export/src/vc-js/index.ts
+++ b/packages/vc-export/src/vc-js/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import * as suites from './suites'
 import documentLoader from './documentLoader'
 import context from './context'

--- a/packages/vc-export/src/vc-js/suites/KiltAbstractSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAbstractSuite.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable class-methods-use-this */
 import {
   DocumentLoader,

--- a/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/vc-js
  */
 

--- a/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable max-classes-per-file */
 import {
   Blockchain,

--- a/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/vc-js
  */
 

--- a/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type {
   DocumentLoader,
   ExpansionMap,

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @group unit/vc-js
  */
 

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import type {
   DocumentLoader,
   ExpansionMap,

--- a/packages/vc-export/src/vc-js/suites/index.ts
+++ b/packages/vc-export/src/vc-js/suites/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
 import KiltIntegritySuite from './KiltIntegritySuite'
 import KiltSignatureSuite from './KiltSignatureSuite'
 import KiltAttestedSuite from './KiltAttestedSuite'

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -1,4 +1,11 @@
 /**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * @packageDocumentation
  * @module VerificationUtils
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3809,6 +3809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-license-header@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eslint-plugin-license-header@npm:0.2.0"
+  dependencies:
+    requireindex: ^1.2.0
+  checksum: 53a36318185f84cf64824fe7ed3242ca9f0483e182bc258114ed508e2318bc5ee25b30fc2dd348ee7b02ff21767eec5b466868e1c44ec70a2e82aa03c105a305
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-prettier@npm:^3.1.4":
   version: 3.1.4
   resolution: "eslint-plugin-prettier@npm:3.1.4"
@@ -7680,6 +7689,13 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"requireindex@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "requireindex@npm:1.2.0"
+  checksum: a6c6c2edd46bcce88f839f69f1d29a11920664862d8b78c205fc69ab2d65a8f592c1a8d68755335898af14ab110cc9fdfc7c572412d38cec485bdf4db45c49c5
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -7811,6 +7827,7 @@ fsevents@^2.1.2:
     eslint-plugin-import: ^2.22.0
     eslint-plugin-jsdoc: ^30.0.3
     eslint-plugin-jsx-a11y: ^6.3.1
+    eslint-plugin-license-header: ^0.2.0
     eslint-plugin-prettier: ^3.1.4
     eslint-plugin-tsc: ^1.2.0
     husky: ^4.2.5


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1432
This PR introduces two changes to how we handle the licenses included with the SDK code; it does not change the licensing conditions themselves.

1. This makes sure that a copy of the LICENSE file in the root of the repository is included with all packages published to npm. It does so by copying the LICENSE file to each sub-package as a pre-publish step. 
2. It additionally introduces a linter rule which checks for a licensing disclaimer at the top of each source file. You can automatically add this disclaimer to files where it is missing using the command `yarn lint:fix`.  Only `.ts` files are considered.

## How to test:
You can try running the linting after removing or altering a license header.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
