### PR TITLE
docs: fix links in SDK README

### DIFF
--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -21,7 +21,7 @@ Regarding the privacy enhancement, please have a look at our [lightning talk for
 
 [KILT](https://kilt.io) documentation is provided in several guides and demos.
 
-- [KILT workshop](https://github.com/KILTprotocol/kilt-workshop-101) 👈 Start here to get familiar with the basics
+- [KILT workshop](https://dev.kilt.io/docs/sdk/workshop/welcome/) 👈 Start here to get familiar with the basics
 - [Getting started guide](https://github.com/KILTprotocol/sdk-js/blob/master/docs/getting-started.md) 👈 Start here if you'd like to include KILT in your project
 - [KILT Developer overview](https://dev.kilt.io/) 👈 Checkout for an overview of the codebase, infrastructure and deployed KILT instances.
 - [API documentation](https://kiltprotocol.github.io/sdk-js)
@@ -86,7 +86,7 @@ Claim {
 
 ## Job Board
 
-Check to see if we have any [Job Offers](https://kilt.io/job-offers/)
+Check to see if we have any [Job Offers](https://www.kilt.io/community/careers/)
 
 ## License
 


### PR DESCRIPTION
The current SDK readme shows outdated links for workshop and careers page. This PR fixes that.