### PR TITLE
fix: ensure message is owner in messages

### DIFF
--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -267,7 +267,10 @@ describe('revocation', () => {
             reSign: true,
           })
         )
-    ).rejects.toThrow()
+    ).rejects.toMatchObject({
+      section: 'delegation',
+      name: 'UnauthorizedRemoval',
+    })
 
     // Check that delegation fails to verify but that it is still on the blockchain (i.e., not removed)
     await expect(delegationA.verify()).resolves.toBeFalsy()
@@ -393,7 +396,7 @@ describe('Deposit claiming', () => {
 
     await expect(DelegationNode.query(delegatedNode.id)).resolves.toBeNull()
     await expect(DelegationNode.query(subDelegatedNode.id)).resolves.toBeNull()
-  }, 60_000)
+  }, 80_000)
 })
 
 describe('handling queries to data not on chain', () => {

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -227,7 +227,7 @@ describe('revocation', () => {
     secondDelegee = claimer
   })
 
-  it('delegator can revoke and remove delegation', async () => {
+  it('delegator can revoke but not remove delegation', async () => {
     const rootNode = await writeHierarchy(delegator, DriversLicense.hash)
     const delegationA = await addDelegation(
       rootNode.id,
@@ -252,7 +252,9 @@ describe('revocation', () => {
     ).resolves.not.toThrow()
     await expect(delegationA.verify()).resolves.toBe(false)
 
-    // Test removal with deposit payer's account.
+    // Delegation removal can only be done by either the delegation owner themselves via DID call
+    // or the deposit owner as a regular signed call.
+    // Change introduced in https://github.com/KILTprotocol/mashnet-node/pull/304
     await expect(
       delegationA
         .remove()
@@ -265,11 +267,11 @@ describe('revocation', () => {
             reSign: true,
           })
         )
-    ).resolves.not.toThrow()
+    ).rejects.toThrow()
 
-    // Check that delegation fails to verify and that it is not stored on the blockchain anymore.
-    await expect(DelegationNode.query(delegationA.id)).resolves.toBeNull()
-    await expect(delegationA.verify()).resolves.toBe(false)
+    // Check that delegation fails to verify but that it is still on the blockchain (i.e., not removed)
+    await expect(delegationA.verify()).resolves.toBeFalsy()
+    await expect(DelegationNode.query(delegationA.id)).resolves.not.toBeNull()
   }, 60_000)
 
   it('delegee cannot revoke root but can revoke own delegation', async () => {

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -172,6 +172,25 @@ export function getIdentifierFromKiltDid(did: string): string {
   return parseDidUrl(did).identifier
 }
 
+// Returns true if both didA and didB refer to the same DID subject, i.e., whether they have the same identifier as specified in the method spec.
+export function isSameSubject(
+  didA: IDidDetails['did'],
+  didB: IDidDetails['did']
+): boolean {
+  // eslint-disable-next-line prefer-const
+  let { identifier: identifierA, type: typeA } = parseDidUrl(didA)
+  // eslint-disable-next-line prefer-const
+  let { identifier: identifierB, type: typeB } = parseDidUrl(didB)
+  // Skip key encoding part
+  if (typeA === 'light') {
+    identifierA = identifierA.substring(2)
+  }
+  if (typeB === 'light') {
+    identifierB = identifierB.substring(2)
+  }
+  return identifierA === identifierB
+}
+
 export function validateKiltDid(
   input: unknown,
   allowFragment = false

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -9,6 +9,8 @@
  * @group unit/messaging
  */
 
+import { hexToU8a } from '@polkadot/util'
+
 import type {
   ICredential,
   IEncryptedMessage,
@@ -25,7 +27,14 @@ import { KeyRelationship } from '@kiltprotocol/types'
 
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 import { Quote, RequestForAttestation } from '@kiltprotocol/core'
-import { createLocalDemoDidFromSeed, DemoKeystore } from '@kiltprotocol/did'
+import {
+  createLocalDemoDidFromSeed,
+  createLightDidFromSeed,
+  DemoKeystore,
+  DidUtils,
+  LightDidDetails,
+  newFullDidDetailsfromKeys,
+} from '@kiltprotocol/did'
 import { Message } from './Message'
 
 describe('Messaging', () => {
@@ -161,15 +170,50 @@ describe('Messaging', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"Error parsing message body"`)
   })
 
-  it('verifies the message sender is the owner', async () => {
+  it('verifies the message with sender is the owner (as full DID)', async () => {
+    const lightDidOwner = await createLightDidFromSeed(keystore, '//Owner')
+    const lightDidOwnerIdentifier = DidUtils.getIdentifierFromKiltDid(
+      lightDidOwner.did
+    ).substring(2)
+    const lightDidOwnerAuthKey = lightDidOwner
+      .getKeys(KeyRelationship.authentication)
+      .pop()!
+    const fullDidOwner = newFullDidDetailsfromKeys({
+      authentication: {
+        id: `did:kilt:${lightDidOwnerIdentifier}#auth-key`,
+        controller: `did:kilt:${lightDidOwnerIdentifier}`,
+        publicKeyHex: lightDidOwnerAuthKey.publicKeyHex,
+        type: lightDidOwnerAuthKey.type,
+      },
+    })
+
+    const lightDidAttester = await createLightDidFromSeed(
+      keystore,
+      '//Attester'
+    )
+    const lightDidAttesterIdentifier = DidUtils.getIdentifierFromKiltDid(
+      lightDidAttester.did
+    ).substring(2)
+    const lightDidAttesterAuthKey = lightDidAttester
+      .getKeys(KeyRelationship.authentication)
+      .pop()!
+    const fullDidAttester = newFullDidDetailsfromKeys({
+      authentication: {
+        id: `did:kilt:${lightDidAttesterIdentifier}#auth-key`,
+        controller: `did:kilt:${lightDidAttesterIdentifier}`,
+        publicKeyHex: lightDidAttesterAuthKey.publicKeyHex,
+        type: lightDidAttesterAuthKey.type,
+      },
+    })
+
     const content = RequestForAttestation.fromClaim({
       cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
-      owner: identityAlice.did,
+      owner: fullDidOwner.did,
       contents: {},
     })
 
     const quoteData: IQuote = {
-      attesterDid: identityAlice.did,
+      attesterDid: fullDidAttester.did,
       cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
       cost: {
         tax: { vat: 3.3 },
@@ -182,14 +226,14 @@ describe('Messaging', () => {
     }
     const quoteAttesterSigned = await Quote.createAttesterSignature(
       quoteData,
-      identityAlice,
+      fullDidAttester,
       keystore
     )
     const bothSigned = await Quote.createQuoteAgreement(
       quoteAttesterSigned,
       content.rootHash,
-      identityAlice.did,
-      identityBob,
+      fullDidAttester.did,
+      fullDidOwner,
       keystore,
       mockResolver
     )
@@ -201,12 +245,29 @@ describe('Messaging', () => {
       type: Message.BodyType.REQUEST_ATTESTATION,
     }
 
-    Message.ensureOwnerIsSender(
-      new Message(requestAttestationBody, identityAlice.did, identityBob.did)
-    )
+    // Should not throw if the owner and sender DID is the same.
     expect(() =>
       Message.ensureOwnerIsSender(
-        new Message(requestAttestationBody, identityBob.did, identityAlice.did)
+        new Message(requestAttestationBody, fullDidOwner.did, identityBob.did)
+      )
+    ).not.toThrow()
+
+    // Should not throw if the sender is the light DID version of the owner.
+    // This is technically not to be allowed but message verification is not concerned with that.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(requestAttestationBody, lightDidOwner.did, identityBob.did)
+      )
+    ).not.toThrow()
+
+    // Should throw if the sender and the owner are two different entities.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          requestAttestationBody,
+          fullDidAttester.did,
+          identityAlice.did
+        )
       )
     ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH('Claim', 'Sender'))
 
@@ -214,7 +275,7 @@ describe('Messaging', () => {
       delegationId: null,
       claimHash: requestAttestationBody.content.requestForAttestation.rootHash,
       cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
-      owner: identityBob.did,
+      owner: fullDidAttester.did,
       revoked: false,
     }
 
@@ -224,14 +285,36 @@ describe('Messaging', () => {
       },
       type: Message.BodyType.SUBMIT_ATTESTATION,
     }
+
+    // Should not throw if the owner and sender DID is the same.
     expect(() =>
       Message.ensureOwnerIsSender(
-        new Message(submitAttestationBody, identityAlice.did, identityBob.did)
+        new Message(
+          submitAttestationBody,
+          fullDidAttester.did,
+          identityAlice.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the sender is the light DID version of the owner.
+    // This is technically not to be allowed but message verification is not concerned with that.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitAttestationBody,
+          lightDidAttester.did,
+          identityAlice.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should throw if the sender and the owner are two different entities.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(submitAttestationBody, fullDidOwner.did, identityBob.did)
       )
     ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH('Attestation', 'Sender'))
-    Message.ensureOwnerIsSender(
-      new Message(submitAttestationBody, identityBob.did, identityAlice.did)
-    )
 
     const credential: ICredential = {
       request: content,
@@ -243,14 +326,375 @@ describe('Messaging', () => {
       type: Message.BodyType.SUBMIT_CREDENTIAL,
     }
 
-    Message.ensureOwnerIsSender(
-      new Message(submitClaimsForCTypeBody, identityAlice.did, identityBob.did)
-    )
+    // Should not throw if the owner and sender DID is the same.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(submitClaimsForCTypeBody, fullDidOwner.did, identityBob.did)
+      )
+    ).not.toThrow()
+
+    // Should not throw if the sender is the light DID version of the owner.
+    // This is technically not to be allowed but message verification is not concerned with that.
     expect(() =>
       Message.ensureOwnerIsSender(
         new Message(
           submitClaimsForCTypeBody,
-          identityBob.did,
+          lightDidOwner.did,
+          identityBob.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should throw if the sender and the owner are two different entities.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitClaimsForCTypeBody,
+          fullDidAttester.did,
+          identityAlice.did
+        )
+      )
+    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH('Claims', 'Sender'))
+  })
+
+  it('verifies the message with sender is the owner (as light DID)', async () => {
+    const lightDidOwner = await createLightDidFromSeed(keystore, '//Owner')
+    const lightDidOwnerIdentifier = DidUtils.getIdentifierFromKiltDid(
+      lightDidOwner.did
+    ).substring(2)
+    const lightDidOwnerAuthKey = lightDidOwner
+      .getKeys(KeyRelationship.authentication)
+      .pop()!
+    const lightDidOwnerWithEncodedDetails = new LightDidDetails({
+      authenticationKey: {
+        publicKey: hexToU8a(lightDidOwnerAuthKey.publicKeyHex),
+        type: lightDidOwnerAuthKey.type,
+      },
+      serviceEndpoints: [
+        {
+          id: 'id-1',
+          types: ['type-1'],
+          urls: ['url-1'],
+        },
+      ],
+    })
+    const fullDidOwner = newFullDidDetailsfromKeys({
+      authentication: {
+        id: `did:kilt:${lightDidOwnerIdentifier}#auth-key`,
+        controller: `did:kilt:${lightDidOwnerIdentifier}`,
+        publicKeyHex: lightDidOwnerAuthKey.publicKeyHex,
+        type: lightDidOwnerAuthKey.type,
+      },
+    })
+
+    const lightDidAttester = await createLightDidFromSeed(
+      keystore,
+      '//Attester'
+    )
+    const lightDidAttesterIdentifier = DidUtils.getIdentifierFromKiltDid(
+      lightDidAttester.did
+    ).substring(2)
+    const lightDidAttesterAuthKey = lightDidAttester
+      .getKeys(KeyRelationship.authentication)
+      .pop()!
+    const lightDidAttesterWithEncodedDetails = new LightDidDetails({
+      authenticationKey: {
+        publicKey: hexToU8a(lightDidAttesterAuthKey.publicKeyHex),
+        type: lightDidAttesterAuthKey.type,
+      },
+      serviceEndpoints: [
+        {
+          id: 'id-1',
+          types: ['type-1'],
+          urls: ['url-1'],
+        },
+      ],
+    })
+    const fullDidAttester = newFullDidDetailsfromKeys({
+      authentication: {
+        id: `did:kilt:${lightDidAttesterIdentifier}#auth-key`,
+        controller: `did:kilt:${lightDidAttesterIdentifier}`,
+        publicKeyHex: lightDidAttesterAuthKey.publicKeyHex,
+        type: lightDidAttesterAuthKey.type,
+      },
+    })
+
+    // Create request for attestation to the light DID with no encoded details
+    const content = RequestForAttestation.fromClaim({
+      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      owner: lightDidOwner.did,
+      contents: {},
+    })
+
+    const quoteData: IQuote = {
+      attesterDid: lightDidAttester.did,
+      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cost: {
+        tax: { vat: 3.3 },
+        net: 23.4,
+        gross: 23.5,
+      },
+      currency: 'Euro',
+      termsAndConditions: 'https://coolcompany.io/terms.pdf',
+      timeframe: date,
+    }
+    const quoteAttesterSigned = await Quote.createAttesterSignature(
+      quoteData,
+      lightDidAttester,
+      keystore
+    )
+    const bothSigned = await Quote.createQuoteAgreement(
+      quoteAttesterSigned,
+      content.rootHash,
+      lightDidAttester.did,
+      lightDidOwner,
+      keystore,
+      mockResolver
+    )
+    const requestAttestationBody: IRequestAttestation = {
+      content: {
+        requestForAttestation: content,
+        quote: bothSigned,
+      },
+      type: Message.BodyType.REQUEST_ATTESTATION,
+    }
+
+    // Create request for attestation to the light DID with encoded details
+    const contentWithEncodedDetails = RequestForAttestation.fromClaim({
+      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      owner: lightDidOwnerWithEncodedDetails.did,
+      contents: {},
+    })
+
+    const quoteDataEncodedDetails: IQuote = {
+      attesterDid: lightDidAttesterWithEncodedDetails.did,
+      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cost: {
+        tax: { vat: 3.3 },
+        net: 23.4,
+        gross: 23.5,
+      },
+      currency: 'Euro',
+      termsAndConditions: 'https://coolcompany.io/terms.pdf',
+      timeframe: date,
+    }
+    const quoteAttesterSignedEncodedDetails =
+      await Quote.createAttesterSignature(
+        quoteDataEncodedDetails,
+        lightDidAttesterWithEncodedDetails,
+        keystore
+      )
+    const bothSignedEncodedDetails = await Quote.createQuoteAgreement(
+      quoteAttesterSignedEncodedDetails,
+      content.rootHash,
+      lightDidAttesterWithEncodedDetails.did,
+      lightDidOwnerWithEncodedDetails,
+      keystore,
+      mockResolver
+    )
+    const requestAttestationBodyWithEncodedDetails: IRequestAttestation = {
+      content: {
+        requestForAttestation: contentWithEncodedDetails,
+        quote: bothSignedEncodedDetails,
+      },
+      type: Message.BodyType.REQUEST_ATTESTATION,
+    }
+
+    // Should not throw if the owner and sender DID is the same.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(requestAttestationBody, lightDidOwner.did, identityBob.did)
+      )
+    ).not.toThrow()
+
+    // Should not throw if the owner has no additional details and the sender does.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          requestAttestationBodyWithEncodedDetails,
+          lightDidOwner.did,
+          identityBob.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the owner has additional details and the sender does not.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          requestAttestationBodyWithEncodedDetails,
+          lightDidOwner.did,
+          identityBob.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the sender is the full DID version of the owner.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(requestAttestationBody, fullDidOwner.did, identityBob.did)
+      )
+    ).not.toThrow()
+
+    // Should throw if the sender and the owner are two different entities.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          requestAttestationBody,
+          fullDidAttester.did,
+          identityAlice.did
+        )
+      )
+    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH('Claim', 'Sender'))
+
+    const attestation = {
+      delegationId: null,
+      claimHash: requestAttestationBody.content.requestForAttestation.rootHash,
+      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      owner: lightDidAttester.did,
+      revoked: false,
+    }
+
+    const submitAttestationBody: ISubmitAttestation = {
+      content: {
+        attestation,
+      },
+      type: Message.BodyType.SUBMIT_ATTESTATION,
+    }
+
+    const attestationWithEncodedDetails = {
+      delegationId: null,
+      claimHash: requestAttestationBody.content.requestForAttestation.rootHash,
+      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      owner: lightDidAttesterWithEncodedDetails.did,
+      revoked: false,
+    }
+
+    const submitAttestationBodyWithEncodedDetails: ISubmitAttestation = {
+      content: {
+        attestation: attestationWithEncodedDetails,
+      },
+      type: Message.BodyType.SUBMIT_ATTESTATION,
+    }
+
+    // Should not throw if the owner and sender DID is the same.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitAttestationBody,
+          lightDidAttester.did,
+          lightDidOwner.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the owner has no additional details and the sender does.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitAttestationBody,
+          lightDidAttesterWithEncodedDetails.did,
+          lightDidOwner.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the owner has additional details and the sender does not.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitAttestationBodyWithEncodedDetails,
+          lightDidAttester.did,
+          lightDidOwner.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the sender is the full DID version of the owner.
+
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitAttestationBody,
+          fullDidAttester.did,
+          lightDidOwner.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should throw if the sender and the owner are two different entities.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(submitAttestationBody, lightDidOwner.did, identityBob.did)
+      )
+    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH('Attestation', 'Sender'))
+
+    const credential: ICredential = {
+      request: content,
+      attestation: submitAttestationBody.content.attestation,
+    }
+
+    const submitClaimsForCTypeBody: ISubmitCredential = {
+      content: [credential],
+      type: Message.BodyType.SUBMIT_CREDENTIAL,
+    }
+
+    const credentialWithEncodedDetails: ICredential = {
+      request: contentWithEncodedDetails,
+      attestation: submitAttestationBody.content.attestation,
+    }
+
+    const submitClaimsForCTypeBodyWithEncodedDetails: ISubmitCredential = {
+      content: [credentialWithEncodedDetails],
+      type: Message.BodyType.SUBMIT_CREDENTIAL,
+    }
+
+    // Should not throw if the owner and sender DID is the same.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitClaimsForCTypeBody,
+          lightDidOwner.did,
+          identityBob.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the owner has no additional details and the sender does.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitClaimsForCTypeBody,
+          lightDidOwnerWithEncodedDetails.did,
+          identityBob.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the owner has additional details and the sender does not.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitClaimsForCTypeBodyWithEncodedDetails,
+          lightDidOwner.did,
+          identityBob.did
+        )
+      )
+    ).not.toThrow()
+
+    // Should not throw if the sender is the full DID version of the owner.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(submitClaimsForCTypeBody, fullDidOwner.did, identityBob.did)
+      )
+    ).not.toThrow()
+
+    // Should throw if the sender and the owner are two different entities.
+    expect(() =>
+      Message.ensureOwnerIsSender(
+        new Message(
+          submitClaimsForCTypeBody,
+          fullDidAttester.did,
           identityAlice.did
         )
       )

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -611,7 +611,6 @@ describe('Messaging', () => {
     ).not.toThrow()
 
     // Should not throw if the sender is the full DID version of the owner.
-
     expect(() =>
       Message.ensureOwnerIsSender(
         new Message(


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1772

Fixes a bug in the message verification logic which used to match for equality between sender and owner.
This PR introduces an utility function in `DidUtils` called `isSameSubject(didA, didB)` which returns `true` if both DIDs refer to the same subject (i.e., the two DIDs share the same identifier). Several unit tests have been added to the messaging unit tests.