### PR TITLE
fix: bump node types

### DIFF
--- a/packages/did/src/global.d.ts
+++ b/packages/did/src/global.d.ts
@@ -1,7 +1,0 @@
-import type { URL as NodeURL } from 'url'
-
-declare global {
-  class URL extends NodeURL {}
-}
-
-export {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,9 +1965,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 14.0.27
-  resolution: "@types/node@npm:14.0.27"
-  checksum: 8068203dc89c6319961a2cc9134f6be719728c78835aeec31e4972ac262d20d625b6ac617b1479223188c173da5c480001d212a0780a49a44058c4ae4ea28f2f
+  version: 14.18.12
+  resolution: "@types/node@npm:14.18.12"
+  checksum: 8a0273caa0584020adb8802784fc7d4f18f05e6c205335b7f3818a91d6b0c22736b9f51da3428d5bc54076ad47f1a4d6d57990a3ce8489a520ac66b2b3ff24bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fixes KILTProtocol/sdk-js#497

Bumps `@types/node` in our lock file to a version that includes global definitions for `URL` and removes these definitions from our repo. This is to avoid conflicts between declarations as typescript does not simply merge these. 
SDK consumers for whom this creates issues should either update their node types, make a global declaration in their own project or disable dependency type checks. 

## How to test:
N/A

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
