### PR TITLE
feat: new / changed message types for credential api v1

### DIFF
--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -263,7 +263,9 @@ async function main(): Promise<void> {
       /* 6.1. Request presentation for CTYPE */
       const messageBodyForClaimer: MessageBody = {
         type: Kilt.Message.BodyType.REQUEST_CLAIMS_FOR_CTYPES,
-        content: [{ cTypeHash: ctype.hash }],
+        content: {
+          cTypes: { [ctype.hash]: {} },
+        },
       }
       const messageForClaimer = new Kilt.Message(
         messageBodyForClaimer,

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -70,7 +70,9 @@ describe('Messaging', () => {
     const message = new Message(
       {
         type: Message.BodyType.REQUEST_CLAIMS_FOR_CTYPES,
-        content: [{ cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}` }],
+        content: {
+          cTypes: { [`kilt:ctype:${Crypto.hashStr('0x12345678')}`]: {} },
+        },
       },
       identityAlice.did,
       identityBob.did
@@ -135,7 +137,9 @@ describe('Messaging', () => {
     const message = new Message(
       {
         type: Message.BodyType.REQUEST_CLAIMS_FOR_CTYPES,
-        content: [{ cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}` }],
+        content: {
+          cTypes: { [`kilt:ctype:${Crypto.hashStr('0x12345678')}`]: {} },
+        },
       },
       wrongSender,
       identityBob.did

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -473,15 +473,18 @@ describe('Messaging Utilities', () => {
     ]
     // Request Claims for CTypes content
     requestClaimsForCTypesContent = {
-      cTypeHash: claim.cTypeHash,
-      acceptedAttester: [identityAlice.did],
-      requiredProperties: ['id', 'name'],
+      cTypes: {
+        [claim.cTypeHash]: {
+          trustedAttesters: [identityAlice.did],
+          requiredProperties: ['id', 'name'],
+        },
+      },
+      challenge: '1234',
     }
     // Compressed Request claims for CType content
     compressedRequestClaimsForCTypesContent = [
-      claim.cTypeHash,
-      [identityAlice.did],
-      ['id', 'name'],
+      [[claim.cTypeHash, [identityAlice.did], ['id', 'name']]],
+      '1234',
     ]
     // Submit claims for CType content
     submitClaimsForCTypesContent = [legitimation]
@@ -642,16 +645,13 @@ describe('Messaging Utilities', () => {
       type: Message.BodyType.REJECT_ATTESTATION_FOR_CLAIM,
     }
     requestClaimsForCTypesBody = {
-      content: [requestClaimsForCTypesContent, requestClaimsForCTypesContent],
+      content: requestClaimsForCTypesContent,
       type: Message.BodyType.REQUEST_CLAIMS_FOR_CTYPES,
     }
 
     compressedRequestClaimsForCTypesBody = [
       Message.BodyType.REQUEST_CLAIMS_FOR_CTYPES,
-      [
-        compressedRequestClaimsForCTypesContent,
-        compressedRequestClaimsForCTypesContent,
-      ],
+      compressedRequestClaimsForCTypesContent,
     ]
 
     submitClaimsForCTypesBody = {
@@ -1065,7 +1065,10 @@ describe('Messaging Utilities', () => {
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectAttestationForClaimBody)
     ).toThrowErrorWithCode(SDKErrors.ERROR_HASH_MALFORMED())
-    requestClaimsForCTypesBody.content[0].cTypeHash = 'this is not a cTypeHash'
+    requestClaimsForCTypesBody.content.cTypes = {
+      ...requestClaimsForCTypesBody.content.cTypes,
+      'this is not a cTypeHash': {},
+    }
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestClaimsForCTypesBody)
     ).toThrowErrorWithCode(SDKErrors.ERROR_HASH_MALFORMED())


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1642
This PR adds / changes message types in order to support the credential API v1: https://github.com/KILTprotocol/credential-api

## How to test:
Please provide a brief step-by-step instruction.
If necessary provide information about dependencies (specific configuration, branches, database dumps, etc.)

- Step 1
- Step 2
- etc.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
