### PR TITLE
fix: clear promise timeout after it finishes

### DIFF
--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
@@ -37,7 +37,7 @@ export function makeSubscriptionPromise<SubscriptionType>(
   let resolve: (value: SubscriptionType) => void
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let reject: (reason: any) => void
-  const promise = new Promise<SubscriptionType>((res, rej) => {
+  let promise = new Promise<SubscriptionType>((res, rej) => {
     resolve = res
     reject = rej
   })
@@ -50,10 +50,14 @@ export function makeSubscriptionPromise<SubscriptionType>(
       : (value) => {
           if (resolveOn(value)) resolve(value)
         }
-  if (timeout)
-    setTimeout(() => {
+  if (timeout) {
+    const to = setTimeout(() => {
       reject(SDKErrors.ERROR_TIMEOUT())
     }, timeout)
+    promise = promise.finally(() => {
+      clearTimeout(to)
+    })
+  }
   return { promise, subscription }
 }
 


### PR DESCRIPTION
## quickfix
Makes sure we clear the timeout in the subscription promise after the promise has resolved or rejected.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
