### PR TITLE
fix: keyring and type from self exposed

### DIFF
--- a/docs/example.ts
+++ b/docs/example.ts
@@ -8,7 +8,7 @@
 /* eslint-disable no-console */
 
 import * as Kilt from '@kiltprotocol/sdk-js'
-import { KeyRelationship } from '@kiltprotocol/sdk-js'
+import { KeyRelationship, KeyringPair } from '@kiltprotocol/sdk-js'
 import type {
   Credential,
   Claim,
@@ -21,7 +21,6 @@ import type {
   ISubmitCredential,
   IDidKeyDetails,
 } from '@kiltprotocol/sdk-js'
-import { KeyringPair } from '@polkadot/keyring/types'
 import { mnemonicGenerate } from '@polkadot/util-crypto'
 
 const NODE_URL = 'ws://127.0.0.1:9944'

--- a/packages/core/src/__integrationtests__/Deposit.spec.ts
+++ b/packages/core/src/__integrationtests__/Deposit.spec.ts
@@ -20,11 +20,11 @@ import {
 import {
   IRequestForAttestation,
   KeyRelationship,
+  KeyringPair,
   KeystoreSigner,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import { DecoderUtils, Keyring } from '@kiltprotocol/utils'
-import { KeyringPair } from '@polkadot/keyring/types'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
 import { mnemonicGenerate, randomAsHex } from '@polkadot/util-crypto'
 import { BN } from '@polkadot/util'

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 
-import { KeyringPair } from '@polkadot/keyring/types'
 import { BN, hexToU8a } from '@polkadot/util'
 import { Keyring } from '@kiltprotocol/utils'
 import { randomAsU8a } from '@polkadot/util-crypto'
@@ -16,7 +15,11 @@ import {
 } from '@kiltprotocol/did'
 import { Balance } from '../balance'
 import { BlockchainUtils } from '@kiltprotocol/chain-helpers'
-import { KeyRelationship, KeystoreSigner } from '@kiltprotocol/types'
+import {
+  KeyRelationship,
+  KeyringPair,
+  KeystoreSigner,
+} from '@kiltprotocol/types'
 
 export const EXISTENTIAL_DEPOSIT = new BN(10 ** 13)
 export const ENDOWMENT = EXISTENTIAL_DEPOSIT.muln(1000)


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1694

Import Keyring and types from self exposed location, to avoid having redundant packages, reducing bundle size etc.
This could also be done with all the other polkadot stuff we use.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
