### PR TITLE
fix: add authentication key requirement for didLookup pallet calls

### DIFF
--- a/packages/did/src/DidDetails/FullDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.utils.ts
@@ -33,6 +33,7 @@ const methodMapping: SectionMapping<
     submitDidCall: 'paymentAccount',
     default: KeyRelationship.authentication,
   },
+  didLookup: { default: KeyRelationship.authentication },
   web3Names: { default: KeyRelationship.authentication },
   // Batch calls are not included here
   default: { default: 'paymentAccount' },


### PR DESCRIPTION
The DID logic did not include any DID key for the `didLookup` pallet, which accepts a DID origin with an authentication key.

## How to test

Use `"@kiltprotocol/sdk-js": "0.26.1-beta.1"` against a version of the node that has the fixed origin, e.g., https://github.com/KILTprotocol/mashnet-node/pull/343.