### PR TITLE
chore: change years in LICENSE

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable license-header/header */
 module.exports = {
   env: {
     browser: true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, BOTLabs GmbH
+Copyright (c) 2018-2021, BOTLabs GmbH
 All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -95,7 +95,7 @@ const lightDID = new LightDidDetails({
   encryptionKey: {
     publicKey: encryptionKeyPublicDetails.publicKey,
     type: DemoKeystore.getKeypairTypeForAlg(encryptionKeyPublicDetails.alg),
-  }
+  },
 })
 
 // Will print `did:kilt:light:014sxSYXakw1ZXBymzT9t3Yw91mUaqKST5bFUEjGEpvkTuckar:oWFlomlwdWJsaWNLZXlYILu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7ZHR5cGVmeDI1NTE5`.
@@ -174,12 +174,18 @@ const authenticationKeyPublicDetails = await keystore.generateKeypair({
 // The extrinsic is unsigned and contains the DID creation operation signed with the DID authentication key.
 // The second argument, the submitter account, ensures that only an entity authorised by the DID subject
 // can submit the extrinsic to the KILT blockchain.
-const { extrinsic, did } = await DidUtils.writeDidFromPublicKeys(keystore, aliceKiltAccount.address, {
-  [KeyRelationship.authentication]: {
-    publicKey: authenticationKeyPublicDetails.publicKey,
-    type: DemoKeystore.getKeypairTypeForAlg(authenticationKeyPublicDetails.alg),
-  },
-})
+const { extrinsic, did } = await DidUtils.writeDidFromPublicKeys(
+  keystore,
+  aliceKiltAccount.address,
+  {
+    [KeyRelationship.authentication]: {
+      publicKey: authenticationKeyPublicDetails.publicKey,
+      type: DemoKeystore.getKeypairTypeForAlg(
+        authenticationKeyPublicDetails.alg
+      ),
+    },
+  }
+)
 // Will print `did:kilt:4sxSYXakw1ZXBymzT9t3Yw91mUaqKST5bFUEjGEpvkTuckar`.
 console.log(did)
 
@@ -329,21 +335,15 @@ As the creation of a full DID requires a deposit that will lock 0,1 KILT from th
 Claiming back the deposit of a DID is semantically equivalent to deleting the DID, with the difference that the extrinsic to claim the deposit can only be called by the deposit owner and does not require a valid signature by the DID subject:
 
 ```typescript
-import {
-  generateReclaimDepositExtrinsic,
-} from '@kiltprotocol/did/src/Did.chain'
+import { generateReclaimDepositExtrinsic } from '@kiltprotocol/did/src/Did.chain'
 
 // Generate the submittable extrinsic to claim the deposit back, by including the DID identifier for which the deposit needs to be returned.
 const depositClaimExtrinsic = await generateReclaimDepositExtrinsic(fullDID.did)
 
 // The submission will fail if `aliceKiltAccount` is not the owner of the deposit associated with the given DID identifier.
-await BlockchainUtils.signAndSubmitTx(
-  depositClaimExtrinsic,
-  aliceKiltAccount,
-  {
-    resolveOn,
-  }
-)
+await BlockchainUtils.signAndSubmitTx(depositClaimExtrinsic, aliceKiltAccount, {
+  resolveOn,
+})
 ```
 
 ## Migrating a light DID to a full DID


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1453
The LICENSE file still had `Copyright 2019`, while the rest of the code uses `2018-2021`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
