### PR TITLE
fix: light did encoding

### DIFF
--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -54,7 +54,7 @@ describe('Light DID v1 tests', () => {
 
     const did = new LightDidDetails(didCreationDetails)
     expect(did.did).toEqual(
-      `did:kilt:light:01${address}:oWFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTk=`
+      `did:kilt:light:01${address}:z1Ac9CMtYCTRWjetJfJqJoV7FcPDD9nHPHDHry7t3KZmvYe1HQP1tgnBuoG3enuGaowpF8V88sCxytDPDy6ZxhW`
     )
   })
 
@@ -78,7 +78,7 @@ describe('Light DID v1 tests', () => {
 
     const did = new LightDidDetails(didCreationDetails)
     expect(did.did).toEqual(
-      `did:kilt:light:01${address}:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4GjYmlkc215LXNlcnZpY2UtZW5kcG9pbnRldHlwZXOCdkNvbGxhdG9yQ3JlZGVudGlhbFR5cGVtU29jaWFsS1lDVHlwZWR1cmxzgnVodHRwczovL215X2RvbWFpbi5vcmdtcmFuZG9tX2RvbWFpbg==`
+      `did:kilt:light:01${address}:z1cMUDNpqRXwbeHqACfmSMkde311bJLNpk7KwDAdtMTGRTihJ5fortrNvov9chGUJitnb2STbUL5nvZSijCoV2av2UAfe5f66dbFa7hZzgWt2SBfrJFNRtiaYeEXt27G1SKsdnMP5UCQJtR672uH3tg13LXtdYKgvkC7VdQ7QDioGD8G1YJMVfgjuDS6RKt4U6VzbDzDMcoAZGuMWZe41Lzf9x1FFH2BGG87hD2BBorKvLkCV`
     )
   })
 })

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -7,6 +7,7 @@
 
 import { encode as cborEncode, decode as cborDecode } from 'cbor'
 import { SDKErrors } from '@kiltprotocol/utils'
+import { base58Decode, base58Encode } from '@polkadot/util-crypto'
 import type { LightDidDetailsCreationOpts } from '../types'
 import { getEncodingForSigningKeyType, parseDidUrl } from '../Did.utils'
 
@@ -57,12 +58,13 @@ export function checkLightDidCreationOptions(
 }
 
 /**
- * Serialize the optional encryption key of an off-chain DID using the CBOR serialization algorithm and encoding the result in Base64 format.
+ * Serialize the optional encryption key of an off-chain DID using the CBOR serialization algorithm
+ * and encoding the result in Base58 format with a multibase prefix.
  *
  * @param details The light DID details to encode.
  * @param details.encryptionKey The DID encryption key.
  * @param details.serviceEndpoints The DID service endpoints.
- * @returns The Base64-encoded and CBOR-serialized off-chain DID optional details.
+ * @returns The Base58-encoded and CBOR-serialized off-chain DID optional details.
  */
 export function serializeAndEncodeAdditionalLightDidDetails({
   encryptionKey,
@@ -82,7 +84,9 @@ export function serializeAndEncodeAdditionalLightDidDetails({
     return null
   }
 
-  return cborEncode(objectToSerialize).toString('base64')
+  const serialized = cborEncode(objectToSerialize)
+  // Add a flag to recognize the serialization algorithm. (Currently only custom object + cbor)
+  return base58Encode([0x0, ...serialized], true)
 }
 
 export function decodeAndDeserializeAdditionalLightDidDetails(
@@ -90,12 +94,16 @@ export function decodeAndDeserializeAdditionalLightDidDetails(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   version = 1
 ): Pick<LightDidDetailsCreationOpts, 'encryptionKey' | 'serviceEndpoints'> {
-  const decodedPayload: Map<string, unknown> = cborDecode(rawInput, {
-    encoding: 'base64',
-  })
+  const decoded = base58Decode(rawInput, true)
+  const serializationFlag = decoded[0]
+  if (serializationFlag !== 0x0) {
+    throw new Error('Serialization algorithm not supported')
+  }
+  const withoutFlag = decoded.slice(1)
+  const deserialized: Map<string, unknown> = cborDecode(withoutFlag)
 
   return {
-    encryptionKey: decodedPayload[ENCRYPTION_KEY_MAP_KEY],
-    serviceEndpoints: decodedPayload[SERVICES_KEY_MAP_KEY],
+    encryptionKey: deserialized[ENCRYPTION_KEY_MAP_KEY],
+    serviceEndpoints: deserialized[SERVICES_KEY_MAP_KEY],
   }
 }

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -303,37 +303,37 @@ describe('Light DID Document exporting tests', () => {
     const didDoc = exportToDidDocument(didDetails, 'application/json')
 
     expect(didDoc).toStrictEqual({
-      id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y',
+      id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR',
       verificationMethod: [
         {
-          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y#authentication',
+          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR#authentication',
           controller:
-            'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y',
+            'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR',
           type: 'Ed25519VerificationKey2018',
           publicKeyBase58: 'CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB',
         },
         {
-          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y#encryption',
+          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR#encryption',
           controller:
-            'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y',
+            'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR',
           type: 'X25519KeyAgreementKey2019',
           publicKeyBase58: 'DdqGmK5uamYN5vmuZrzpQhKeehLdwtPLVJdhu5P2iJKC',
         },
       ],
       authentication: [
-        'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y#authentication',
+        'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR#authentication',
       ],
       keyAgreement: [
-        'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y#encryption',
+        'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR#encryption',
       ],
       service: [
         {
-          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y#id-1',
+          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR#id-1',
           type: ['type-1'],
           serviceEndpoints: ['url-1'],
         },
         {
-          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:omFlomlwdWJsaWNLZXnYQFggu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7tkdHlwZWZ4MjU1MTlhc4KjYmlkZGlkLTFldHlwZXOBZnR5cGUtMWR1cmxzgWV1cmwtMaNiaWRkaWQtMmV0eXBlc4FmdHlwZS0yZHVybHOBZXVybC0y#id-2',
+          id: 'did:kilt:light:014rmqfMwFrv9mhwJwMb1vGWcmKmCNTRM8J365TRsJuPzXDNGF:z13nCdN4Pm2E11EsvuHFWcHY4c82dCFRxZP7MYtJD6ctPRrXzup7Cv8Wap18LHQaJYDnbvFdXQrpYjuXsoxKb2PhKXujiGAE5pFDyFGKjL8AJLGB2hXGSZyarmzeqjjYmEHSuHgCfH1cYPRHRCUaEAtehQvv6ZCpoPjChqcm7XaetboiWDisJ42smzR#id-2',
           type: ['type-2'],
           serviceEndpoints: ['url-2'],
         },


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1745
references https://github.com/KILTprotocol/sdk-js/pull/448. Look there for a problem description.

Instead of supporting both `base64` and `base58`. This PR switches completely to `base58`.
It also add the "multibase" flag for base58 and a custom flag `0` for our current serialisation algorithm (which is a custom object fed into cbor)

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
