### PR TITLE
fix: update key types encoding for retro-compatibility

### DIFF
--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -625,7 +625,7 @@ export function encodeDidSignature(
   key: Pick<ChainDidKey, 'type'>,
   signature: Pick<DidSignature, 'signature'>
 ): SignatureEnum {
-  if (!Object.keys(VerificationKeyType).some((kt) => kt === key.type)) {
+  if (!Object.values(VerificationKeyType).some((kt) => kt === key.type)) {
     throw SDKErrors.ERROR_DID_ERROR(
       `encodedDidSignature requires a verification key. A key of type "${key.type}" was used instead.`
     )

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -91,7 +91,7 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.did).toStrictEqual(expectedDid)
     // Verify base58 encoding
     expect(lightDidDetails?.did).toStrictEqual(
-      `did:kilt:light:00${authKey.address}:z12fAUWqFgvKum5CE8EdUjuaP3QWVZV1MXcnskZpFVN2tvCqWmXyBvVH1wvGqrK2LYCwhXBwDhoan1jUtLEu9nvirB6FYFZpUvsTENM71XB9CagmSgUwNeqTbBmK6fyMNfMhgRPd9HDAZKw96A9FvSBqrXhBqKX9dhsFft6rJzSzKdVgzmmd8bn5AGjcXBVmJeGXZZcjniikWk44HUFuvdTxdvgvwpvu`
+      `did:kilt:light:00${authKey.address}:z12fAUWqFgvKum5CE8EdUjuaP3QWVZV1MXcnskZpFVN2tvCqWmXyBvVH1wvGqrK2LYCwhXBwDhoan1jXcsesDnDNaBKXmjjT6weqynvXJAzQHvxhTt8j1uwMyBSxdANHdNN1NTjczhL5rVJYYqJ12kzneFWurNAzUstsQc3n9zZiFK4BdFV9SD5i5jE7AuTuUL3VraoFZ98CgpSP72ebtLFEH1SosdDT`
     )
 
     expect(lightDidDetails?.getKey('authentication')).toStrictEqual<DidKey>({
@@ -202,7 +202,7 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.did).toStrictEqual(expectedDid)
     // Verify base58 encoding
     expect(lightDidDetails?.did).toStrictEqual(
-      `did:kilt:light:01${authKey.address}:z1Ac9CMtYCTRWjetJfJqJoV7FcP9zdFudqUaupQkBCERoCQcnu2SUS5CGHdCXhWoxbihovMVymRperWATas8NsS`
+      `did:kilt:light:01${authKey.address}:z1Ac9CMtYCTRWjetJfJqJoV7FcP9zdFudqUaupQkBCERoCQcnu2SUS5CGHdCXhWoxbihovMVymRperWSPpRc7mJ`
     )
 
     expect(lightDidDetails?.getKey('authentication')).toStrictEqual<DidKey>({
@@ -334,7 +334,7 @@ describe('When creating an instance from a URI', () => {
 
     // Verify base58 encoding
     expect(builtLightDidDetails.did).toStrictEqual(
-      `did:kilt:light:00${expectedLightDidDetails.identifier}:z12fAUWqFgvKum5CE8EdUjuaP3QWVZV1MXcnskZpFVN2tvCqWmXyBvVH1wvGqrK2LYCwhXBwDhoan1jUtLEu9nvirB6FYFZpUvsTENM71XB9CagmSgUwNeqTbBmK6fyMNfMhgRPd9HDAZKw96A9FvSBqrXhBqKX9dhsFft6rJzSzKdVgzmmd8bn5AGjcXBVmJeGXZZcjniikWk44HUFuvdTxdvgvwpvu`
+      `did:kilt:light:00${expectedLightDidDetails.identifier}:z12fAUWqFgvKum5CE8EdUjuaP3QWVZV1MXcnskZpFVN2tvCqWmXyBvVH1wvGqrK2LYCwhXBwDhoan1jXcsesDnDNaBKXmjjT6weqynvXJAzQHvxhTt8j1uwMyBSxdANHdNN1NTjczhL5rVJYYqJ12kzneFWurNAzUstsQc3n9zZiFK4BdFV9SD5i5jE7AuTuUL3VraoFZ98CgpSP72ebtLFEH1SosdDT`
     )
     expect(builtLightDidDetails?.authenticationKey.id).toStrictEqual(
       'authentication'

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -278,7 +278,7 @@ describe('When exporting a DID Document from a full DID', () => {
 })
 
 describe('When exporting a DID Document from a light DID', () => {
-  const authKey = generateAttestationKeyDetails() as NewDidVerificationKey
+  const authKey = generateAuthenticationKeyDetails() as NewDidVerificationKey
   const encKey: DidKey = generateEncryptionKeyDetails()
   const serviceEndpoints: DidServiceEndpoint[] = [
     generateServiceEndpointDetails('id-1'),
@@ -300,37 +300,37 @@ describe('When exporting a DID Document from a light DID', () => {
     const didDoc = exportToDidDocument(lightDidDetails, 'application/json')
 
     expect(didDoc).toStrictEqual({
-      id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d',
+      id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK',
       verificationMethod: [
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#authentication',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#authentication',
           controller:
-            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d',
+            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK',
           type: 'Ed25519VerificationKey2018',
           publicKeyBase58: '11111111111111111111111111111111',
         },
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#encryption',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#encryption',
           controller:
-            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d',
+            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK',
           type: 'X25519KeyAgreementKey2019',
           publicKeyBase58: '11111111111111111111111111111111',
         },
       ],
       authentication: [
-        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#authentication',
+        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#authentication',
       ],
       keyAgreement: [
-        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#encryption',
+        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#encryption',
       ],
       service: [
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#id-1',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#id-1',
           type: ['type-id-1'],
           serviceEndpoint: ['url-id-1'],
         },
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#id-2',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#id-2',
           type: ['type-id-2'],
           serviceEndpoint: ['url-id-2'],
         },
@@ -343,37 +343,37 @@ describe('When exporting a DID Document from a light DID', () => {
 
     expect(didDoc).toStrictEqual({
       '@context': ['https://www.w3.org/ns/did/v1'],
-      id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d',
+      id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK',
       verificationMethod: [
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#authentication',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#authentication',
           controller:
-            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d',
+            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK',
           type: 'Ed25519VerificationKey2018',
           publicKeyBase58: '11111111111111111111111111111111',
         },
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#encryption',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#encryption',
           controller:
-            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d',
+            'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK',
           type: 'X25519KeyAgreementKey2019',
           publicKeyBase58: '11111111111111111111111111111111',
         },
       ],
       authentication: [
-        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#authentication',
+        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#authentication',
       ],
       keyAgreement: [
-        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#encryption',
+        'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#encryption',
       ],
       service: [
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#id-1',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#id-1',
           type: ['type-id-1'],
           serviceEndpoint: ['url-id-1'],
         },
         {
-          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74YCnyboHBUvqEs6J8jdYY5dK2XeqCCs653Sf9XVH4RN2WvPrDFZXzzKf3KigvcaE7kkaEwLZvcas3U1M2ZDZCajDG71winwaRNrDtcqkJL9V6Q5yKNWRacw7hJ58d#id-2',
+          id: 'did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z1ERkVVjngcarMbJn6YssB1PYULescQneSSEfCTJwYbzT2aK8fzH5WPsp3G4UVuLWWfsTayketnFV74vLhFc3AXGE4HBVxqDt8bdEtDBNSELnBnJxpL3CUBe79MKo95NfGAiFZPkFBrAmqgSDNZR1RhdUidXLmTMuS9BF6T9kKbbyAzJnAARG88BBF8bXPMUU268GYSHYKK#id-2',
           type: ['type-id-2'],
           serviceEndpoint: ['url-id-2'],
         },

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -49,7 +49,7 @@ export type EncryptionKeyRelationship = KeyRelationship.keyAgreement
  * Possible types for a DID encryption key.
  */
 export enum EncryptionKeyType {
-  X25519 = 'X25519',
+  X25519 = 'x25519',
 }
 
 /**

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -36,9 +36,9 @@ export type VerificationKeyRelationship =
  * Possible types for a DID verification key.
  */
 export enum VerificationKeyType {
-  Sr25519 = 'Sr25519',
-  Ed25519 = 'Ed25519',
-  Ecdsa = 'Ecdsa',
+  Sr25519 = 'sr25519',
+  Ed25519 = 'ed25519',
+  Ecdsa = 'ecdsa',
 }
 
 /**


### PR DESCRIPTION
Revert the encoding of all key types to be lowercase, e.g. `X25519` -> `x25519` for retro-compatibility with lightDID encoding logic.