### PR TITLE
feat: add support for delegation deposit reclaim

### DIFF
--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -374,7 +374,7 @@ describe('Deposit claiming', () => {
       BlockchainUtils.signAndSubmitTx(depositClaimTx, devBob, {
         resolveOn: BlockchainUtils.IS_IN_BLOCK,
       })
-    ).rejects
+    ).rejects.toThrow()
 
     // Test removal success with the right account.
     await BlockchainUtils.signAndSubmitTx(depositClaimTx, paymentAccount, {

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -339,7 +339,7 @@ describe('revocation', () => {
   }, 60_000)
 })
 
-describe.only('Deposit claiming', () => {
+describe('Deposit claiming', () => {
   it('deposit payer should be able to claim back its own deposit and delete any children', async () => {
     const rootNode = await writeHierarchy(root, DriversLicense.hash)
     const delegatedNode = await addDelegation(

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -121,7 +121,7 @@ export async function revoke(
  * Generate the extrinsic to remove a given delegation node. The submitter can be the owner of the delegation node itself or an ancestor thereof.
  *
  * @param delegationId The identifier of the delegation node to remove.
- * @param maxRevocations The max number of children nodes that will be removed as part of the revocation operation. This value does not include the node itself being removed.
+ * @param maxRevocations The max number of children nodes that will be removed as part of the removal operation. This value does not include the node itself being removed.
  * @returns The [[SubmittableExtrinsic]] for the `removeDelegation` call.
  */
 export async function remove(
@@ -131,6 +131,27 @@ export async function remove(
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const tx: SubmittableExtrinsic =
     blockchain.api.tx.delegation.removeDelegation(delegationId, maxRevocations)
+  return tx
+}
+
+/**
+ * Generate the extrinsic to reclaim the deposit for a given delegation node.
+ *
+ * The generated extrinsic can only be successfully executed if the submitter is the original payer of the delegation deposit.
+ *
+ * @param delegationId The identifier of the delegation node to claim back deposit for.
+ * @param maxRemovals The max number of children nodes that will be removed as part of the operation. This value does not include the node itself being removed.
+ * @returns The [[SubmittableExtrinsic]] for the `reclaimDeposit` call.
+ */
+export async function reclaimDeposit(
+  delegationId: IDelegationNode['id'],
+  maxRemovals: number
+): Promise<SubmittableExtrinsic> {
+  const { api } = await BlockchainApiConnection.getConnectionOrConnect()
+  const tx: SubmittableExtrinsic = api.tx.delegation.reclaimDeposit(
+    delegationId,
+    maxRemovals
+  )
   return tx
 }
 

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -47,6 +47,7 @@ jest.mock('./DelegationNode.chain', () => {
       ) => {
         nodes[nodeId] = new DelegationNode({
           ...nodes[nodeId],
+          childrenIds: nodes[nodeId].childrenIds,
           revoked: true,
         })
       }

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -46,6 +46,7 @@ import {
   revoke,
   storeAsDelegation,
   storeAsRoot,
+  reclaimDeposit,
 } from './DelegationNode.chain'
 import { query as queryDetails } from './DelegationHierarchyDetails.chain'
 import * as DelegationNodeUtils from './DelegationNode.utils'
@@ -410,6 +411,19 @@ export class DelegationNode implements IDelegationNode {
     const childCount = await this.subtreeNodeCount()
     log.debug(`:: remove(${this.id}) with maxRevocations=${childCount}`)
     return remove(this.id, childCount)
+  }
+
+  /**
+   * [ASYNC] Reclaims the deposit of a delegation and removes the delegation and all its children.
+   *
+   * This call can only be successfully executed if the submitter of the transaction is the original payer of the delegationdeposit.
+   *
+   * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
+   */
+  public async reclaimDeposit(): Promise<SubmittableExtrinsic> {
+    const childCount = await this.subtreeNodeCount()
+    log.debug(`:: reclaimDeposit(${this.id}) with maxRemovals=${childCount}`)
+    return reclaimDeposit(this.id, childCount)
   }
 
   /**

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -425,7 +425,7 @@ export class DelegationNode implements IDelegationNode {
   /**
    * [ASYNC] Reclaims the deposit of a delegation and removes the delegation and all its children.
    *
-   * This call can only be successfully executed if the submitter of the transaction is the original payer of the delegationdeposit.
+   * This call can only be successfully executed if the submitter of the transaction is the original payer of the delegation deposit.
    *
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
    */

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -65,7 +65,7 @@ export class DelegationNode implements IDelegationNode {
   public readonly id: IDelegationNode['id']
   public readonly hierarchyId: IDelegationNode['hierarchyId']
   public readonly parentId?: IDelegationNode['parentId']
-  public readonly childrenIds: Array<IDelegationNode['id']> = []
+  private childrenIdentifiers: Array<IDelegationNode['id']> = []
   public readonly account: IDidDetails['did']
   public readonly permissions: IDelegationNode['permissions']
   private hierarchyDetails?: IDelegationHierarchyDetails
@@ -88,11 +88,15 @@ export class DelegationNode implements IDelegationNode {
     this.id = id
     this.hierarchyId = hierarchyId
     this.parentId = parentId
-    this.childrenIds = childrenIds
+    this.childrenIdentifiers = childrenIds
     this.account = account
     this.permissions = permissions
     this.revoked = revoked
     DelegationNodeUtils.errorCheck(this)
+  }
+
+  public get childrenIds(): Array<IDelegationNode['id']> {
+    return this.childrenIdentifiers
   }
 
   /**
@@ -196,6 +200,11 @@ export class DelegationNode implements IDelegationNode {
    * @returns Promise containing the children as an array of [[DelegationNode]], which is empty if there are no children.
    */
   public async getChildren(): Promise<DelegationNode[]> {
+    const refreshedNodeDetails = await query(this.id)
+    // Updates the children info with the latest information available on chain.
+    if (refreshedNodeDetails) {
+      this.childrenIdentifiers = refreshedNodeDetails.childrenIds
+    }
     return getChildren(this)
   }
 


### PR DESCRIPTION
# Add support for delegation deposit reclaim

This PR fixes https://github.com/KILTprotocol/ticket/issues/1685 by adding a new function on `DelegationNode` and the relative chain file to generate a `SubmittableExtrinsic` for the `reclaim_deposit` chain function.

This PR targets `develop` commit https://github.com/KILTprotocol/mashnet-node/commit/fc56483437001e68174f47b424fc0c6b01ad35be and `master` commit https://github.com/KILTprotocol/mashnet-node/commit/dff5ae8646753484cf594cd9af1184bd93bd405e (integration tests for this branch are failing as delegation deposits have not yet been merged).

Companion PR (already merged on `develop`) -> https://github.com/KILTprotocol/mashnet-node/pull/295

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
