### PR TITLE
test against updated dependencies

### DIFF
--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -47,21 +47,6 @@ jobs:
           name: build-${{ matrix.node-version }}
           path: build.zip
 
-  lint:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: build-14.x
-      - name: unzip
-        run: unzip build.zip -d .
-      - name: lint
-        run: yarn lint
-      - name: typecheck
-        run: yarn check
-
   test:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -1,10 +1,8 @@
 name: Test with updated polkadot dependencies
 
 on:
-  pull_request:
-    branches:
-      - develop
-      - master
+  schedule:
+    - cron: 59 23 * * SAT
 
 env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -31,10 +31,8 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-yarn-
-      - name: upgrade polkadot dependencies
-        run: yarn up @polkadot/* --mode update-lockfile
-      - name: discard changes to package.json files
-        run: git restore ./packages/
+      - name: delete yarn.lock
+        run: rm -f yarn.lock
       - name: run yarn install
         run: yarn install
       - name: yarn build

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -1,11 +1,13 @@
 name: Test with updated polkadot dependencies
 
 on:
-
   pull_request:
     branches:
       - develop
       - master
+
+env:
+  YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
 jobs:
   build:

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -1,0 +1,132 @@
+name: Test with updated polkadot dependencies
+
+on:
+
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-yarn-
+      - name: upgrade polkadot dependencies
+        run: yarn up @polkadot/* --mode update-lockfile
+      - name: discard changes to package.json files
+        run: git restore ./packages/
+      - name: run yarn install
+        run: yarn install
+      - name: yarn build
+        run: yarn build
+      - name: zip build
+        run: zip -r build.zip .
+      - name: upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-${{ matrix.node-version }}
+          path: build.zip
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-14.x
+      - name: unzip
+        run: unzip build.zip -d .
+      - name: lint
+        run: yarn lint
+      - name: typecheck
+        run: yarn check
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        required: ['required']
+        include:
+          - node-version: 16.x
+            required: 'optional'
+
+    continue-on-error: ${{ matrix.required == 'optional' }}
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-${{ matrix.node-version }}
+      - name: unzip
+        run: unzip build.zip -d .
+      - name: unit tests
+        run: yarn test:ci
+
+  integration_test:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    strategy:
+      matrix:
+        image: ['latest-rc']
+        required: ['optional']
+        include:
+          - image: 'latest-develop'
+            required: 'optional'
+
+    continue-on-error: ${{ matrix.required == 'optional' }}
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-14.x
+      - name: unzip
+        run: unzip build.zip -d .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: run integration tests
+        timeout-minutes: 60
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: kilt/prototype-chain
+          IMAGE_TAG: ${{ matrix.image }}
+        run: |
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker run -d --rm -p 9944:9944 $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --dev --ws-port 9944 --ws-external
+          sleep 5s
+          yarn test:integration:run
+          docker stop $(docker ps -f ancestor=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -q)

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -16,7 +16,9 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          ref: master
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -3,9 +3,6 @@ name: Test with updated polkadot dependencies
 on:
   schedule:
     - cron: 59 23 * * SAT
-  pull_request:
-    branches:
-      - develop
 
 env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -3,6 +3,9 @@ name: Test with updated polkadot dependencies
 on:
   schedule:
     - cron: 59 23 * * SAT
+  pull_request:
+    branches:
+      - develop
 
 env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-updated-dependencies
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-yarn-
       - name: delete yarn.lock

--- a/packages/did/src/global.d.ts
+++ b/packages/did/src/global.d.ts
@@ -1,7 +1,0 @@
-import type { URL as NodeURL } from 'url'
-
-declare global {
-  class URL extends NodeURL {}
-}
-
-export {}

--- a/packages/testing/src/mocks/typeRegistry.ts
+++ b/packages/testing/src/mocks/typeRegistry.ts
@@ -11,11 +11,7 @@ import { Metadata, TypeRegistry } from '@polkadot/types'
 import metaStatic from './metadata/spiritnet.json'
 
 // adapted from https://github.com/polkadot-js/apps/blob/master/packages/test-support/src/api/createAugmentedApi.ts
-export type StaticMetadata =
-  | Uint8Array
-  | string
-  | Map<string, unknown>
-  | Record<string, unknown>
+export type StaticMetadata = ConstructorParameters<typeof Metadata>[1]
 
 export function createRegistryFromMetadata(
   meta: StaticMetadata = metaStatic

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,9 +1847,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 14.0.27
-  resolution: "@types/node@npm:14.0.27"
-  checksum: 8068203dc89c6319961a2cc9134f6be719728c78835aeec31e4972ac262d20d625b6ac617b1479223188c173da5c480001d212a0780a49a44058c4ae4ea28f2f
+  version: 14.18.12
+  resolution: "@types/node@npm:14.18.12"
+  checksum: 8a0273caa0584020adb8802784fc7d4f18f05e6c205335b7f3818a91d6b0c22736b9f51da3428d5bc54076ad47f1a4d6d57990a3ce8489a520ac66b2b3ff24bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1826

Will run unit & integration tests every Saturday night, using an install with no lock file. That means all dependencies are at their latest version allowed by the semver range.
Will run from the default branch (develop), but will checkout master (latest commit).

I fixed two type issues in an attempt to make the tests run on the current branch with the latest polkadot deps, but could revert that potentially. 
I'm torn especially about deleting the `global.d.ts` (https://github.com/KILTprotocol/sdk-js/pull/481/commits/06c536bc504aeee883ebc08522875a54c1881037) although it constituted a dirty fix for a specific version of `@types/node` that is lacking some global definitions. The community was torn on this one and removed and re-added it repeatedly, so that some versions have it, others don't. For those that have it, the global definition produces a type conflict. For those that don't have it, removing the global definition results in an error with a missing type in one of our dependencies.

## How to test:
Look at the older workflow runs, e.g. [this](https://github.com/KILTprotocol/sdk-js/runs/5376718315)

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
