### PR TITLE
hotfix: cherry pick integration test fix for scheduled runs

### DIFF
--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -11,7 +11,6 @@
 
 import type { ICredential, IClaim, KeyringPair } from '@kiltprotocol/types'
 import { DemoKeystore, FullDidDetails } from '@kiltprotocol/did'
-import { BN } from '@polkadot/util'
 import { Crypto } from '@kiltprotocol/utils'
 import { Attestation } from '../attestation/Attestation'
 import { getRevokeTx, getRemoveTx } from '../attestation/Attestation.chain'
@@ -49,9 +48,7 @@ beforeAll(async () => {
 
 it('fetches the correct deposit amount', async () => {
   const depositAmount = await Attestation.queryDepositAmount()
-  expect(depositAmount.toString()).toStrictEqual(
-    new BN(134900000000000).toString()
-  )
+  expect(depositAmount.toString()).toMatchInlineSnapshot('"120900000000000"')
 })
 
 describe('handling attestations that do not exist', () => {

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -13,7 +13,6 @@ import type { ICType, IDelegationNode, KeyringPair } from '@kiltprotocol/types'
 import { Permission } from '@kiltprotocol/types'
 import { DemoKeystore, FullDidDetails } from '@kiltprotocol/did'
 import { randomAsHex } from '@polkadot/util-crypto'
-import { BN } from '@polkadot/util'
 import { Attestation } from '../attestation/Attestation'
 import { Claim } from '../claim/Claim'
 import { RequestForAttestation } from '../requestforattestation/RequestForAttestation'
@@ -105,9 +104,7 @@ beforeAll(async () => {
 
 it('fetches the correct deposit amount', async () => {
   const depositAmount = await DelegationNode.queryDepositAmount()
-  expect(depositAmount.toString()).toStrictEqual(
-    new BN(1000000000000000).toString()
-  )
+  expect(depositAmount.toString()).toMatchInlineSnapshot('"1000000000000000"')
 })
 
 it('should be possible to delegate attestation rights', async () => {

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -71,9 +71,7 @@ beforeAll(async () => {
 
 it('fetches the correct deposit amount', async () => {
   const depositAmount = await DidChain.queryDepositAmount()
-  expect(depositAmount.toString()).toStrictEqual(
-    new BN(2071900000000000).toString()
-  )
+  expect(depositAmount.toString()).toMatchInlineSnapshot('"2007900000000000"')
 })
 
 describe('write and didDeleteTx', () => {


### PR DESCRIPTION
fixes https://github.com/KILTprotocol/sdk-js/issues/504

As far as I can see the only issue leading to failure in our weekly run with updated deps is that the integration tests are out of sync with the latest chain runtime. This should take care of the problem.