### PR TITLE
docs: extract ctypeHash in example.ts

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -379,8 +379,9 @@ async function doVerification(
     { senderDetails: verifierLightDid, receiverDetails: claimerLightDid }
   )
 
-  const ctypeHash = verifierAcceptedCredentialsMessageDec.body
-    .content[0] as IAcceptCredential['content']['0']
+  const ctypeHash = (
+    verifierAcceptedCredentialsMessageDec.body as IAcceptCredential
+  ).content[0]
   console.log('claimer checks the ctypeHash matches', ctypeHash)
 
   const challenge = Kilt.Utils.UUID.generate()

--- a/docs/example.ts
+++ b/docs/example.ts
@@ -379,8 +379,8 @@ async function doVerification(
     { senderDetails: verifierLightDid, receiverDetails: claimerLightDid }
   )
 
-  const ctypeHash =
-    verifierAcceptedCredentialsMessageDec.body as IAcceptCredential
+  const ctypeHash = verifierAcceptedCredentialsMessageDec.body
+    .content[0] as IAcceptCredential['content']['0']
   console.log('claimer checks the ctypeHash matches', ctypeHash)
 
   const challenge = Kilt.Utils.UUID.generate()


### PR DESCRIPTION
## No-Ticket
In the last merge, the ctypehash in example.ts was not correctly extracted. This fixed it.