### PR TITLE
feat: add querying support for deposits and deleted DIDs

### DIFF
--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
@@ -35,6 +35,7 @@ export function makeSubscriptionPromise<SubscriptionType>(
 } {
   const { resolveOn, rejectOn, timeout } = { ...terminationOptions }
   let resolve: (value: SubscriptionType) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let reject: (reason: any) => void
   const promise = new Promise<SubscriptionType>((res, rej) => {
     resolve = res

--- a/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
+++ b/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
@@ -143,6 +143,7 @@ export const ExtrinsicErrors = {
 
 /**
  * @internal
+ * PalletIndex reflects the numerical index of a pallet assigned in the chain's metadata.
  */
 export enum PalletIndex {
   CType = 9,

--- a/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
+++ b/packages/chain-helpers/src/errorhandling/ExtrinsicError.ts
@@ -143,7 +143,6 @@ export const ExtrinsicErrors = {
 
 /**
  * @internal
- * PalletIndex reflects the numerical index of a pallet assigned in the chain's metadata.
  */
 export enum PalletIndex {
   CType = 9,
@@ -166,7 +165,6 @@ export interface IPalletToExtrinsicErrors {
 
 /**
  * @internal
- * This dictionary holds all [[ExtrinsicError]]s, divided by pallets.
  */
 export const PalletToExtrinsicErrors: IPalletToExtrinsicErrors = {
   [PalletIndex.CType]: {
@@ -212,12 +210,9 @@ export const PalletToExtrinsicErrors: IPalletToExtrinsicErrors = {
 
 /**
  * @internal
- * Maps a [[ModuleError]] to its corresponding [[ExtrinsicError]].
- *
  * @param p The parameter object.
  * @param p.index The index of the KILT pallet in the metadata.
  * @param p.error The index of the position of the pallet's error definition inside the chain code.
- *
  * @returns A new corresponding [[ExtrinsicError]].
  */
 export function errorForPallet({

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -16,6 +16,7 @@ import {
   DemoKeystore,
   FullDidDetails,
 } from '@kiltprotocol/did'
+import { BN } from '@polkadot/util'
 import { Crypto } from '@kiltprotocol/utils'
 import { randomAsHex } from '@polkadot/util-crypto'
 import Attestation from '../attestation/Attestation'
@@ -56,6 +57,13 @@ beforeAll(async () => {
 beforeEach(async () => {
   await Promise.all(
     [attester, anotherAttester, claimer].map((i) => i.refreshTxIndex())
+  )
+})
+
+it('fetches the correct deposit amount', async () => {
+  const depositAmount = await Attestation.queryDepositAmount()
+  expect(depositAmount.toString()).toStrictEqual(
+    new BN(1000000000000000).toString()
   )
 })
 

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -18,6 +18,7 @@ import {
   FullDidDetails,
 } from '@kiltprotocol/did'
 import { randomAsHex } from '@polkadot/util-crypto'
+import { BN } from '@polkadot/util'
 import Attestation from '../attestation/Attestation'
 import Claim from '../claim/Claim'
 import RequestForAttestation from '../requestforattestation/RequestForAttestation'
@@ -113,6 +114,13 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await Promise.all([attester, root, claimer].map((i) => i.refreshTxIndex()))
+})
+
+it('fetches the correct deposit amount', async () => {
+  const depositAmount = await DelegationNode.queryDepositAmount()
+  expect(depositAmount.toString()).toStrictEqual(
+    new BN(1000000000000000).toString()
+  )
 })
 
 it('should be possible to delegate attestation rights', async () => {

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -240,9 +240,7 @@ describe('write and didDeleteTx', () => {
     await expect(DidChain.queryById(didIdentifier)).resolves.toBe(null)
 
     // Check that DID is now blacklisted.
-    await expect(DidChain.queryDeletedDids()).resolves.toStrictEqual([
-      didIdentifier,
-    ])
+    await expect(DidChain.queryDeletedDids()).resolves.toStrictEqual([did])
     await expect(DidChain.queryDidDeletionStatus(did)).resolves.toBeTruthy()
   }, 60_000)
 })

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -45,6 +45,13 @@ beforeAll(async () => {
   paymentAccount = devAlice
 })
 
+it('fetches the correct deposit amount', async () => {
+  const depositAmount = await DidChain.queryDepositAmount()
+  expect(depositAmount.toString()).toStrictEqual(
+    new BN(2000000000000000).toString()
+  )
+})
+
 describe('write and didDeleteTx', () => {
   let didIdentifier: string
   let key: DidTypes.INewPublicKey

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -151,18 +151,17 @@ export async function reclaimDeposit(
   log.debug(
     () => `Claiming deposit for the attestation with claim hash ${claimHash}`
   )
-  const tx: SubmittableExtrinsic = blockchain.api.tx.attestation.reclaimDeposit(
-    claimHash
-  )
+  const tx: SubmittableExtrinsic =
+    blockchain.api.tx.attestation.reclaimDeposit(claimHash)
   return tx
 }
 
-async function queryRawDepositAmount(): Promise<U128> {
+async function queryDepositAmountEncoded(): Promise<U128> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   return api.consts.attestation.deposit as U128
 }
 
 export async function queryDepositAmount(): Promise<BN> {
-  const encodedDeposit = await queryRawDepositAmount()
+  const encodedDeposit = await queryDepositAmountEncoded()
   return encodedDeposit.toBn()
 }

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -151,8 +151,9 @@ export async function reclaimDeposit(
   log.debug(
     () => `Claiming deposit for the attestation with claim hash ${claimHash}`
   )
-  const tx: SubmittableExtrinsic =
-    blockchain.api.tx.attestation.reclaimDeposit(claimHash)
+  const tx: SubmittableExtrinsic = blockchain.api.tx.attestation.reclaimDeposit(
+    claimHash
+  )
   return tx
 }
 

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  * @module Attestation
  */
-import { Option, Struct } from '@polkadot/types'
+import { Option, Struct, U128 } from '@polkadot/types'
 import type {
   IAttestation,
   Deposit,
@@ -20,6 +20,7 @@ import type { AccountId, Hash } from '@polkadot/types/interfaces'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { DidUtils } from '@kiltprotocol/did'
+import { BN } from '@polkadot/util'
 import Attestation from './Attestation'
 import type { DelegationNodeId } from '../delegation/DelegationDecoder'
 
@@ -154,4 +155,14 @@ export async function reclaimDeposit(
     claimHash
   )
   return tx
+}
+
+async function queryRawDepositAmount(): Promise<U128> {
+  const { api } = await BlockchainApiConnection.getConnectionOrConnect()
+  return api.consts.attestation.deposit as U128
+}
+
+export async function queryDepositAmount(): Promise<BN> {
+  const encodedDeposit = await queryRawDepositAmount()
+  return encodedDeposit.toBn()
 }

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -25,12 +25,14 @@ import type {
   IRequestForAttestation,
   CompressedAttestation,
 } from '@kiltprotocol/types'
+import { BN } from '@polkadot/util'
 import {
   revoke,
   query,
   store,
   remove,
   reclaimDeposit,
+  queryDepositAmount,
 } from './Attestation.chain'
 import AttestationUtils from './Attestation.utils'
 import DelegationNode from '../delegation/DelegationNode'
@@ -303,5 +305,14 @@ export default class Attestation implements IAttestation {
   public static decompress(attestation: CompressedAttestation): Attestation {
     const decompressedAttestation = AttestationUtils.decompress(attestation)
     return Attestation.fromAttestation(decompressedAttestation)
+  }
+
+  /**
+   * [STATIC] Query and return the amount of KILTs (in femto notation) needed to deposit in order to create an attestation.
+   *
+   * @returns The amount of femtoKILTs required to deposit to create the attestation.
+   */
+  public static queryDepositAmount(): Promise<BN> {
+    return queryDepositAmount()
   }
 }

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -91,9 +91,6 @@ export async function query(
 
 /**
  * @internal
- *
- * Revokes part of a delegation tree at specified node, also revoking all nodes below.
- *
  * @param delegationId The id of the node in the delegation tree at which to revoke.
  * @param maxDepth How many nodes may be traversed upwards in the hierarchy when searching for a node owned by `identity`. Each traversal will add to the transaction fee. Therefore a higher number will increase the fees locked until the transaction is complete. A number lower than the actual required traversals will result in a failed extrinsic (node will not be revoked).
  * @param maxRevocations How many delegation nodes may be revoked during the process. Each revocation adds to the transaction fee. A higher number will require more fees to be locked while an insufficiently high number will lead to premature abortion of the revocation process, leaving some nodes unrevoked. Revocations will first be performed on child nodes, therefore the current node is only revoked when this is accurate.
@@ -116,9 +113,6 @@ export async function revoke(
 
 /**
  * @internal
- *
- * Revokes and removes part of a delegation tree at specified node, also removing all nodes below.
- *
  * @param delegationId The id of the node in the delegation tree at which to remove.
  * @param maxRevocations How many delegation nodes may be removed during the process. Each removal adds to the transaction fee. A higher number will require more fees to be locked while an insufficiently high number will lead to premature abortion of the removal process, leaving some nodes unremoved. Removals will first be performed on child nodes, therefore the current node is only removed when this is accurate.
  * @returns An unsigned SubmittableExtrinsic ready to be signed and dispatched.

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -102,12 +102,11 @@ export async function revoke(
   maxRevocations: number
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const tx: SubmittableExtrinsic =
-    blockchain.api.tx.delegation.revokeDelegation(
-      delegationId,
-      maxDepth,
-      maxRevocations
-    )
+  const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.revokeDelegation(
+    delegationId,
+    maxDepth,
+    maxRevocations
+  )
   return tx
 }
 
@@ -122,8 +121,10 @@ export async function remove(
   maxRevocations: number
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const tx: SubmittableExtrinsic =
-    blockchain.api.tx.delegation.removeDelegation(delegationId, maxRevocations)
+  const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.removeDelegation(
+    delegationId,
+    maxRevocations
+  )
   return tx
 }
 
@@ -168,10 +169,9 @@ export async function getAttestationHashes(
   id: IDelegationNode['id']
 ): Promise<string[]> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const encodedHashes =
-    await blockchain.api.query.attestation.delegatedAttestations<
-      Option<Vec<Hash>>
-    >(id)
+  const encodedHashes = await blockchain.api.query.attestation.delegatedAttestations<
+    Option<Vec<Hash>>
+  >(id)
   return decodeDelegatedAttestations(encodedHashes)
 }
 

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -105,11 +105,12 @@ export async function revoke(
   maxRevocations: number
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.revokeDelegation(
-    delegationId,
-    maxDepth,
-    maxRevocations
-  )
+  const tx: SubmittableExtrinsic =
+    blockchain.api.tx.delegation.revokeDelegation(
+      delegationId,
+      maxDepth,
+      maxRevocations
+    )
   return tx
 }
 
@@ -127,10 +128,8 @@ export async function remove(
   maxRevocations: number
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const tx: SubmittableExtrinsic = blockchain.api.tx.delegation.removeDelegation(
-    delegationId,
-    maxRevocations
-  )
+  const tx: SubmittableExtrinsic =
+    blockchain.api.tx.delegation.removeDelegation(delegationId, maxRevocations)
   return tx
 }
 
@@ -175,18 +174,19 @@ export async function getAttestationHashes(
   id: IDelegationNode['id']
 ): Promise<string[]> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
-  const encodedHashes = await blockchain.api.query.attestation.delegatedAttestations<
-    Option<Vec<Hash>>
-  >(id)
+  const encodedHashes =
+    await blockchain.api.query.attestation.delegatedAttestations<
+      Option<Vec<Hash>>
+    >(id)
   return decodeDelegatedAttestations(encodedHashes)
 }
 
-async function queryRawDepositAmount(): Promise<U128> {
+async function queryDepositAmountEncoded(): Promise<U128> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   return api.consts.delegation.deposit as U128
 }
 
 export async function queryDepositAmount(): Promise<BN> {
-  const encodedDeposit = await queryRawDepositAmount()
+  const encodedDeposit = await queryDepositAmountEncoded()
   return encodedDeposit.toBn()
 }

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -10,13 +10,14 @@
  * @module DelegationNode
  */
 
-import type { Option, Vec } from '@polkadot/types'
+import type { Option, Vec, U128 } from '@polkadot/types'
 import type { IDelegationNode, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import type { Hash } from '@polkadot/types/interfaces'
 import { DecoderUtils, SDKErrors } from '@kiltprotocol/utils'
 import { DidTypes, DidUtils } from '@kiltprotocol/did'
+import { BN } from '@polkadot/util'
 import { decodeDelegationNode, IChainDelegationNode } from './DelegationDecoder'
 import DelegationNode from './DelegationNode'
 import { permissionsAsBitset } from './DelegationNode.utils'
@@ -178,4 +179,14 @@ export async function getAttestationHashes(
     Option<Vec<Hash>>
   >(id)
   return decodeDelegatedAttestations(encodedHashes)
+}
+
+async function queryRawDepositAmount(): Promise<U128> {
+  const { api } = await BlockchainApiConnection.getConnectionOrConnect()
+  return api.consts.delegation.deposit as U128
+}
+
+export async function queryDepositAmount(): Promise<BN> {
+  const encodedDeposit = await queryRawDepositAmount()
+  return encodedDeposit.toBn()
 }

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -34,12 +34,14 @@ import {
 import { Crypto, SDKErrors, UUID } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
 import { DidTypes, DidUtils } from '@kiltprotocol/did'
+import { BN } from '@polkadot/util'
 import type { DelegationHierarchyDetailsRecord } from './DelegationDecoder'
 import { query as queryAttestation } from '../attestation/Attestation.chain'
 import {
   getChildren,
   getAttestationHashes,
   query,
+  queryDepositAmount,
   remove,
   revoke,
   storeAsDelegation,
@@ -423,5 +425,14 @@ export default class DelegationNode implements IDelegationNode {
     const result = await query(delegationId)
     log.info(`result: ${JSON.stringify(result)}`)
     return result
+  }
+
+  /**
+   * [STATIC] Query and return the amount of KILTs (in femto notation) needed to deposit in order to create a delegation.
+   *
+   * @returns The amount of femtoKILTs required to deposit to create the delegation.
+   */
+  public static queryDepositAmount(): Promise<BN> {
+    return queryDepositAmount()
   }
 }

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -55,7 +55,7 @@ export async function queryDidEncoded(
   return api.query.did.did<Option<IDidChainRecordCodec>>(didIdentifier)
 }
 
-// Query ALL deleted DIDs, which can get quite time consuming.
+// Query ALL deleted DIDs, which can be very time consuming if the number of deleted DIDs gets large.
 export async function queryDeletedDidsEncoded(): Promise<GenericAccountId[]> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   // Query all the storage keys, and then only take the relevant property, i.e., the encoded DID identifier.

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -10,7 +10,7 @@
  * @module DID
  */
 
-import type { Option, u32 } from '@polkadot/types'
+import type { Option, u32, U128 } from '@polkadot/types'
 import type {
   IIdentity,
   SubmittableExtrinsic,
@@ -86,6 +86,11 @@ export async function queryEndpointsCountsEncoded(
 ): Promise<u32> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   return api.query.did.didEndpointsCount<u32>(didIdentifier)
+}
+
+async function queryDepositAmountEncoded(): Promise<U128> {
+  const { api } = await BlockchainApiConnection.getConnectionOrConnect()
+  return api.consts.did.deposit as U128
 }
 
 // ### DECODED QUERYING (builds on top of raw querying)
@@ -257,6 +262,11 @@ export async function queryLastTxCounter(
   }
   const encoded = await queryDidEncoded(identifier)
   return encoded.isSome ? encoded.unwrap().lastTxCounter.toBn() : new BN(0)
+}
+
+export async function queryDepositAmount(): Promise<BN> {
+  const encodedDeposit = await queryDepositAmountEncoded()
+  return encodedDeposit.toBn()
 }
 
 // ### EXTRINSICS

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -280,9 +280,11 @@ export async function queryDepositAmount(): Promise<BN> {
   return encodedDeposit.toBn()
 }
 
-export async function queryDeletedDids(): Promise<Array<IIdentity['address']>> {
+export async function queryDeletedDids(): Promise<Array<IDidDetails['did']>> {
   const encodedIdentifiers = await queryDeletedDidsEncoded()
-  return encodedIdentifiers.map((id) => id.toHuman())
+  return encodedIdentifiers.map((id) =>
+    getKiltDidFromIdentifier(id.toHuman(), 'full')
+  )
 }
 
 // TODO: This function currently fetches ALL the deleted DIDs and then checks if the provided one is inside, which becomes very inefficient if a lot of DIDs have been deleted.
@@ -292,10 +294,7 @@ export async function queryDeletedDids(): Promise<Array<IIdentity['address']>> {
 export async function queryDidDeletionStatus(
   didUri: IDidDetails['did']
 ): Promise<boolean> {
-  const { identifier } = parseDidUrl(didUri)
-
-  const deletedDids = new Set<IDidDetails['did']>(await queryDeletedDids())
-  return deletedDids.has(identifier)
+  return (await queryDeletedDids()).includes(didUri)
 }
 
 // ### EXTRINSICS

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -67,7 +67,7 @@ export async function queryDeletedDidsEncoded(): Promise<GenericAccountId[]> {
 }
 
 // Returns the raw representation of the storage entry for the given DID identifier.
-export async function queryDidDeletionStatusEncoded(
+async function queryDidDeletionStatusEncoded(
   didIdentifier: IIdentity['address']
 ): Promise<Uint8Array> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()


### PR DESCRIPTION
# Add querying support for deposits and deleted DIDs

This PR adds:
- support to query the amount of KILTs needed to deposit before creating an attestation, a delegation, or a DID
- support to query all the deleted DID identifiers and also to check whether a given DID identifier has been deleted (or blacklisted).

For both features, integration tests have been added.

## Linked components

- Node commit with which this PR has been tested to work: https://github.com/KILTprotocol/mashnet-node/commit/2e937de64c2c0979d2f1b74b8faa2a038707828c
- Fixes https://github.com/KILTprotocol/ticket/issues/1657
- Fixes https://github.com/KILTprotocol/ticket/issues/1639

Blocking https://github.com/KILTprotocol/sdk-js/pull/431.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
