### PR TITLE
feat: add SDK runtime checks for BoundedVec RPC limits

### DIFF
--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1257,7 +1257,7 @@ describe('DID extrinsics batching', () => {
   })
 })
 
-describe.only('Runtime constraints', () => {
+describe('Runtime constraints', () => {
   let testAuthKey: NewDidVerificationKey
   beforeAll(async () => {
     testAuthKey = await keystore

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1516,9 +1516,9 @@ describe.only('Runtime constraints', () => {
               {
                 id: 'id-1',
                 types: ['type-1'],
-                // Maximum is 100
+                // Maximum is 200
                 urls: [
-                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                 ],
               },
             ],
@@ -1538,7 +1538,7 @@ describe.only('Runtime constraints', () => {
                 types: ['type-1'],
                 // One more than the maximum
                 urls: [
-                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                 ],
               },
             ],
@@ -1547,7 +1547,7 @@ describe.only('Runtime constraints', () => {
           keystore
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"The service with ID \\"id-1\\" has the URL \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long. Max number of characters allowed for a service URL is 100."'
+        '"The service with ID \\"id-1\\" has the URL \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long. Max number of characters allowed for a service URL is 100."'
       )
     }, 30_000)
   })
@@ -1638,9 +1638,9 @@ describe.only('Runtime constraints', () => {
         DidChain.getAddEndpointExtrinsic({
           id: 'id-1',
           types: ['type-1'],
-          // Maximum is 100
+          // Maximum is 200
           urls: [
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           ],
         })
       ).resolves.not.toThrow()
@@ -1650,11 +1650,11 @@ describe.only('Runtime constraints', () => {
           types: ['type-1'],
           // One more than the maximum
           urls: [
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           ],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"The service with ID \\"id-1\\" has the URL \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long. Max number of characters allowed for a service URL is 100."'
+        '"The service with ID \\"id-1\\" has the URL \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long. Max number of characters allowed for a service URL is 100."'
       )
     }, 30_000)
   })

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -75,30 +75,6 @@ describe('When there is an Web3NameCreator and a payer', () => {
     await expect(p).rejects.toThrowError('Inability to pay some fees')
   }, 30_000)
 
-  it('should not be possible to create a web3 name that is too short', async () => {
-    // Minimum is 3
-    await expect(Web3Names.getClaimTx('aaa')).resolves.not.toThrow()
-    // One less than the minimum
-    await expect(
-      Web3Names.getClaimTx('aa')
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"'
-    )
-  }, 30_000)
-
-  it('should not be possible to create a web3 name that is too long', async () => {
-    // Maximum is 32
-    await expect(
-      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-    ).resolves.not.toThrow()
-    // One more than the maximum
-    await expect(async () =>
-      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"'
-    )
-  }, 30_000)
-
   it('should be possible to create a w3n name with enough tokens', async () => {
     const tx = await Web3Names.getClaimTx(nick)
     const authorizedTx = await w3nCreator.authorizeExtrinsic(
@@ -230,6 +206,56 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
     await expect(p).resolves.not.toThrow()
   }, 40_000)
+})
+
+describe('Runtime constraints', () => {
+  it('should not be possible to create a web3 name that is too short', async () => {
+    // Minimum is 3
+    await expect(Web3Names.getClaimTx('aaa')).resolves.not.toThrow()
+    // One less than the minimum
+    await expect(
+      Web3Names.getClaimTx('aa')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"'
+    )
+  }, 30_000)
+
+  it('should not be possible to create a web3 name that is too long', async () => {
+    // Maximum is 32
+    await expect(
+      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    ).resolves.not.toThrow()
+    // One more than the maximum
+    await expect(async () =>
+      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"'
+    )
+  }, 30_000)
+
+  it('should not be possible to claim deposit for a web3 name that is too short', async () => {
+    // Minimum is 3
+    await expect(Web3Names.getReclaimDepositTx('aaa')).resolves.not.toThrow()
+    // One less than the minimum
+    await expect(
+      Web3Names.getReclaimDepositTx('aa')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"'
+    )
+  }, 30_000)
+
+  it('should not be possible to claim deposit for a web3 name that is too long', async () => {
+    // Maximum is 32
+    await expect(
+      Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    ).resolves.not.toThrow()
+    // One more than the maximum
+    await expect(async () =>
+      Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"'
+    )
+  }, 30_000)
 })
 
 afterAll(() => {

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -75,6 +75,30 @@ describe('When there is an Web3NameCreator and a payer', () => {
     await expect(p).rejects.toThrowError('Inability to pay some fees')
   }, 30_000)
 
+  it('should not be possible to create a web3 name that is too short', async () => {
+    // Minimum is 3
+    await expect(Web3Names.getClaimTx('aaa')).resolves.not.toThrow()
+    // One less than the minimum
+    await expect(
+      Web3Names.getClaimTx('aa')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"'
+    )
+  }, 30_000)
+
+  it('should not be possible to create a web3 name that is too long', async () => {
+    // Maximum is 32
+    await expect(
+      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    ).resolves.not.toThrow()
+    // One more than the maximum
+    await expect(async () =>
+      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"'
+    )
+  }, 30_000)
+
   it('should be possible to create a w3n name with enough tokens', async () => {
     const tx = await Web3Names.getClaimTx(nick)
     const authorizedTx = await w3nCreator.authorizeExtrinsic(

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -216,7 +216,7 @@ describe('Runtime constraints', () => {
     await expect(
       Web3Names.getClaimTx('aa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"'
+      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3."'
     )
   }, 30_000)
 
@@ -229,7 +229,7 @@ describe('Runtime constraints', () => {
     await expect(async () =>
       Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"'
+      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32."'
     )
   }, 30_000)
 
@@ -240,7 +240,7 @@ describe('Runtime constraints', () => {
     await expect(
       Web3Names.getReclaimDepositTx('aa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"'
+      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3."'
     )
   }, 30_000)
 
@@ -253,7 +253,7 @@ describe('Runtime constraints', () => {
     await expect(async () =>
       Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"'
+      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32."'
     )
   }, 30_000)
 })

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -49,13 +49,13 @@ import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 
+import { ApiPromise } from '@polkadot/api'
 import { DidDetails } from './DidDetails/index.js'
 import {
   getSigningAlgorithmForVerificationKeyType,
   getVerificationKeyTypeForSigningAlgorithm,
 } from './Did.utils.js'
 import { FullDidCreationDetails } from './types.js'
-import { ApiPromise } from '@polkadot/api'
 
 const log = ConfigService.LoggingFactory.getLogger('Did')
 
@@ -376,30 +376,30 @@ function checkServiceEndpointInput(
 
   if (endpoint.id.length > maxServiceIdLength) {
     throw SDKErrors.ERROR_DID_ERROR(
-      `The service with ID ${endpoint.id} has an ID that is too long. Max number of characters allowed for a service ID is ${maxServiceIdLength}.`
+      `The service with ID "${endpoint.id}" has an ID that is too long. Max number of characters allowed for a service ID is ${maxServiceIdLength}.`
     )
   }
   if (endpoint.types.length > maxNumberOfTypesPerService) {
     throw SDKErrors.ERROR_DID_ERROR(
-      `The service with ID ${endpoint.id} has too many types. Max number of types allowed per service is ${maxNumberOfTypesPerService}.`
+      `The service with ID "${endpoint.id}" has too many types. Max number of types allowed per service is ${maxNumberOfTypesPerService}.`
     )
   }
   if (endpoint.urls.length > maxNumberOfUrlsPerService) {
     throw SDKErrors.ERROR_DID_ERROR(
-      `The service with ID ${endpoint.id} has too many URLs. Max number of URLs allowed per service is ${maxNumberOfUrlsPerService}.`
+      `The service with ID "${endpoint.id}" has too many URLs. Max number of URLs allowed per service is ${maxNumberOfUrlsPerService}.`
     )
   }
   endpoint.types.forEach((type) => {
     if (type.length > maxServiceTypeLength) {
       throw SDKErrors.ERROR_DID_ERROR(
-        `The service with ID ${endpoint.id} has the type ${type} that is too long. Max number of characters allowed for a service type is ${maxServiceTypeLength}.`
+        `The service with ID "${endpoint.id}" has the type "${type}" that is too long. Max number of characters allowed for a service type is ${maxServiceTypeLength}.`
       )
     }
   })
   endpoint.urls.forEach((url) => {
     if (url.length > maxServiceUrlLength) {
       throw SDKErrors.ERROR_DID_ERROR(
-        `The service with ID ${endpoint.id} has the URL ${url} that is too long. Max number of characters allowed for a service URL is ${maxServiceUrlLength}.`
+        `The service with ID "${endpoint.id}" has the URL "${url}" that is too long. Max number of characters allowed for a service URL is ${maxServiceUrlLength}.`
       )
     }
   })
@@ -640,7 +640,7 @@ export async function getRemoveEndpointExtrinsic(
   ).toNumber()
   if (endpointId.length > maxServiceIdLength) {
     throw SDKErrors.ERROR_DID_ERROR(
-      `The service ID ${endpointId} has is too long. Max number of characters allowed for a service ID is ${maxServiceIdLength}.`
+      `The service ID "${endpointId}" has is too long. Max number of characters allowed for a service ID is ${maxServiceIdLength}.`
     )
   }
 

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -635,6 +635,15 @@ export async function getRemoveEndpointExtrinsic(
   endpointId: DidServiceEndpoint['id']
 ): Promise<Extrinsic> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
+  const maxServiceIdLength = (
+    api.consts.did.maxServiceIdLength as u32
+  ).toNumber()
+  if (endpointId.length > maxServiceIdLength) {
+    throw SDKErrors.ERROR_DID_ERROR(
+      `The service ID ${endpointId} has is too long. Max number of characters allowed for a service ID is ${maxServiceIdLength}.`
+    )
+  }
+
   return api.tx.did.removeServiceEndpoint(endpointId)
 }
 

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -420,20 +420,20 @@ export async function generateCreateTxFromCreationDetails(
     serviceEndpoints = [],
   } = details
 
-  const newKeyAgreementKeys: PublicKeyEnum[] = keyAgreementKeys.map(
-    ({ publicKey }) =>
-      formatPublicKey({ type: EncryptionKeyType.X25519, publicKey })
-  )
-
   const maxKeyAgreementKeys = (
     api.consts.did.maxNewKeyAgreementKeys as u32
   ).toNumber()
 
-  if (newKeyAgreementKeys.length > maxKeyAgreementKeys) {
+  if (keyAgreementKeys.length > maxKeyAgreementKeys) {
     throw SDKErrors.ERROR_DID_ERROR(
       `The number of key agreement keys in the creation operation is greater than the maximum allowed, which is ${maxKeyAgreementKeys}.`
     )
   }
+
+  const newKeyAgreementKeys: PublicKeyEnum[] = keyAgreementKeys.map(
+    ({ publicKey }) =>
+      formatPublicKey({ type: EncryptionKeyType.X25519, publicKey })
+  )
 
   const newAssertionKey = assertionKey
     ? formatPublicKey(assertionKey)

--- a/packages/did/src/Web3Names/Web3Names.chain.ts
+++ b/packages/did/src/Web3Names/Web3Names.chain.ts
@@ -12,9 +12,9 @@ import {
   IDidDetails,
 } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import { DecoderUtils } from '@kiltprotocol/utils'
+import { DecoderUtils, SDKErrors } from '@kiltprotocol/utils'
 
-import type { Option, Bytes, Struct, u128 } from '@polkadot/types'
+import type { Option, Bytes, Struct, u128, u32 } from '@polkadot/types'
 import type { AnyNumber } from '@polkadot/types/types'
 import { BN } from '@polkadot/util'
 
@@ -44,6 +44,20 @@ export async function getClaimTx(
   name: Web3Name
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
+  const [minLength, maxLength] = [
+    (blockchain.api.consts.web3Names.minNameLength as u32).toNumber(),
+    (blockchain.api.consts.web3Names.maxNameLength as u32).toNumber(),
+  ]
+  if (name.length < minLength) {
+    throw SDKErrors.ERROR_WEB3_NAME_ERROR(
+      `The provided name ${name} is shorter than the minimum number of characters allowed, which is ${minLength}`
+    )
+  }
+  if (name.length > maxLength) {
+    throw SDKErrors.ERROR_WEB3_NAME_ERROR(
+      `The provided name ${name} is longer than the maximum number of characters allowed, which is ${maxLength}`
+    )
+  }
   return blockchain.api.tx.web3Names.claim(name)
 }
 

--- a/packages/did/src/Web3Names/Web3Names.chain.ts
+++ b/packages/did/src/Web3Names/Web3Names.chain.ts
@@ -46,12 +46,12 @@ function checkWeb3NameInputConstraints(
 
   if (web3Name.length < minLength) {
     throw SDKErrors.ERROR_WEB3_NAME_ERROR(
-      `The provided name "${web3Name}" is shorter than the minimum number of characters allowed, which is ${minLength}`
+      `The provided name "${web3Name}" is shorter than the minimum number of characters allowed, which is ${minLength}.`
     )
   }
   if (web3Name.length > maxLength) {
     throw SDKErrors.ERROR_WEB3_NAME_ERROR(
-      `The provided name "${web3Name}" is longer than the maximum number of characters allowed, which is ${maxLength}`
+      `The provided name "${web3Name}" is longer than the maximum number of characters allowed, which is ${maxLength}.`
     )
   }
 }

--- a/packages/did/src/Web3Names/Web3Names.chain.ts
+++ b/packages/did/src/Web3Names/Web3Names.chain.ts
@@ -46,12 +46,12 @@ function checkWeb3NameInputConstraints(
 
   if (web3Name.length < minLength) {
     throw SDKErrors.ERROR_WEB3_NAME_ERROR(
-      `The provided name ${web3Name} is shorter than the minimum number of characters allowed, which is ${minLength}`
+      `The provided name "${web3Name}" is shorter than the minimum number of characters allowed, which is ${minLength}`
     )
   }
   if (web3Name.length > maxLength) {
     throw SDKErrors.ERROR_WEB3_NAME_ERROR(
-      `The provided name ${web3Name} is longer than the maximum number of characters allowed, which is ${maxLength}`
+      `The provided name "${web3Name}" is longer than the maximum number of characters allowed, which is ${maxLength}`
     )
   }
 }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -83,6 +83,7 @@ export enum ErrorCode {
   ERROR_KEYSTORE_ERROR = 30015,
   ERROR_DID_EXPORTER_ERROR = 30016,
   ERROR_DID_BUILDER_ERROR = 30017,
+  ERROR_WEB3_NAME_ERROR = 30018,
 
   // Compression / Decompressions
   ERROR_DECOMPRESSION_ARRAY = 40001,
@@ -170,6 +171,11 @@ export const ERROR_DID_BUILDER_ERROR: (input: string) => SDKError = (
   input: string
 ) => {
   return new SDKError(ErrorCode.ERROR_DID_BUILDER_ERROR, input)
+}
+export const ERROR_WEB3_NAME_ERROR: (input: string) => SDKError = (
+  input: string
+) => {
+  return new SDKError(ErrorCode.ERROR_WEB3_NAME_ERROR, input)
 }
 
 export const ERROR_CLAIM_HASH_NOT_PROVIDED: () => SDKError = () => {


### PR DESCRIPTION
This PR fixes https://github.com/KILTprotocol/ticket/issues/1868 by adding checks to the chain files of web3 names and DIDs, which are the only two places where one or more extrinsics accept a `BoundedVec` as a parameter. If not handled by the SDK, the underlying WASM panics and a stack trace is shown, which is not really usable for the SDK user.

## How to test

Some integration tests have been added to both `Did.spec.ts` and `Web3Names.spec.ts`. Try to run those.

## About potential integration tests failing

Right now, the SDK assumes that the max length for a URL in a service endpoint is 200, which is in the node `master` but not in the node `develop`. This means that integration  tests with `develop` will fail as long as the change is not merged back from `master`.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
