### PR TITLE
fix: reject subscription promise on disconnect

### DIFF
--- a/packages/testing/src/mocks/mockedApi.ts
+++ b/packages/testing/src/mocks/mockedApi.ts
@@ -200,6 +200,9 @@ export function getMockedApi(): MockApiPromise {
     __setDefaultResult: (status: Partial<ExtrinsicStatus>) => {
       defaultTxResult = makeSubmittableResult(TYPE_REGISTRY, status)
     },
+    on: jest.fn(),
+    off: jest.fn(),
+    once: jest.fn(),
     rpc: {
       system: {
         chain: jest.fn(),


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1835

To avoid tx status & event subscription to go stale or miss important updates (like finalisation), this makes sure that they are rejected on disconnect. Users would then have to go and check on chain if their transactions were successful by checking the desired effects. 

## How to test:
Using a test chain, make a transaction, submit it via the Blockchain helpers and interrupt the connection after receiving the `isReady` status update (e.g. by switching wifi off).

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
