### PR TITLE
feat: string pattern types for did uri, did resource uri, and hex string

### DIFF
--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -14,6 +14,7 @@ import type {
   IAttestation,
   Deposit,
   SubmittableExtrinsic,
+  IRequestForAttestation,
 } from '@kiltprotocol/types'
 import { DecoderUtils } from '@kiltprotocol/utils'
 import type { AccountId, Hash } from '@polkadot/types/interfaces'
@@ -58,7 +59,7 @@ export interface AttestationDetails extends Struct {
 
 function decode(
   encoded: Option<AttestationDetails>,
-  claimHash: string // all the other decoders do not use extra data; they just return partial types
+  claimHash: IRequestForAttestation['rootHash'] // all the other decoders do not use extra data; they just return partial types
 ): Attestation | null {
   DecoderUtils.assertCodecIsType(encoded, [
     'Option<AttestationAttestationsAttestationDetails>',
@@ -67,7 +68,7 @@ function decode(
     const chainAttestation = encoded.unwrap()
     const attestation: IAttestation = {
       claimHash,
-      cTypeHash: chainAttestation.ctypeHash.toString(),
+      cTypeHash: chainAttestation.ctypeHash.toHex(),
       owner: DidUtils.getKiltDidFromIdentifier(
         chainAttestation.attester.toString(),
         'full'
@@ -100,7 +101,9 @@ export async function queryRaw(
  * @param claimHash The hash of the claim attested in the attestation.
  * @returns Either the retrieved [[Attestation]] or null.
  */
-export async function query(claimHash: string): Promise<Attestation | null> {
+export async function query(
+  claimHash: IRequestForAttestation['rootHash']
+): Promise<Attestation | null> {
   const encoded = await queryRaw(claimHash)
   return decode(encoded, claimHash)
 }

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -213,6 +213,7 @@ describe('Attestation', () => {
       delegationId: null,
     } as IAttestation
 
+    // @ts-ignore
     const malformedOwner = {
       claimHash,
       cTypeHash,

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -15,6 +15,7 @@ import type {
   IAttestation,
   CompressedAttestation,
   ICType,
+  DidUri,
 } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
@@ -39,9 +40,9 @@ beforeAll(() => {
 })
 
 describe('Attestation', () => {
-  const identityAlice =
+  const identityAlice: DidUri =
     'did:kilt:4nwPAmtsK5toZfBM9WvmAe4Fa3LyZ3X3JHt7EUFfrcPPAZAm'
-  const identityBob =
+  const identityBob: DidUri =
     'did:kilt:4nxhWrDR27YzC5z4soRcz31MaeFn287JRqiE5y4u7jBEdgP2'
   let rawCTypeSchema: ICType['schema']
   let testCType: CType

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -24,6 +24,7 @@ import {
   Blockchain,
   BlockchainApiConnection,
 } from '@kiltprotocol/chain-helpers'
+import type { HexString } from '@polkadot/util/types'
 import { Claim } from '../claim/Claim'
 import { CType } from '../ctype/CType'
 import { RequestForAttestation } from '../requestforattestation/RequestForAttestation'
@@ -182,12 +183,10 @@ describe('Attestation', () => {
     }).toThrow()
   })
   it('error check should throw errors on faulty Attestations', () => {
-    const { cTypeHash, claimHash } = {
-      cTypeHash:
-        '0xa8c5bdb22aaea3fceb5467d37169cbe49c71f226233037537e70a32a032304ff',
-      claimHash:
-        '0x21a3448ccf10f6568d8cd9a08af689c220d842b893a40344d010e398ab74e557',
-    }
+    const cTypeHash: HexString =
+      '0xa8c5bdb22aaea3fceb5467d37169cbe49c71f226233037537e70a32a032304ff'
+    const claimHash: HexString =
+      '0x21a3448ccf10f6568d8cd9a08af689c220d842b893a40344d010e398ab74e557'
 
     const everything = {
       claimHash,
@@ -197,6 +196,7 @@ describe('Attestation', () => {
       delegationId: null,
     }
 
+    // @ts-ignore
     const noClaimHash = {
       claimHash: '',
       cTypeHash,
@@ -205,6 +205,7 @@ describe('Attestation', () => {
       delegationId: null,
     } as IAttestation
 
+    // @ts-ignore
     const noCTypeHash = {
       claimHash,
       cTypeHash: '',

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -50,7 +50,9 @@ export class Attestation implements IAttestation {
    * });
    * ```
    */
-  public static async query(claimHash: string): Promise<Attestation | null> {
+  public static async query(
+    claimHash: IAttestation['claimHash']
+  ): Promise<Attestation | null> {
     return query(claimHash)
   }
 
@@ -335,7 +337,7 @@ export class Attestation implements IAttestation {
    */
   public static async checkValidity(
     attestation: IAttestation,
-    claimHash: string = attestation.claimHash
+    claimHash: IAttestation['claimHash'] = attestation.claimHash
   ): Promise<boolean> {
     // Query attestation by claimHash. null if no attestation is found on-chain for this hash
     const chainAttestation: Attestation | null = await Attestation.query(

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -10,13 +10,18 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { IClaim, CompressedClaim, ICType } from '@kiltprotocol/types'
+import type {
+  IClaim,
+  CompressedClaim,
+  ICType,
+  DidUri,
+} from '@kiltprotocol/types'
 import { CType } from '../ctype/CType'
 import { Claim } from './Claim'
 import * as ClaimUtils from './Claim.utils'
 
 describe('Claim', () => {
-  let did: string
+  let did: DidUri
   let claimContents: any
   let rawCType: ICType['schema']
   let testCType: CType
@@ -109,6 +114,7 @@ describe('Claim', () => {
       owner: ownerAddress,
     } as IClaim
 
+    // @ts-ignore
     const noCTypeHash = {
       cTypeHash: '',
       contents: claimContents,

--- a/packages/core/src/claim/Claim.utils.ts
+++ b/packages/core/src/claim/Claim.utils.ts
@@ -19,6 +19,7 @@ import type {
 } from '@kiltprotocol/types'
 import { jsonabc, DataUtils, Crypto, SDKErrors } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
+import type { HexString } from '@polkadot/util/types'
 import { getIdForCTypeHash } from '../ctype/CType.utils.js'
 
 const VC_VOCAB = 'https://www.w3.org/2018/credentials#'
@@ -104,7 +105,7 @@ export function hashClaimContents(
     canonicalisation?: (claim: PartialClaim) => string[]
   } = {}
 ): {
-  hashes: string[]
+  hashes: HexString[]
   nonceMap: Record<string, string>
 } {
   // apply defaults

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -371,6 +371,7 @@ describe('RequestForAttestation', () => {
     )
     expect(Credential.isICredential(testAttestation)).toBeTruthy()
     const { cTypeHash } = testAttestation.attestation
+    // @ts-ignore
     testAttestation.attestation.cTypeHash = [
       cTypeHash.slice(0, 15),
       ((parseInt(cTypeHash.charAt(15), 16) + 1) % 16).toString(16),

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -107,7 +107,7 @@ describe('CType', () => {
     }
     const invalidAddressCtype: ICType = {
       ...claimCtype,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      // @ts-ignore
       owner: claimCtype.owner!.replace('4', 'D'),
     }
 

--- a/packages/core/src/ctype/CType.utils.ts
+++ b/packages/core/src/ctype/CType.utils.ts
@@ -19,6 +19,7 @@ import type {
 } from '@kiltprotocol/types'
 import { jsonabc, Crypto, SDKErrors, JsonSchema } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
+import type { HexString } from '@polkadot/util/types'
 import { getOwner, isStored } from './CType.chain.js'
 import { CTypeModel, CTypeWrapperModel } from './CTypeSchema.js'
 
@@ -92,7 +93,7 @@ export function getSchemaPropertiesForHash(
 
 export function getHashForSchema(
   schema: CTypeSchemaWithoutId | ICType['schema']
-): string {
+): HexString {
   const preparedSchema = getSchemaPropertiesForHash(schema)
   return Crypto.hashObjectAsStr(preparedSchema)
 }

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -11,7 +11,11 @@
  */
 
 import type { Option, Vec, U128 } from '@polkadot/types'
-import type { IDelegationNode, SubmittableExtrinsic } from '@kiltprotocol/types'
+import type {
+  IAttestation,
+  IDelegationNode,
+  SubmittableExtrinsic,
+} from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import type { Hash } from '@polkadot/types/interfaces'
@@ -182,7 +186,9 @@ export async function getChildren(
   return childrenNodes
 }
 
-function decodeDelegatedAttestations(queryResult: Option<Vec<Hash>>): string[] {
+function decodeDelegatedAttestations(
+  queryResult: Option<Vec<Hash>>
+): Array<IAttestation['claimHash']> {
   DecoderUtils.assertCodecIsType(queryResult, ['Option<Vec<H256>>'])
   return queryResult.unwrapOrDefault().map((hash) => hash.toHex())
 }
@@ -195,7 +201,7 @@ function decodeDelegatedAttestations(queryResult: Option<Vec<Hash>>): string[] {
  */
 export async function getAttestationHashes(
   id: IDelegationNode['id']
-): Promise<string[]> {
+): Promise<Array<IAttestation['claimHash']>> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const encodedHashes =
     await blockchain.api.query.attestation.delegatedAttestations<

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -15,6 +15,7 @@ import {
   IDelegationNode,
   IDelegationHierarchyDetails,
   Permission,
+  DidUri,
 } from '@kiltprotocol/types'
 import { encodeAddress } from '@polkadot/keyring'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
@@ -69,7 +70,7 @@ describe('DelegationNode', () => {
   let hierarchyId: string
   let parentId: string
   let hashList: string[]
-  let addresses: string[]
+  let addresses: DidUri[]
 
   beforeAll(() => {
     successId = Crypto.hashStr('success')
@@ -82,8 +83,9 @@ describe('DelegationNode', () => {
       .map<string>((_val, index) => Crypto.hashStr(`${index + 1}`))
     addresses = Array(10002)
       .fill('')
-      .map<string>((_val, index) =>
-        encodeAddress(Crypto.hash(`${index}`, 256), 38)
+      .map<DidUri>(
+        (_val, index) =>
+          `did:kilt:${encodeAddress(Crypto.hash(`${index}`, 256), 38)}`
       )
   })
 
@@ -443,7 +445,10 @@ describe('DelegationNode', () => {
     })
 
     it('returns null if looking for non-existent account', async () => {
-      const noOnesAddress = encodeAddress(Crypto.hash('-1', 256), 38)
+      const noOnesAddress: DidUri = `did:kilt:${encodeAddress(
+        Crypto.hash('-1', 256),
+        38
+      )}`
       await Promise.all([
         expect(
           nodes[hashList[10]].findAncestorOwnedBy(noOnesAddress)
@@ -484,6 +489,7 @@ describe('DelegationNode', () => {
         permissions: [Permission.DELEGATE],
         parentId: undefined,
         revoked: false,
+        childrenIds: [],
       } as IDelegationNode
 
       // @ts-expect-error
@@ -496,6 +502,7 @@ describe('DelegationNode', () => {
         permissions: [Permission.DELEGATE],
         parentId: undefined,
         revoked: false,
+        childrenIds: [],
       } as IDelegationNode
 
       const malformedParentIdDelegationNode = {
@@ -505,6 +512,7 @@ describe('DelegationNode', () => {
         permissions: [Permission.DELEGATE],
         parentId: 'malformed',
         revoked: false,
+        childrenIds: [],
       } as IDelegationNode
 
       expect(() => errorCheck(malformedPremissionsDelegationNode)).toThrowError(

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -16,6 +16,7 @@ import {
   IDelegationHierarchyDetails,
   Permission,
   DidUri,
+  ICType,
 } from '@kiltprotocol/types'
 import { encodeAddress } from '@polkadot/keyring'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
@@ -170,7 +171,7 @@ describe('DelegationNode', () => {
         [hierarchyId]: {
           id: hierarchyId,
           cTypeHash:
-            'kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84',
+            '0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84',
         },
       }
 
@@ -197,7 +198,7 @@ describe('DelegationNode', () => {
 
       expect(hierarchyDetails).toBeDefined()
       expect(hierarchyDetails.cTypeHash).toBe(
-        'kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84'
+        '0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84'
       )
     })
   })
@@ -537,7 +538,7 @@ describe('DelegationNode', () => {
 })
 
 describe('DelegationHierarchy', () => {
-  let ctypeHash: string
+  let ctypeHash: ICType['hash']
   let ROOT_IDENTIFIER: string
   let ROOT_SUCCESS: string
 

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -25,6 +25,8 @@
 
 import {
   DidVerificationKey,
+  IAttestation,
+  ICType,
   IDelegationHierarchyDetails,
   IDelegationNode,
   IDidDetails,
@@ -169,7 +171,7 @@ export class DelegationNode implements IDelegationNode {
    *
    * @returns The CType hash associated with the delegation hierarchy.
    */
-  public async getCTypeHash(): Promise<string> {
+  public async getCTypeHash(): Promise<ICType['hash']> {
     return this.getHierarchyDetails().then((details) => details.cTypeHash)
   }
 
@@ -222,7 +224,7 @@ export class DelegationNode implements IDelegationNode {
   public async getAttestations(): Promise<Attestation[]> {
     const attestationHashes = await this.getAttestationHashes()
     const attestations = await Promise.all(
-      attestationHashes.map((claimHash: string) => {
+      attestationHashes.map((claimHash) => {
         return queryAttestation(claimHash)
       })
     )
@@ -235,7 +237,9 @@ export class DelegationNode implements IDelegationNode {
    *
    * @returns Promise containing all attestation hashes attested with this node.
    */
-  public async getAttestationHashes(): Promise<string[]> {
+  public async getAttestationHashes(): Promise<
+    Array<IAttestation['claimHash']>
+  > {
     return getAttestationHashes(this.id)
   }
 

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -127,6 +127,7 @@ describe('Claim', () => {
     // build request for attestation with legitimations
     request = RequestForAttestation.fromClaim(claim)
 
+    // @ts-ignore
     invalidCostQuoteData = {
       cTypeHash: '0x12345678',
       cost: invalidCost,

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -24,6 +24,7 @@ import type {
   IQuoteAttesterSigned,
   KeystoreSigner,
   DidVerificationKey,
+  IRequestForAttestation,
 } from '@kiltprotocol/types'
 import { KeyRelationship } from '@kiltprotocol/types'
 import { Crypto, SDKErrors, JsonSchema } from '@kiltprotocol/utils'
@@ -179,7 +180,7 @@ export async function fromQuoteDataAndIdentity(
 
 export async function createQuoteAgreement(
   attesterSignedQuote: IQuoteAttesterSigned,
-  requestRootHash: string,
+  requestRootHash: IRequestForAttestation['rootHash'],
   attesterIdentity: IDidDetails['uri'],
   claimerIdentity: DidDetails,
   signer: KeystoreSigner,

--- a/packages/core/src/quote/Quote.utils.ts
+++ b/packages/core/src/quote/Quote.utils.ts
@@ -15,6 +15,7 @@ import type {
   CompressedQuote,
   CompressedQuoteAgreed,
   CompressedQuoteAttesterSigned,
+  DidPublicKey,
   DidSignature,
   ICostBreakdown,
   IQuote,
@@ -107,11 +108,13 @@ export function decompressQuote(quote: CompressedQuote): IQuote {
   }
 }
 
-function compressSignature(comp: DidSignature): [string, string] {
+function compressSignature(comp: DidSignature): [string, DidPublicKey['uri']] {
   return [comp.signature, comp.keyUri]
 }
 
-function decompressSignature(comp: [string, string]): DidSignature {
+function decompressSignature(
+  comp: [string, DidPublicKey['uri']]
+): DidSignature {
   return { signature: comp[0], keyUri: comp[1] }
 }
 

--- a/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
@@ -20,6 +20,7 @@ import type {
   CompressedRequestForAttestation,
   IRequestForAttestation,
   DidSignature,
+  DidUri,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 import { Attestation } from '../attestation/Attestation'
@@ -40,7 +41,7 @@ const rawCType: ICType['schema'] = {
 }
 
 function buildRequestForAttestation(
-  claimerDid: string,
+  claimerDid: DidUri,
   contents: IClaimContents,
   legitimations: Credential[]
 ): RequestForAttestation {
@@ -311,6 +312,7 @@ describe('RequestForAttestation', () => {
         []
       ),
     } as IRequestForAttestation
+    // @ts-ignore
     builtRequestMalformedRootHash.rootHash = [
       builtRequestMalformedRootHash.rootHash.slice(0, 15),
       (

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -26,7 +26,6 @@ import type {
   ICredential,
   KeystoreSigner,
   IDidResolver,
-  DidSignature,
   DidPublicKey,
   DidVerificationKey,
 } from '@kiltprotocol/types'
@@ -131,13 +130,13 @@ export class RequestForAttestation implements IRequestForAttestation {
     return true
   }
 
-  public claim: IClaim
-  public legitimations: Credential[]
-  public claimerSignature?: DidSignature & { challenge?: string }
-  public claimHashes: string[]
-  public claimNonceMap: Record<string, string>
-  public rootHash: Hash
-  public delegationId: IDelegationNode['id'] | null
+  public claim: IRequestForAttestation['claim']
+  public legitimations: IRequestForAttestation['legitimations']
+  public claimerSignature?: IRequestForAttestation['claimerSignature']
+  public claimHashes: IRequestForAttestation['claimHashes']
+  public claimNonceMap: IRequestForAttestation['claimNonceMap']
+  public rootHash: IRequestForAttestation['rootHash']
+  public delegationId: IRequestForAttestation['delegationId']
 
   /**
    * Builds a new [[RequestForAttestation]] instance.

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -36,7 +36,7 @@ import {
   DidSignature,
   DidVerificationKey,
   EncryptionKeyType,
-  IDidIdentifier,
+  DidIdentifier,
   IIdentity,
   KeyRelationship,
   KeystoreSigner,
@@ -105,7 +105,7 @@ interface IServiceEndpointChainRecordCodec extends Struct {
 // Query a full DID given the identifier (a KILT address for v1).
 // Interacts with the Did storage map.
 async function queryDidEncoded(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<Option<IDidChainRecordCodec>> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   return api.query.did.did<Option<IDidChainRecordCodec>>(didIdentifier)
@@ -125,7 +125,7 @@ async function queryDeletedDidsEncoded(): Promise<GenericAccountId[]> {
 // Query a DID service given the DID identifier and the service ID.
 // Interacts with the ServiceEndpoints storage double map.
 async function queryServiceEncoded(
-  didIdentifier: IDidIdentifier,
+  didIdentifier: DidIdentifier,
   serviceId: string
 ): Promise<Option<IServiceEndpointChainRecordCodec>> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
@@ -137,7 +137,7 @@ async function queryServiceEncoded(
 // Query all services for a DID given the DID identifier.
 // Interacts with the ServiceEndpoints storage double map.
 async function queryAllServicesEncoded(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<IServiceEndpointChainRecordCodec[]> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   const encodedEndpoints = await api.query.did.serviceEndpoints.entries<
@@ -149,7 +149,7 @@ async function queryAllServicesEncoded(
 // Query the # of services stored under a DID without fetching all the services.
 // Interacts with the DidEndpointsCount storage map.
 async function queryEndpointsCountsEncoded(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<u32> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   return api.query.did.didEndpointsCount<u32>(didIdentifier)
@@ -243,7 +243,7 @@ function decodeDidChainRecord(
 }
 
 export async function queryDetails(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<IDidChainRecordJSON | null> {
   const result = await queryDidEncoded(didIdentifier)
   if (result.isNone) {
@@ -253,7 +253,7 @@ export async function queryDetails(
 }
 
 export async function queryKey(
-  didIdentifier: IDidIdentifier,
+  didIdentifier: DidIdentifier,
   keyId: DidKey['id']
 ): Promise<DidKey | null> {
   const didDetails = await queryDetails(didIdentifier)
@@ -277,14 +277,14 @@ function decodeServiceChainRecord(
 }
 
 export async function queryServiceEndpoints(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<DidServiceEndpoint[]> {
   const encoded = await queryAllServicesEncoded(didIdentifier)
   return encoded.map((e) => decodeServiceChainRecord(e))
 }
 
 export async function queryServiceEndpoint(
-  didIdentifier: IDidIdentifier,
+  didIdentifier: DidIdentifier,
   serviceId: DidServiceEndpoint['id']
 ): Promise<DidServiceEndpoint | null> {
   const serviceEncoded = await queryServiceEncoded(didIdentifier, serviceId)
@@ -294,19 +294,19 @@ export async function queryServiceEndpoint(
 }
 
 export async function queryEndpointsCounts(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<BN> {
   const endpointsCountEncoded = await queryEndpointsCountsEncoded(didIdentifier)
   return endpointsCountEncoded.toBn()
 }
 
-export async function queryNonce(didIdentifier: IDidIdentifier): Promise<BN> {
+export async function queryNonce(didIdentifier: DidIdentifier): Promise<BN> {
   const encoded = await queryDidEncoded(didIdentifier)
   return encoded.isSome ? encoded.unwrap().lastTxCounter.toBn() : new BN(0)
 }
 
 export async function queryDidDeletionStatus(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<boolean> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   // The following function returns something different than 0x00 if there is an entry for the provided key, 0x00 otherwise.
@@ -322,7 +322,7 @@ export async function queryDepositAmount(): Promise<BN> {
   return encodedDeposit.toBn()
 }
 
-export async function queryDeletedDidIdentifiers(): Promise<IDidIdentifier[]> {
+export async function queryDeletedDidIdentifiers(): Promise<DidIdentifier[]> {
   const encodedIdentifiers = await queryDeletedDidsEncoded()
   return encodedIdentifiers.map((id) => id.toHuman())
 }
@@ -333,7 +333,7 @@ export type PublicKeyEnum = Record<string, Uint8Array>
 export type SignatureEnum = Record<string, Uint8Array>
 
 export type AuthorizeCallInput = {
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
   txCounter: AnyNumber
   call: Extrinsic
   submitter: IIdentity['address']
@@ -341,7 +341,7 @@ export type AuthorizeCallInput = {
 }
 
 interface IDidAuthorizedCallOperation extends Struct {
-  did: IDidIdentifier
+  did: DidIdentifier
   txCounter: u64
   call: Call
   submitter: GenericAccountId
@@ -571,7 +571,7 @@ export async function getDeleteDidExtrinsic(
 }
 
 export async function getReclaimDepositExtrinsic(
-  didIdentifier: IDidIdentifier,
+  didIdentifier: DidIdentifier,
   endpointsCount: BN
 ): Promise<SubmittableExtrinsic> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -15,7 +15,7 @@ import {
   DidVerificationKey,
   EncryptionKeyType,
   IDidDetails,
-  IDidIdentifier,
+  DidIdentifier,
   IDidResolver,
   NewDidKey,
   VerificationKeyRelationship,
@@ -55,7 +55,7 @@ export const defaultKeySelectionCallback = <T>(keys: T[]): Promise<T | null> =>
   Promise.resolve(keys[0] || null)
 
 export function getKiltDidFromIdentifier(
-  identifier: IDidIdentifier,
+  identifier: DidIdentifier,
   didType: 'full' | 'light',
   version?: number,
   encodedDetails?: string
@@ -76,7 +76,7 @@ export type IDidParsingResult = {
   did: IDidDetails['uri']
   version: number
   type: 'light' | 'full'
-  identifier: IDidIdentifier
+  identifier: DidIdentifier
   fragment?: string
   authKeyTypeEncoding?: string
   encodedDetails?: string
@@ -123,7 +123,7 @@ export function parseDidUri(didUri: string): IDidParsingResult {
 
 export function getIdentifierFromKiltDid(
   did: IDidDetails['uri']
-): IDidIdentifier {
+): DidIdentifier {
   return parseDidUri(did).identifier
 }
 

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
@@ -12,7 +12,7 @@ import type {
   DidEncryptionKey,
   KeystoreSigner,
   IIdentity,
-  IDidIdentifier,
+  DidIdentifier,
   DidVerificationKey,
   NewDidVerificationKey,
   NewDidEncryptionKey,
@@ -38,7 +38,7 @@ import { deriveChainKeyId } from './FullDidBuilder.utils.js'
 
 export type FullDidUpdateBuilderCreationDetails = {
   authenticationKey: DidVerificationKey
-  identifier: IDidIdentifier
+  identifier: DidIdentifier
   keyAgreementKeys?: DidEncryptionKey[]
   assertionKey?: DidVerificationKey
   delegationKey?: DidVerificationKey
@@ -55,7 +55,7 @@ export type FullDidUpdateCallback = (
  * A builder to batch multiple changes before a DID update.
  */
 export class FullDidUpdateBuilder extends FullDidBuilder {
-  protected identifier: IDidIdentifier
+  protected identifier: DidIdentifier
   protected uri: IDidDetails['uri']
   protected batch: Extrinsic[] = []
 

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -15,7 +15,7 @@ import {
   DidSignature,
   DidVerificationKey,
   IDidDetails,
-  IDidIdentifier,
+  DidIdentifier,
   KeystoreSigner,
   VerificationKeyType,
   KeyRelationship,
@@ -70,7 +70,7 @@ export abstract class DidDetails implements IDidDetails {
     this.serviceEndpoints = new Map(Object.entries(serviceEndpoints))
   }
 
-  public abstract get identifier(): IDidIdentifier
+  public abstract get identifier(): DidIdentifier
 
   /**
    * Returns the first authentication key of the DID.

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -10,7 +10,7 @@ import { BN } from '@polkadot/util'
 import {
   DidKey,
   DidServiceEndpoint,
-  IDidIdentifier,
+  DidIdentifier,
   KeyRelationship,
   VerificationKeyType,
   EncryptionKeyType,
@@ -91,7 +91,7 @@ jest.mock('../Did.chain.ts', () => {
   return {
     queryDetails: jest.fn(
       async (
-        didIdentifier: IDidIdentifier
+        didIdentifier: DidIdentifier
       ): Promise<IDidChainRecordJSON | null> => {
         if (didIdentifier === existingIdentifier) {
           return existingDidDetails
@@ -100,7 +100,7 @@ jest.mock('../Did.chain.ts', () => {
       }
     ),
     queryServiceEndpoints: jest.fn(
-      async (didIdentifier: IDidIdentifier): Promise<DidServiceEndpoint[]> => {
+      async (didIdentifier: DidIdentifier): Promise<DidServiceEndpoint[]> => {
         if (didIdentifier === existingIdentifier) {
           return existingServiceEndpoints
         }

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -11,7 +11,7 @@ import { BN } from '@polkadot/util'
 import type {
   DidVerificationKey,
   IDidDetails,
-  IDidIdentifier,
+  DidIdentifier,
   IIdentity,
   KeystoreSigner,
   SubmittableExtrinsic,
@@ -45,7 +45,7 @@ import {
 } from './FullDidDetails.utils.js'
 
 export class FullDidDetails extends DidDetails {
-  public readonly identifier: IDidIdentifier
+  public readonly identifier: DidIdentifier
 
   /**
    * Create an instance of [[FullDidDetails]] with the provided details.
@@ -65,7 +65,7 @@ export class FullDidDetails extends DidDetails {
     keys,
     keyRelationships,
     serviceEndpoints = {},
-  }: DidConstructorDetails & { identifier: IDidIdentifier }) {
+  }: DidConstructorDetails & { identifier: DidIdentifier }) {
     super({ uri, keys, keyRelationships, serviceEndpoints })
 
     this.identifier = identifier

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -10,6 +10,7 @@ import { Keyring } from '@polkadot/api'
 import {
   DidKey,
   DidServiceEndpoint,
+  DidUri,
   EncryptionKeyType,
   KeyRelationship,
   VerificationKeyType,
@@ -377,7 +378,7 @@ describe('When creating an instance from a URI', () => {
     const expectedLightDidDetails: LightDidDetails =
       LightDidDetails.fromDetails(creationOptions)
 
-    const uriWithFragment = `${expectedLightDidDetails.uri}#authentication`
+    const uriWithFragment: DidUri = `${expectedLightDidDetails.uri}#authentication`
 
     expect(() => LightDidDetails.fromUri(uriWithFragment, true)).toThrow()
     expect(() => LightDidDetails.fromUri(uriWithFragment, false)).not.toThrow()
@@ -400,6 +401,7 @@ describe('When creating an instance from a URI', () => {
       `did:kilt:light:00${validKiltAddress}:randomdetails`,
     ]
     incorrectURIs.forEach((uri) => {
+      // @ts-ignore
       expect(() => LightDidDetails.fromUri(uri)).toThrow()
     })
   })

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -9,7 +9,7 @@ import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
 
 import type {
   IDidDetails,
-  IDidIdentifier,
+  DidIdentifier,
   IIdentity,
   KeystoreSigner,
   DidUri,
@@ -51,10 +51,10 @@ const authenticationKeyId = 'authentication'
 const encryptionKeyId = 'encryption'
 
 export class LightDidDetails extends DidDetails {
-  public readonly identifier: IDidIdentifier
+  public readonly identifier: DidIdentifier
 
   private constructor(
-    identifier: IDidIdentifier,
+    identifier: DidIdentifier,
     {
       uri,
       keys,
@@ -204,7 +204,7 @@ export class LightDidDetails extends DidDetails {
    * @returns The resulting [[LightDidDetails]].
    */
   public static fromIdentifier(
-    identifier: IDidIdentifier,
+    identifier: DidIdentifier,
     keyType: LightDidSupportedVerificationKeyType = VerificationKeyType.Sr25519
   ): LightDidDetails {
     const authenticationKey: NewLightDidAuthenticationKey = {

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -12,6 +12,7 @@ import type {
   IDidIdentifier,
   IIdentity,
   KeystoreSigner,
+  DidUri,
 } from '@kiltprotocol/types'
 import { VerificationKeyType } from '@kiltprotocol/types'
 
@@ -109,7 +110,7 @@ export class LightDidDetails extends DidDetails {
 
     let uri = getKiltDidFromIdentifier(id, 'light', LIGHT_DID_LATEST_VERSION)
     if (encodedDetails) {
-      uri = uri.concat(':', encodedDetails)
+      uri = uri.concat(':', encodedDetails) as DidUri
     }
 
     // Authentication key always has the #authentication ID.

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -11,7 +11,7 @@ import {
   DidKey,
   DidServiceEndpoint,
   EncryptionKeyType,
-  IDidIdentifier,
+  DidIdentifier,
   NewDidVerificationKey,
   VerificationKeyType,
 } from '@kiltprotocol/types'
@@ -74,7 +74,7 @@ jest.mock('../Did.chain', () => {
   const queryDetails = jest.fn(
     async (
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      didIdentifier: IDidIdentifier
+      didIdentifier: DidIdentifier
     ): Promise<IDidChainRecordJSON | null> => {
       const authKey = generateAuthenticationKeyDetails()
       const encKey = generateEncryptionKeyDetails()
@@ -97,7 +97,7 @@ jest.mock('../Did.chain', () => {
   )
   const queryKey = jest.fn(
     async (
-      didIdentifier: IDidIdentifier,
+      didIdentifier: DidIdentifier,
       keyId: DidKey['id']
     ): Promise<DidKey | null> => {
       const details = await queryDetails(didIdentifier)
@@ -106,13 +106,13 @@ jest.mock('../Did.chain', () => {
   )
   const queryServiceEndpoint = jest.fn(
     async (
-      didIdentifier: IDidIdentifier,
+      didIdentifier: DidIdentifier,
       serviceId: DidServiceEndpoint['id']
     ): Promise<DidServiceEndpoint | null> =>
       generateServiceEndpointDetails(serviceId)
   )
   const queryServiceEndpoints = jest.fn(
-    async (didIdentifier: IDidIdentifier): Promise<DidServiceEndpoint[]> => {
+    async (didIdentifier: DidIdentifier): Promise<DidServiceEndpoint[]> => {
       return [
         (await queryServiceEndpoint(
           didIdentifier,

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -163,17 +163,17 @@ export async function resolveKey(
 /**
  * Resolve a DID service URI to the service details.
  *
- * @param didUri The DID service URI.
+ * @param serviceUri The DID service URI.
  * @returns The details associated with the service endpoint.
  */
 export async function resolveServiceEndpoint(
-  didUri: DidPublicServiceEndpoint['uri']
+  serviceUri: DidPublicServiceEndpoint['uri']
 ): Promise<ResolvedDidServiceEndpoint | null> {
-  const { identifier, fragment: serviceId, type } = parseDidUri(didUri)
+  const { identifier, fragment: serviceId, type, did } = parseDidUri(serviceUri)
 
   // A fragment (serviceId) IS expected to resolve a service endpoint.
   if (!serviceId) {
-    throw SDKErrors.ERROR_INVALID_DID_FORMAT(didUri)
+    throw SDKErrors.ERROR_INVALID_DID_FORMAT(serviceUri)
   }
 
   switch (type) {
@@ -183,28 +183,28 @@ export async function resolveServiceEndpoint(
         return null
       }
       return {
-        uri: didUri,
+        uri: serviceUri,
         type: serviceEndpoint.types,
         serviceEndpoint: serviceEndpoint.urls,
       }
     }
     case 'light': {
-      const resolvedDetails = await resolveDoc(didUri)
+      const resolvedDetails = await resolveDoc(did)
       if (!resolvedDetails) {
-        throw SDKErrors.ERROR_INVALID_DID_FORMAT(didUri)
+        throw SDKErrors.ERROR_INVALID_DID_FORMAT(serviceUri)
       }
       const serviceEndpoint = resolvedDetails.details?.getEndpoint(serviceId)
       if (!serviceEndpoint) {
         return null
       }
       return {
-        uri: didUri,
+        uri: serviceUri,
         type: serviceEndpoint.types,
         serviceEndpoint: serviceEndpoint.urls,
       }
     }
     default:
-      throw SDKErrors.ERROR_UNSUPPORTED_DID(didUri)
+      throw SDKErrors.ERROR_UNSUPPORTED_DID(did)
   }
 }
 
@@ -219,12 +219,12 @@ export async function resolve(
 ): Promise<
   DidResolvedDetails | ResolvedDidKey | ResolvedDidServiceEndpoint | null
 > {
-  const { fragment } = parseDidUri(didUri)
+  const { fragment, did } = parseDidUri(didUri)
 
   if (fragment) {
     return resolveKey(didUri) || resolveServiceEndpoint(didUri) || null
   }
-  return resolveDoc(didUri)
+  return resolveDoc(did)
 }
 
 export const DidResolver: IDidResolver = {

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -9,6 +9,7 @@ import {
   DidPublicKey,
   DidPublicServiceEndpoint,
   DidResolvedDetails,
+  DidResourceUri,
   IDidDetails,
   IDidResolver,
   ResolvedDidKey,
@@ -222,7 +223,11 @@ export async function resolve(
   const { fragment, did } = parseDidUri(didUri)
 
   if (fragment) {
-    return resolveKey(didUri) || resolveServiceEndpoint(didUri) || null
+    return (
+      resolveKey(didUri as DidResourceUri) ||
+      resolveServiceEndpoint(didUri as DidResourceUri) ||
+      null
+    )
   }
   return resolveDoc(did)
 }

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -22,6 +22,8 @@ import {
   VerificationKeyType,
   EncryptionKeyType,
   DidUri,
+  DidPublicKey,
+  DidResourceUri,
 } from '@kiltprotocol/types'
 
 import type { IDidChainRecordJSON } from '../Did.chain'
@@ -196,7 +198,7 @@ describe('When resolving a key', () => {
       identifierWithAuthenticationKey,
       'full'
     )
-    const keyIdUri = `${fullDid}#auth`
+    const keyIdUri: DidPublicKey['uri'] = `${fullDid}#auth`
 
     await expect(
       DidResolver.resolveKey(keyIdUri)
@@ -210,7 +212,7 @@ describe('When resolving a key', () => {
 
   it('returns null if either the DID or the key do not exist', async () => {
     const deletedFullDid = getKiltDidFromIdentifier(deletedIdentifier, 'full')
-    let keyIdUri = `${deletedFullDid}#enc`
+    let keyIdUri: DidPublicKey['uri'] = `${deletedFullDid}#enc`
 
     await expect(DidResolver.resolveKey(keyIdUri)).resolves.toBeNull()
 
@@ -228,9 +230,11 @@ describe('When resolving a key', () => {
       deletedIdentifier,
       'full'
     )
+    // @ts-ignore
     await expect(DidResolver.resolveKey(uriWithoutFragment)).rejects.toThrow()
 
     const invalidUri = 'invalid-uri'
+    // @ts-ignore
     await expect(DidResolver.resolveKey(invalidUri)).rejects.toThrow()
   })
 })
@@ -241,7 +245,7 @@ describe('When resolving a service endpoint', () => {
       identifierWithServiceEndpoints,
       'full'
     )
-    const serviceIdUri = `${fullDid}#service-1`
+    const serviceIdUri: DidResourceUri = `${fullDid}#service-1`
 
     await expect(
       DidResolver.resolveServiceEndpoint(serviceIdUri)
@@ -254,7 +258,7 @@ describe('When resolving a service endpoint', () => {
 
   it('returns null if either the DID or the service do not exist', async () => {
     const deletedFullDid = getKiltDidFromIdentifier(deletedIdentifier, 'full')
-    let serviceIdUri = `${deletedFullDid}#service-1`
+    let serviceIdUri: DidResourceUri = `${deletedFullDid}#service-1`
 
     await expect(
       DidResolver.resolveServiceEndpoint(serviceIdUri)
@@ -272,16 +276,18 @@ describe('When resolving a service endpoint', () => {
   })
 
   it('throws for invalid URIs', async () => {
-    const uriWithoutFragment = getKiltDidFromIdentifier(
+    const uriWithoutFragment: DidUri = getKiltDidFromIdentifier(
       deletedIdentifier,
       'full'
     )
     await expect(
+      // @ts-ignore
       DidResolver.resolveServiceEndpoint(uriWithoutFragment)
     ).rejects.toThrow()
 
     const invalidUri = 'invalid-uri'
     await expect(
+      // @ts-ignore
       DidResolver.resolveServiceEndpoint(invalidUri)
     ).rejects.toThrow()
   })

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -15,7 +15,7 @@ import {
   DidResolvedDetails,
   DidServiceEndpoint,
   IDidDetails,
-  IDidIdentifier,
+  DidIdentifier,
   KeyringPair,
   ResolvedDidKey,
   ResolvedDidServiceEndpoint,
@@ -87,7 +87,7 @@ function generateServiceEndpointDetails(serviceId: string): DidServiceEndpoint {
 jest.mock('../Did.chain', () => {
   const queryDetails = jest.fn(
     async (
-      didIdentifier: IDidIdentifier
+      didIdentifier: DidIdentifier
     ): Promise<IDidChainRecordJSON | null> => {
       const authKey = generateAuthenticationKeyDetails()
       const encKey = generateEncryptionKeyDetails()
@@ -137,7 +137,7 @@ jest.mock('../Did.chain', () => {
   )
   const queryKey = jest.fn(
     async (
-      didIdentifier: IDidIdentifier,
+      didIdentifier: DidIdentifier,
       keyId: DidKey['id']
     ): Promise<DidKey | null> => {
       const details = await queryDetails(didIdentifier)
@@ -146,7 +146,7 @@ jest.mock('../Did.chain', () => {
   )
   const queryServiceEndpoint = jest.fn(
     async (
-      didIdentifier: IDidIdentifier,
+      didIdentifier: DidIdentifier,
       serviceId: DidServiceEndpoint['id']
     ): Promise<DidServiceEndpoint | null> => {
       switch (didIdentifier) {
@@ -158,7 +158,7 @@ jest.mock('../Did.chain', () => {
     }
   )
   const queryServiceEndpoints = jest.fn(
-    async (didIdentifier: IDidIdentifier): Promise<DidServiceEndpoint[]> => {
+    async (didIdentifier: DidIdentifier): Promise<DidServiceEndpoint[]> => {
       switch (didIdentifier) {
         case identifierWithServiceEndpoints:
           return [
@@ -177,7 +177,7 @@ jest.mock('../Did.chain', () => {
     }
   )
   const queryDidDeletionStatus = jest.fn(
-    async (didIdentifier: IDidIdentifier): Promise<boolean> => {
+    async (didIdentifier: DidIdentifier): Promise<boolean> => {
       return didIdentifier === deletedIdentifier
     }
   )
@@ -517,7 +517,7 @@ describe('When resolving a light DID', () => {
         'full'
       ),
     })
-    expect(details?.uri).toStrictEqual<IDidIdentifier>(migratedDid)
+    expect(details?.uri).toStrictEqual<DidIdentifier>(migratedDid)
     expect(details?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -21,6 +21,7 @@ import {
   ResolvedDidServiceEndpoint,
   VerificationKeyType,
   EncryptionKeyType,
+  DidUri,
 } from '@kiltprotocol/types'
 
 import type { IDidChainRecordJSON } from '../Did.chain'
@@ -406,7 +407,7 @@ describe('When resolving a full DID', () => {
       identifierWithAuthenticationKey,
       'full'
     )
-    const keyIdUri = `${fullDidWithAuthenticationKey}#auth`
+    const keyIdUri: DidUri = `${fullDidWithAuthenticationKey}#auth`
     const { details, metadata } = (await DidResolver.resolveDoc(
       keyIdUri
     )) as DidResolvedDetails
@@ -548,7 +549,7 @@ describe('When resolving a light DID', () => {
         type: VerificationKeyType.Sr25519,
       },
     })
-    const keyIdUri = `${lightDid.uri}#auth`
+    const keyIdUri: DidUri = `${lightDid.uri}#auth`
     const { details, metadata } = (await DidResolver.resolveDoc(
       keyIdUri
     )) as DidResolvedDetails

--- a/packages/did/src/Web3Names/Web3Names.chain.ts
+++ b/packages/did/src/Web3Names/Web3Names.chain.ts
@@ -7,7 +7,7 @@
 
 import {
   SubmittableExtrinsic,
-  IDidIdentifier,
+  DidIdentifier,
   Deposit,
   IDidDetails,
 } from '@kiltprotocol/types'
@@ -24,7 +24,7 @@ import { Utils as DidUtils } from '../index.js'
  * Web3NameOwner is a private interface for parsing the owner infos of a Web3Name from the on-chain format.
  */
 interface Web3NameOwner extends Struct {
-  owner: IDidIdentifier
+  owner: DidIdentifier
   claimedAt: AnyNumber
   deposit: Deposit
 }
@@ -77,7 +77,7 @@ export async function getReclaimDepositTx(
  * @returns The registered web3name for this DID if any.
  */
 export async function queryWeb3NameForDidIdentifier(
-  didIdentifier: IDidIdentifier
+  didIdentifier: DidIdentifier
 ): Promise<Web3Name | null> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const encoded = await blockchain.api.query.web3Names.names<Option<Bytes>>(
@@ -95,7 +95,7 @@ export async function queryWeb3NameForDidIdentifier(
  */
 export async function queryDidIdentifierForWeb3Name(
   name: Web3Name
-): Promise<IDidIdentifier | null> {
+): Promise<DidIdentifier | null> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   const encoded = await blockchain.api.query.web3Names.owner<
     Option<Web3NameOwner>

--- a/packages/did/src/types.ts
+++ b/packages/did/src/types.ts
@@ -9,7 +9,7 @@ import type {
   DidKey,
   DidServiceEndpoint,
   IDidDetails,
-  IDidIdentifier,
+  DidIdentifier,
   KeyRelationship,
   NewDidEncryptionKey,
   NewDidVerificationKey,
@@ -48,7 +48,7 @@ export type DidConstructorDetails = {
 }
 
 export type FullDidCreationDetails = {
-  identifier: IDidIdentifier
+  identifier: DidIdentifier
   authenticationKey: NewDidVerificationKey
   keyAgreementKeys?: NewDidEncryptionKey[]
   assertionKey?: NewDidVerificationKey

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -13,6 +13,7 @@ import {
   DidKey,
   DidPublicKey,
   DidResolvedDetails,
+  DidUri,
   EncryptionKeyType,
   ICredential,
   IDidDetails,
@@ -87,14 +88,14 @@ const resolveDoc = async (
   return null
 }
 const resolveKey = async (
-  did: DidPublicKey['uri']
+  keyUri: DidPublicKey['uri']
 ): Promise<ResolvedDidKey | null> => {
-  const { fragment } = DidUtils.parseDidUri(did)
-  const { details } = (await resolveDoc(did)) as DidResolvedDetails
+  const { fragment, did } = DidUtils.parseDidUri(keyUri)
+  const { details } = (await resolveDoc(did as DidUri)) as DidResolvedDetails
   const key = details?.getKey(fragment!) as DidKey
   return {
     controller: details!.uri,
-    uri: did,
+    uri: keyUri,
     publicKey: key.publicKey,
     type: key.type,
   }
@@ -108,7 +109,7 @@ const mockResolver = {
   ): Promise<
     DidResolvedDetails | ResolvedDidKey | ResolvedDidServiceEndpoint | null
   > => {
-    return (await resolveKey(didUri)) || resolveDoc(didUri)
+    return (await resolveKey(didUri)) || resolveDoc(didUri as DidUri)
   },
 } as IDidResolver
 

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -13,6 +13,7 @@ import {
   DidKey,
   DidPublicKey,
   DidResolvedDetails,
+  DidResourceUri,
   DidUri,
   EncryptionKeyType,
   ICredential,
@@ -109,7 +110,10 @@ const mockResolver = {
   ): Promise<
     DidResolvedDetails | ResolvedDidKey | ResolvedDidServiceEndpoint | null
   > => {
-    return (await resolveKey(didUri)) || resolveDoc(didUri as DidUri)
+    return (
+      (await resolveKey(didUri as DidResourceUri)) ||
+      resolveDoc(didUri as DidUri)
+    )
   },
 } as IDidResolver
 

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -189,7 +189,7 @@ describe('Messaging', () => {
       {
         type: Message.BodyType.REQUEST_CREDENTIAL,
         content: {
-          cTypes: [{ cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}` }],
+          cTypes: [{ cTypeHash: `${Crypto.hashStr('0x12345678')}` }],
         },
       },
       aliceLightDid.uri,
@@ -255,7 +255,7 @@ describe('Messaging', () => {
 
   it('verifies the message with sender is the owner (as full DID)', async () => {
     const content = RequestForAttestation.fromClaim({
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: `${Crypto.hashStr('0x12345678')}`,
       owner: aliceFullDid.uri,
       contents: {},
     })
@@ -263,7 +263,7 @@ describe('Messaging', () => {
 
     const quoteData: IQuote = {
       attesterDid: bobFullDid.uri,
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: `${Crypto.hashStr('0x12345678')}`,
       cost: {
         tax: { vat: 3.3 },
         net: 23.4,
@@ -321,7 +321,7 @@ describe('Messaging', () => {
     const attestation = {
       delegationId: null,
       claimHash: requestAttestationBody.content.requestForAttestation.rootHash,
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: Crypto.hashStr('0x12345678'),
       owner: bobFullDid.uri,
       revoked: false,
     }
@@ -391,7 +391,7 @@ describe('Messaging', () => {
   it('verifies the message with sender is the owner (as light DID)', async () => {
     // Create request for attestation to the light DID with no encoded details
     const content = RequestForAttestation.fromClaim({
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: `${Crypto.hashStr('0x12345678')}`,
       owner: aliceLightDid.uri,
       contents: {},
     })
@@ -399,7 +399,7 @@ describe('Messaging', () => {
     const date: string = new Date(2019, 11, 10).toISOString()
     const quoteData: IQuote = {
       attesterDid: bobLightDid.uri,
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: `${Crypto.hashStr('0x12345678')}`,
       cost: {
         tax: { vat: 3.3 },
         net: 23.4,
@@ -434,14 +434,14 @@ describe('Messaging', () => {
 
     // Create request for attestation to the light DID with encoded details
     const contentWithEncodedDetails = RequestForAttestation.fromClaim({
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: `${Crypto.hashStr('0x12345678')}`,
       owner: aliceLightDidWithDetails.uri,
       contents: {},
     })
 
     const quoteDataEncodedDetails: IQuote = {
       attesterDid: bobLightDidWithDetails.uri,
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: `${Crypto.hashStr('0x12345678')}`,
       cost: {
         tax: { vat: 3.3 },
         net: 23.4,
@@ -521,7 +521,7 @@ describe('Messaging', () => {
     const attestation = {
       delegationId: null,
       claimHash: requestAttestationBody.content.requestForAttestation.rootHash,
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: Crypto.hashStr('0x12345678'),
       owner: bobLightDid.uri,
       revoked: false,
     }
@@ -536,7 +536,7 @@ describe('Messaging', () => {
     const attestationWithEncodedDetails = {
       delegationId: null,
       claimHash: requestAttestationBody.content.requestForAttestation.rootHash,
-      cTypeHash: `kilt:ctype:${Crypto.hashStr('0x12345678')}`,
+      cTypeHash: Crypto.hashStr('0x12345678'),
       owner: bobLightDidWithDetails.uri,
       revoked: false,
     }

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -74,6 +74,7 @@ import type {
   DidPublicKey,
   ResolvedDidKey,
   DidUri,
+  DidResourceUri,
 } from '@kiltprotocol/types'
 import { SDKErrors, Crypto } from '@kiltprotocol/utils'
 import {
@@ -296,7 +297,7 @@ describe('Messaging Utilities', () => {
       resolveDoc,
       resolveKey,
       resolve: async (did: string) => {
-        return resolveKey(did) || resolveDoc(did as DidUri)
+        return resolveKey(did as DidResourceUri) || resolveDoc(did as DidUri)
       },
     } as IDidResolver
 

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -73,6 +73,7 @@ import type {
   DidResolvedDetails,
   DidPublicKey,
   ResolvedDidKey,
+  DidUri,
 } from '@kiltprotocol/types'
 import { SDKErrors, Crypto } from '@kiltprotocol/utils'
 import {
@@ -295,7 +296,7 @@ describe('Messaging Utilities', () => {
       resolveDoc,
       resolveKey,
       resolve: async (did: string) => {
-        return resolveKey(did) || resolveDoc(did)
+        return resolveKey(did) || resolveDoc(did as DidUri)
       },
     } as IDidResolver
 
@@ -1056,16 +1057,19 @@ describe('Messaging Utilities', () => {
     expect(() =>
       MessageUtils.errorCheckMessage(messageRequestTerms)
     ).toThrowErrorWithCode(SDKErrors.ERROR_INVALID_DID_FORMAT(''))
+    // @ts-ignore
     messageSubmitTerms.sender = 'this is not a sender did'
     expect(() =>
       MessageUtils.errorCheckMessage(messageSubmitTerms)
     ).toThrowErrorWithCode(SDKErrors.ERROR_INVALID_DID_FORMAT(''))
+    // @ts-ignore
     messageRejectTerms.sender = 'this is not a sender address'
     expect(() =>
       MessageUtils.errorCheckMessage(messageRejectTerms)
     ).toThrowErrorWithCode(SDKErrors.ERROR_INVALID_DID_FORMAT(''))
   })
   it('error check should throw errors on faulty bodies', () => {
+    // @ts-ignore
     requestTermsBody.content.cTypeHash = 'this is not a ctype hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestTermsBody)
@@ -1086,20 +1090,24 @@ describe('Messaging Utilities', () => {
     ).toThrowErrorWithCode(SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED())
     requestAttestationBody.content.requestForAttestation.claimerSignature = {
       signature: 'this is not the claimers signature',
+      // @ts-ignore
       keyUri: 'this is not a key id',
     }
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestAttestationBody)
     ).toThrowError()
+    // @ts-ignore
     submitAttestationBody.content.attestation.claimHash =
       'this is not the claim hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitAttestationBody)
     ).toThrowErrorWithCode(SDKErrors.ERROR_HASH_MALFORMED())
+    // @ts-ignore
     rejectAttestationForClaimBody.content = 'this is not the root hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectAttestationForClaimBody)
     ).toThrowErrorWithCode(SDKErrors.ERROR_HASH_MALFORMED())
+    // @ts-ignore
     requestCredentialBody.content.cTypes[0].cTypeHash =
       'this is not a cTypeHash'
     expect(() =>
@@ -1110,6 +1118,7 @@ describe('Messaging Utilities', () => {
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitCredentialBody)
     ).toThrowError(SDKErrors.ERROR_REVOCATION_BIT_MISSING())
+    // @ts-ignore
     acceptCredentialBody.content[0] = 'this is not a cTypeHash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(acceptCredentialBody)
@@ -1119,6 +1128,7 @@ describe('Messaging Utilities', () => {
         'accept credential message ctype hash invalid'
       )
     )
+    // @ts-ignore
     rejectCredentialBody.content[0] = 'this is not a cTypeHash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectCredentialBody)
@@ -1132,6 +1142,7 @@ describe('Messaging Utilities', () => {
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestAcceptDelegationBody)
     ).toThrowErrorWithCode(SDKErrors.ERROR_SIGNATURE_DATA_TYPE())
+    // @ts-ignore
     submitAcceptDelegationBody.content.signatures.invitee.keyUri =
       'this is not a key id'
     expect(() =>

--- a/packages/types/src/Attestation.ts
+++ b/packages/types/src/Attestation.ts
@@ -12,9 +12,10 @@
 import type { IDidDetails } from './DidDetails'
 import type { ICType } from './CType'
 import type { IDelegationNode } from './Delegation'
+import type { IRequestForAttestation } from './RequestForAttestation'
 
 export interface IAttestation {
-  claimHash: string
+  claimHash: IRequestForAttestation['rootHash']
   cTypeHash: ICType['hash']
   owner: IDidDetails['uri']
   delegationId: IDelegationNode['id'] | null

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -5,6 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import type { HexString } from '@polkadot/util/types'
 import type { IDidDetails } from './DidDetails'
 
 /**
@@ -34,7 +35,7 @@ export interface ICTypeSchema {
 export type CTypeSchemaWithoutId = Omit<ICTypeSchema, '$id'>
 
 export interface ICType {
-  hash: string
+  hash: HexString
   owner: IDidDetails['uri'] | null
   schema: ICTypeSchema
 }

--- a/packages/types/src/CTypeMetadata.ts
+++ b/packages/types/src/CTypeMetadata.ts
@@ -5,6 +5,8 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import type { HexString } from '@polkadot/util/types'
+
 /**
  * @packageDocumentation
  * @module ICTypeMetadata
@@ -34,5 +36,5 @@ export interface IMetadata {
 
 export interface ICTypeMetadata {
   metadata: IMetadata
-  ctypeHash: string | null
+  ctypeHash: HexString | null
 }

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -11,9 +11,16 @@ import type { DidPublicKey } from './DidDocumentExporter'
 import type { IIdentity } from './Identity'
 
 /**
- * A DID identifier, e.g., 4nvZhWv71x8reD9gq7BUGYQQVvTiThnLpTTanyru9XckaeWa.
+ * A KILT DID identifier, e.g., 4nvZhWv71x8reD9gq7BUGYQQVvTiThnLpTTanyru9XckaeWa.
  */
-export type IDidIdentifier = IIdentity['address']
+export type IDidIdentifier =
+  | IIdentity['address']
+  | `light:00${IIdentity['address']}${string}`
+
+/**
+ * A string containing a KILT DID Uri.
+ */
+export type DidUri = `did:kilt:${IDidIdentifier}`
 
 /**
  * DID keys are purpose-bound. Their role or purpose is indicated by the verification or key relationship type.
@@ -130,7 +137,7 @@ export interface IDidDetails {
   /**
    * The decentralized identifier (DID) to which the remaining info pertains.
    */
-  uri: string
+  uri: DidUri
   /**
    * Retrieves a particular public key record via its id.
    *

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -13,14 +13,14 @@ import type { IIdentity } from './Identity'
 /**
  * A KILT DID identifier, e.g., 4nvZhWv71x8reD9gq7BUGYQQVvTiThnLpTTanyru9XckaeWa.
  */
-export type IDidIdentifier =
+export type DidIdentifier =
   | IIdentity['address']
   | `light:00${IIdentity['address']}${string}`
 
 /**
  * A string containing a KILT DID Uri.
  */
-export type DidUri = `did:kilt:${IDidIdentifier}`
+export type DidUri = `did:kilt:${DidIdentifier}`
 
 /**
  * DID keys are purpose-bound. Their role or purpose is indicated by the verification or key relationship type.

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -15,6 +15,7 @@ import {
   DidServiceEndpoint,
   VerificationKeyType,
   EncryptionKeyType,
+  DidUri,
 } from './DidDetails.js'
 
 export enum DidDocumentPublicKeyType {
@@ -45,13 +46,18 @@ export const EncryptionKeyTypesMap: Record<
 }
 
 /**
+ * URI for DID resources like public keys or service endpoints.
+ */
+export type DidResourceUri = `${DidUri}#${string}`
+
+/**
  * A spec-compliant description of a DID key.
  */
 export type DidPublicKey = {
   /**
    * The full key URI, in the form of <did_subject>#<key_identifier>.
    */
-  uri: string
+  uri: DidResourceUri
   /**
    * The key controller, in the form of <did_subject>.
    */
@@ -73,7 +79,7 @@ export type DidPublicServiceEndpoint = {
   /**
    * The full service URI, in the form of <did_subject>#<service_identifier>.
    */
-  uri: string
+  uri: DidResourceUri
   /**
    * The set of types for this endpoint.
    */

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ICType } from './CType'
-import type { DidSignature } from './DidDetails'
+import type { DidSignature, IDidDetails } from './DidDetails'
 
 export interface ICostBreakdown {
   tax: Record<string, unknown>
@@ -19,7 +19,7 @@ export interface ICostBreakdown {
   gross: number
 }
 export interface IQuote {
-  attesterDid: string
+  attesterDid: IDidDetails['uri']
   cTypeHash: ICType['hash']
   cost: ICostBreakdown
   currency: string

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -12,6 +12,7 @@
 
 import type { ICType } from './CType'
 import type { DidSignature, IDidDetails } from './DidDetails'
+import type { IRequestForAttestation } from './RequestForAttestation'
 
 export interface ICostBreakdown {
   tax: Record<string, unknown>
@@ -31,7 +32,7 @@ export interface IQuoteAttesterSigned extends IQuote {
 }
 
 export interface IQuoteAgreement extends IQuoteAttesterSigned {
-  rootHash: string
+  rootHash: IRequestForAttestation['rootHash']
   claimerSignature: DidSignature
 }
 

--- a/packages/types/src/RequestForAttestation.ts
+++ b/packages/types/src/RequestForAttestation.ts
@@ -10,12 +10,13 @@
  * @module IRequestForAttestation
  */
 
+import type { HexString } from '@polkadot/util/types'
 import type { DidSignature } from './DidDetails'
 import type { ICredential, CompressedCredential } from './Credential'
 import type { IClaim, CompressedClaim } from './Claim'
 import type { IDelegationNode } from './Delegation'
 
-export type Hash = string
+export type Hash = HexString
 
 export type NonceHash = {
   hash: Hash

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -30,6 +30,7 @@ import { naclDecrypt } from '@polkadot/util-crypto/nacl/decrypt'
 import { naclEncrypt } from '@polkadot/util-crypto/nacl/encrypt'
 import nacl from 'tweetnacl'
 import { v4 as uuid } from 'uuid'
+import type { HexString } from '@polkadot/util/types'
 import jsonabc from './jsonabc.cjs'
 
 export { encodeAddress, decodeAddress, u8aToHex, u8aConcat }
@@ -221,7 +222,7 @@ export function hash(value: CryptoInput, bitLength?: BitLength): Uint8Array {
  * @param value Value to be hashed.
  * @returns Blake2b hash as hex string.
  */
-export function hashStr(value: CryptoInput): string {
+export function hashStr(value: CryptoInput): HexString {
   return u8aToHex(hash(value))
 }
 
@@ -258,7 +259,7 @@ export function encodeObjectAsStr(
 export function hashObjectAsStr(
   value: Record<string, any> | string | number | boolean,
   nonce?: string
-): string {
+): HexString {
   let objectAsStr = encodeObjectAsStr(value)
   if (nonce) {
     objectAsStr = nonce + objectAsStr
@@ -359,7 +360,7 @@ export function decryptAsymmetricAsStr(
  * @returns String representation of hash.
  */
 export interface Hasher {
-  (value: string, nonce?: string): string
+  (value: string, nonce?: string): HexString
 }
 
 /**
@@ -396,9 +397,9 @@ export function hashStatements(
   statements: string[],
   options: HashingOptions = {}
 ): Array<{
-  digest: string
+  digest: HexString
   statement: string
-  saltedHash: string
+  saltedHash: HexString
   nonce: string
 }> {
   // apply defaults

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -11,6 +11,7 @@
 
 import {
   DidDocumentPublicKeyType,
+  DidPublicKey,
   DidUri,
   IRequestForAttestation,
 } from '@kiltprotocol/types'
@@ -205,7 +206,7 @@ describe('proofs', () => {
   let documentLoader: DocumentLoader
   beforeAll(() => {
     VC = toVC.fromCredential(credential)
-    const keyId: string = VC.proof[0].verificationMethod
+    const keyId: DidPublicKey['uri'] = VC.proof[0].verificationMethod
     const verificationMethod: IPublicKeyRecord = {
       uri: keyId,
       type: DidDocumentPublicKeyType.Ed25519VerificationKey,

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -11,6 +11,7 @@
 
 import {
   DidDocumentPublicKeyType,
+  DidUri,
   IRequestForAttestation,
 } from '@kiltprotocol/types'
 import { Attestation, Credential, CType } from '@kiltprotocol/core'
@@ -211,7 +212,7 @@ describe('proofs', () => {
       publicKeyBase58: base58Encode(
         Crypto.decodeAddress(DidUtils.parseDidUri(keyId).identifier)
       ),
-      controller: VC.credentialSubject['@id'] as string,
+      controller: VC.credentialSubject['@id'] as DidUri,
     }
     documentLoader = (url) => {
       if (url === keyId) {

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -14,6 +14,7 @@ import { isHex } from '@polkadot/util'
 import type { AnyJson } from '@polkadot/types/types'
 import { ClaimUtils } from '@kiltprotocol/core'
 import type { ICredential, ICType } from '@kiltprotocol/types'
+import type { HexString } from '@polkadot/util/types'
 import {
   DEFAULT_VERIFIABLECREDENTIAL_CONTEXT,
   DEFAULT_VERIFIABLECREDENTIAL_TYPE,
@@ -34,7 +35,7 @@ import type {
   VerifiableCredential,
 } from './types.js'
 
-export function fromCredentialIRI(credentialId: string): string {
+export function fromCredentialIRI(credentialId: string): HexString {
   const hexString = credentialId.startsWith(KILT_CREDENTIAL_IRI_PREFIX)
     ? credentialId.substring(KILT_CREDENTIAL_IRI_PREFIX.length)
     : credentialId

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
@@ -15,7 +15,7 @@ import jsonld from 'jsonld'
 
 import { base58Encode, randomAsHex } from '@polkadot/util-crypto'
 
-import { DidDocumentPublicKeyType } from '@kiltprotocol/types'
+import { DidDocumentPublicKeyType, DidPublicKey } from '@kiltprotocol/types'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import { Crypto } from '@kiltprotocol/utils'
 
@@ -44,27 +44,27 @@ beforeAll(async () => {
     }
     return false
   })
-  documentLoader = async (url) => {
-    if (url.startsWith('did:kilt:')) {
-      const { identifier, fragment, did } = DidUtils.parseDidUri(url)
+  documentLoader = async (uri) => {
+    if (uri.startsWith('did:kilt:')) {
+      const { identifier, fragment, did } = DidUtils.parseDidUri(uri)
       const key: IPublicKeyRecord = {
-        uri: url,
+        uri: uri as DidPublicKey['uri'],
         publicKeyBase58: base58Encode(Crypto.decodeAddress(identifier)),
         controller: did,
         type: DidDocumentPublicKeyType.Ed25519VerificationKey,
       }
       if (fragment) {
-        return { documentUrl: url, document: key }
+        return { documentUrl: uri, document: key }
       }
       return {
-        documentUrl: url,
+        documentUrl: uri,
         document: {
           id: did,
           verificationMethod: [key],
         },
       }
     }
-    return kiltDocumentLoader(url)
+    return kiltDocumentLoader(uri)
   }
 })
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1878

Introduces typings for a number of strings with fixed patterns, such as did uris (`did:kilt:...`) did resource uris (`did:kilt:...#...`) and hex representations of hashes etc (`0x...`)

## How to test:

Check that it does not break anything.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
