### PR TITLE
chore: tsconfig.esm for ESM outputs

### DIFF
--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/chain-helpers/tsconfig.esm.json
+++ b/packages/chain-helpers/tsconfig.esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/config/tsconfig.esm.json
+++ b/packages/config/tsconfig.esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+  "exclude": [
+    "node_modules",
+    "coverage",
+    "build",
+    "scripts",
+    "acceptance-tests",
+    "webpack",
+    "jest",
+    "src/setupTests.ts",
+    "jest.config.js",
+    "docs",
+    "**/*.spec.ts",
+    "src/__integrationtests__",
+    "**/test"
+  ]
+}

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/did/tsconfig.esm.json
+++ b/packages/did/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+   "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+   "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+   "exclude": [
+    "coverage",
+    "**/*.spec.ts",
+  ]
+}

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "clean": "rimraf ./lib",
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "tsc --declaration -p tsconfig.build.json"
+        "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
     },
     "repository": "github:kiltprotocol/sdk-js",
     "engines": {

--- a/packages/messaging/tsconfig.esm.json
+++ b/packages/messaging/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+   "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+   "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+   "exclude": [
+    "coverage",
+    "**/*.spec.ts",
+  ]
+}

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json",
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json",
     "bundle": "rimraf ./dist && webpack --config webpack.config.js"
   },
   "repository": "github:kiltprotocol/sdk-js",

--- a/packages/sdk-js/tsconfig.esm.json
+++ b/packages/sdk-js/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/types/tsconfig.esm.json
+++ b/packages/types/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+  "exclude": [
+    "coverage",
+    "**/*.spec.ts",
+  ]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json && cp -f ./src/jsonabc.d.ts ./lib/jsonabc.d.ts"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json && cp -f ./src/jsonabc.d.ts ./lib/jsonabc.d.ts"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/utils/tsconfig.esm.json
+++ b/packages/utils/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+
+   "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+   "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+   "exclude": [
+    "coverage",
+    "**/*.spec.ts",
+  ]
+}

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./lib",
     "build": "yarn clean && yarn build:ts",
-    "build:ts": "tsc --declaration -p tsconfig.build.json"
+    "build:ts": "tsc --declaration -p tsconfig.build.json && tsc -p tsconfig.esm.json"
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {

--- a/packages/vc-export/tsconfig.esm.json
+++ b/packages/vc-export/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.esm.json",
+
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+  "exclude": [
+    "coverage",
+    "**/*.spec.ts",
+  ]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "es6",
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
This adds a `tsconfig.esm.json` to allow for the output of ESM into the `lib/esm` folder.

The important thing to note is that this doesn't break anything. However, it is not complete

- the ESM outputs does not import from e.g. `errorhandler.js` which is required for Node 12 resolution. (more on this later)
- there are no export maps provided, i.e. this won't by default magically start using the ESM outputs (this is to the first point that "nothing breaks")
- there are also no `"module": "./lib/esm/index.js"` specifier in the `package.json` files - this can only be added after the filename extensions are resolved (otherwise browser bundles may work, but Node ESM won't)

On the ESM imports, Node requires the extra `.js` specifier and TSC (up to 4.5) does not add it. So options are -

- wait till tsc 4.6 and use `"moduleResolution": "node12"` in the `tsconfig.esm.json`
- everywhere where we import from a file, add the `.js` path manually (this could be error prone, but TS fully allows it - the issue is that along the way somebody might forget)
- add a script that check for local imports (files) and add the extension to the output (this is more-or-less what I do elsewhere, although I compile via babel and it has a plugin that does that)

## How to test:

1. Run `yarn build`
2. Inspect the `lib/esm` outputs

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
