### PR TITLE
ci: fix metadata update on scheduled tests

### DIFF
--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -48,9 +48,9 @@ jobs:
           path: |
             locked_dependencies.txt
             yarn.lock
-      
+
       - name: Update metadata to latest spiritnet metadata
-        run: yarn workspace @kiltprotocol/testing run updateMetadata
+        run: yarn workspace @kiltprotocol/testing node ./scripts/fetchMetadata.js -o ./src/mocks/metadata/spiritnet.json -e wss://spiritnet.kilt.io/
 
       - name: yarn build
         run: yarn build

--- a/packages/testing/src/mocks/metadata/spiritnet.json
+++ b/packages/testing/src/mocks/metadata/spiritnet.json
@@ -447,7 +447,7 @@
                   "fields": [
                     {
                       "name": "phase",
-                      "type": 55,
+                      "type": 66,
                       "typeName": "Phase",
                       "docs": []
                     },
@@ -459,7 +459,7 @@
                     },
                     {
                       "name": "topics",
-                      "type": 56,
+                      "type": 67,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -498,7 +498,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 25,
+                          "type": 26,
                           "typeName": "pallet_indices::Event<Runtime>",
                           "docs": []
                         }
@@ -511,7 +511,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 26,
+                          "type": 27,
                           "typeName": "pallet_balances::Event<Runtime>",
                           "docs": []
                         }
@@ -524,7 +524,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 28,
+                          "type": 29,
                           "typeName": "parachain_staking::Event<Runtime>",
                           "docs": []
                         }
@@ -537,7 +537,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 30,
+                          "type": 31,
                           "typeName": "pallet_session::Event",
                           "docs": []
                         }
@@ -550,7 +550,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 31,
+                          "type": 32,
                           "typeName": "pallet_democracy::Event<Runtime>",
                           "docs": []
                         }
@@ -563,7 +563,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 36,
+                          "type": 39,
                           "typeName": "pallet_collective::Event<Runtime, pallet_collective::Instance1>",
                           "docs": []
                         }
@@ -576,7 +576,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 38,
+                          "type": 41,
                           "typeName": "pallet_collective::Event<Runtime, pallet_collective::Instance2>",
                           "docs": []
                         }
@@ -589,7 +589,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 39,
+                          "type": 42,
                           "typeName": "pallet_membership::Event<Runtime>",
                           "docs": []
                         }
@@ -602,7 +602,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 40,
+                          "type": 43,
                           "typeName": "pallet_treasury::Event<Runtime>",
                           "docs": []
                         }
@@ -615,7 +615,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 41,
+                          "type": 44,
                           "typeName": "pallet_utility::Event",
                           "docs": []
                         }
@@ -628,7 +628,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 42,
+                          "type": 45,
                           "typeName": "pallet_vesting::Event<Runtime>",
                           "docs": []
                         }
@@ -641,7 +641,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 43,
+                          "type": 46,
                           "typeName": "pallet_scheduler::Event<Runtime>",
                           "docs": []
                         }
@@ -650,11 +650,37 @@
                       "docs": []
                     },
                     {
+                      "name": "Proxy",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 50,
+                          "typeName": "pallet_proxy::Event<Runtime>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 43,
+                      "docs": []
+                    },
+                    {
+                      "name": "Preimage",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 53,
+                          "typeName": "pallet_preimage::Event<Runtime>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 44,
+                      "docs": []
+                    },
+                    {
                       "name": "KiltLaunch",
                       "fields": [
                         {
                           "name": null,
-                          "type": 46,
+                          "type": 54,
                           "typeName": "kilt_launch::Event<Runtime>",
                           "docs": []
                         }
@@ -667,7 +693,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 47,
+                          "type": 55,
                           "typeName": "ctype::Event<Runtime>",
                           "docs": []
                         }
@@ -680,7 +706,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 48,
+                          "type": 56,
                           "typeName": "attestation::Event<Runtime>",
                           "docs": []
                         }
@@ -693,7 +719,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 50,
+                          "type": 58,
                           "typeName": "delegation::Event<Runtime>",
                           "docs": []
                         }
@@ -706,7 +732,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 52,
+                          "type": 60,
                           "typeName": "did::Event<Runtime>",
                           "docs": []
                         }
@@ -719,7 +745,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 53,
+                          "type": 61,
                           "typeName": "pallet_did_lookup::Event<Runtime>",
                           "docs": []
                         }
@@ -728,11 +754,24 @@
                       "docs": []
                     },
                     {
+                      "name": "Web3Names",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 62,
+                          "typeName": "pallet_web3_names::Event<Runtime>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 68,
+                      "docs": []
+                    },
+                    {
                       "name": "ParachainSystem",
                       "fields": [
                         {
                           "name": null,
-                          "type": 54,
+                          "type": 65,
                           "typeName": "cumulus_pallet_parachain_system::Event<Runtime>",
                           "docs": []
                         }
@@ -767,7 +806,7 @@
                       "name": "ExtrinsicSuccess",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "dispatch_info",
                           "type": 19,
                           "typeName": "DispatchInfo",
                           "docs": []
@@ -775,20 +814,20 @@
                       ],
                       "index": 0,
                       "docs": [
-                        "An extrinsic completed successfully. \\[info\\]"
+                        "An extrinsic completed successfully."
                       ]
                     },
                     {
                       "name": "ExtrinsicFailed",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "dispatch_error",
                           "type": 22,
                           "typeName": "DispatchError",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "dispatch_info",
                           "type": 19,
                           "typeName": "DispatchInfo",
                           "docs": []
@@ -796,7 +835,7 @@
                       ],
                       "index": 1,
                       "docs": [
-                        "An extrinsic failed. \\[error, info\\]"
+                        "An extrinsic failed."
                       ]
                     },
                     {
@@ -811,7 +850,7 @@
                       "name": "NewAccount",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "account",
                           "type": 0,
                           "typeName": "T::AccountId",
                           "docs": []
@@ -819,14 +858,14 @@
                       ],
                       "index": 3,
                       "docs": [
-                        "A new \\[account\\] was created."
+                        "A new account was created."
                       ]
                     },
                     {
                       "name": "KilledAccount",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "account",
                           "type": 0,
                           "typeName": "T::AccountId",
                           "docs": []
@@ -834,20 +873,20 @@
                       ],
                       "index": 4,
                       "docs": [
-                        "An \\[account\\] was reaped."
+                        "An account was reaped."
                       ]
                     },
                     {
                       "name": "Remarked",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "sender",
                           "type": 0,
                           "typeName": "T::AccountId",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "hash",
                           "type": 9,
                           "typeName": "T::Hash",
                           "docs": []
@@ -855,7 +894,7 @@
                       ],
                       "index": 5,
                       "docs": [
-                        "On on-chain remark happened. \\[origin, remark_hash\\]"
+                        "On on-chain remark happened."
                       ]
                     }
                   ]
@@ -1001,15 +1040,9 @@
                       "name": "Module",
                       "fields": [
                         {
-                          "name": "index",
-                          "type": 2,
-                          "typeName": "u8",
-                          "docs": []
-                        },
-                        {
-                          "name": "error",
-                          "type": 2,
-                          "typeName": "u8",
+                          "name": null,
+                          "type": 23,
+                          "typeName": "ModuleError",
                           "docs": []
                         }
                       ],
@@ -1029,16 +1062,22 @@
                       "docs": []
                     },
                     {
+                      "name": "TooManyConsumers",
+                      "fields": [],
+                      "index": 6,
+                      "docs": []
+                    },
+                    {
                       "name": "Token",
                       "fields": [
                         {
                           "name": null,
-                          "type": 23,
+                          "type": 24,
                           "typeName": "TokenError",
                           "docs": []
                         }
                       ],
-                      "index": 6,
+                      "index": 7,
                       "docs": []
                     },
                     {
@@ -1046,12 +1085,12 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 24,
+                          "type": 25,
                           "typeName": "ArithmeticError",
                           "docs": []
                         }
                       ],
-                      "index": 7,
+                      "index": 8,
                       "docs": []
                     }
                   ]
@@ -1062,6 +1101,35 @@
           },
           {
             "id": 23,
+            "type": {
+              "path": [
+                "sp_runtime",
+                "ModuleError"
+              ],
+              "params": [],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": "index",
+                      "type": 2,
+                      "typeName": "u8",
+                      "docs": []
+                    },
+                    {
+                      "name": "error",
+                      "type": 2,
+                      "typeName": "u8",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 24,
             "type": {
               "path": [
                 "sp_runtime",
@@ -1120,7 +1188,7 @@
             }
           },
           {
-            "id": 24,
+            "id": 25,
             "type": {
               "path": [
                 "sp_runtime",
@@ -1155,7 +1223,7 @@
             }
           },
           {
-            "id": 25,
+            "id": 26,
             "type": {
               "path": [
                 "pallet_indices",
@@ -1237,7 +1305,7 @@
             }
           },
           {
-            "id": 26,
+            "id": 27,
             "type": {
               "path": [
                 "pallet_balances",
@@ -1419,7 +1487,7 @@
                         },
                         {
                           "name": "destination_status",
-                          "type": 27,
+                          "type": 28,
                           "typeName": "Status",
                           "docs": []
                         }
@@ -1502,7 +1570,7 @@
             }
           },
           {
-            "id": 27,
+            "id": 28,
             "type": {
               "path": [
                 "frame_support",
@@ -1534,7 +1602,7 @@
             }
           },
           {
-            "id": 28,
+            "id": 29,
             "type": {
               "path": [
                 "parachain_staking",
@@ -2028,25 +2096,25 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         },
                         {
                           "name": null,
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         },
                         {
                           "name": null,
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         },
                         {
                           "name": null,
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         }
@@ -2124,7 +2192,7 @@
             }
           },
           {
-            "id": 29,
+            "id": 30,
             "type": {
               "path": [
                 "sp_arithmetic",
@@ -2148,7 +2216,7 @@
             }
           },
           {
-            "id": 30,
+            "id": 31,
             "type": {
               "path": [
                 "pallet_session",
@@ -2184,7 +2252,7 @@
             }
           },
           {
-            "id": 31,
+            "id": 32,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -2238,7 +2306,7 @@
                         },
                         {
                           "name": "depositors",
-                          "type": 32,
+                          "type": 33,
                           "typeName": "Vec<T::AccountId>",
                           "docs": []
                         }
@@ -2267,7 +2335,7 @@
                         },
                         {
                           "name": "threshold",
-                          "type": 33,
+                          "type": 34,
                           "typeName": "VoteThreshold",
                           "docs": []
                         }
@@ -2333,7 +2401,7 @@
                         },
                         {
                           "name": "result",
-                          "type": 34,
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
@@ -2549,6 +2617,54 @@
                       "docs": [
                         "A proposal_hash has been blacklisted permanently."
                       ]
+                    },
+                    {
+                      "name": "Voted",
+                      "fields": [
+                        {
+                          "name": "voter",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "ref_index",
+                          "type": 7,
+                          "typeName": "ReferendumIndex",
+                          "docs": []
+                        },
+                        {
+                          "name": "vote",
+                          "type": 37,
+                          "typeName": "AccountVote<BalanceOf<T>>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 17,
+                      "docs": [
+                        "An account has voted in a referendum"
+                      ]
+                    },
+                    {
+                      "name": "Seconded",
+                      "fields": [
+                        {
+                          "name": "seconder",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "prop_index",
+                          "type": 7,
+                          "typeName": "PropIndex",
+                          "docs": []
+                        }
+                      ],
+                      "index": 18,
+                      "docs": [
+                        "An account has secconded a proposal"
+                      ]
                     }
                   ]
                 }
@@ -2559,7 +2675,7 @@
             }
           },
           {
-            "id": 32,
+            "id": 33,
             "type": {
               "path": [],
               "params": [],
@@ -2572,7 +2688,7 @@
             }
           },
           {
-            "id": 33,
+            "id": 34,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -2608,7 +2724,7 @@
             }
           },
           {
-            "id": 34,
+            "id": 35,
             "type": {
               "path": [
                 "Result"
@@ -2616,7 +2732,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 35
+                  "type": 36
                 },
                 {
                   "name": "E",
@@ -2631,7 +2747,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 35,
+                          "type": 36,
                           "typeName": null,
                           "docs": []
                         }
@@ -2659,7 +2775,7 @@
             }
           },
           {
-            "id": 35,
+            "id": 36,
             "type": {
               "path": [],
               "params": [],
@@ -2670,7 +2786,92 @@
             }
           },
           {
-            "id": 36,
+            "id": 37,
+            "type": {
+              "path": [
+                "pallet_democracy",
+                "vote",
+                "AccountVote"
+              ],
+              "params": [
+                {
+                  "name": "Balance",
+                  "type": 6
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Standard",
+                      "fields": [
+                        {
+                          "name": "vote",
+                          "type": 38,
+                          "typeName": "Vote",
+                          "docs": []
+                        },
+                        {
+                          "name": "balance",
+                          "type": 6,
+                          "typeName": "Balance",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "Split",
+                      "fields": [
+                        {
+                          "name": "aye",
+                          "type": 6,
+                          "typeName": "Balance",
+                          "docs": []
+                        },
+                        {
+                          "name": "nay",
+                          "type": 6,
+                          "typeName": "Balance",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 38,
+            "type": {
+              "path": [
+                "pallet_democracy",
+                "vote",
+                "Vote"
+              ],
+              "params": [],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 2,
+                      "typeName": null,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 39,
             "type": {
               "path": [
                 "pallet_collective",
@@ -2741,7 +2942,7 @@
                         },
                         {
                           "name": "voted",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         },
@@ -2805,7 +3006,7 @@
                         },
                         {
                           "name": "result",
-                          "type": 34,
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
@@ -2826,7 +3027,7 @@
                         },
                         {
                           "name": "result",
-                          "type": 34,
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
@@ -2872,7 +3073,7 @@
             }
           },
           {
-            "id": 37,
+            "id": 40,
             "type": {
               "path": [],
               "params": [],
@@ -2883,7 +3084,7 @@
             }
           },
           {
-            "id": 38,
+            "id": 41,
             "type": {
               "path": [
                 "pallet_collective",
@@ -2954,7 +3155,7 @@
                         },
                         {
                           "name": "voted",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         },
@@ -3018,7 +3219,7 @@
                         },
                         {
                           "name": "result",
-                          "type": 34,
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
@@ -3039,7 +3240,7 @@
                         },
                         {
                           "name": "result",
-                          "type": 34,
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
@@ -3085,7 +3286,7 @@
             }
           },
           {
-            "id": 39,
+            "id": 42,
             "type": {
               "path": [
                 "pallet_membership",
@@ -3162,7 +3363,7 @@
             }
           },
           {
-            "id": 40,
+            "id": 43,
             "type": {
               "path": [
                 "pallet_treasury",
@@ -3186,7 +3387,7 @@
                       "name": "Proposed",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "proposal_index",
                           "type": 7,
                           "typeName": "ProposalIndex",
                           "docs": []
@@ -3194,14 +3395,14 @@
                       ],
                       "index": 0,
                       "docs": [
-                        "New proposal. \\[proposal_index\\]"
+                        "New proposal."
                       ]
                     },
                     {
                       "name": "Spending",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "budget_remaining",
                           "type": 6,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
@@ -3209,26 +3410,26 @@
                       ],
                       "index": 1,
                       "docs": [
-                        "We have ended a spend period and will now allocate funds. \\[budget_remaining\\]"
+                        "We have ended a spend period and will now allocate funds."
                       ]
                     },
                     {
                       "name": "Awarded",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "proposal_index",
                           "type": 7,
                           "typeName": "ProposalIndex",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "award",
                           "type": 6,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "account",
                           "type": 0,
                           "typeName": "T::AccountId",
                           "docs": []
@@ -3236,20 +3437,20 @@
                       ],
                       "index": 2,
                       "docs": [
-                        "Some funds have been allocated. \\[proposal_index, award, beneficiary\\]"
+                        "Some funds have been allocated."
                       ]
                     },
                     {
                       "name": "Rejected",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "proposal_index",
                           "type": 7,
                           "typeName": "ProposalIndex",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "slashed",
                           "type": 6,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
@@ -3257,14 +3458,14 @@
                       ],
                       "index": 3,
                       "docs": [
-                        "A proposal was rejected; funds were slashed. \\[proposal_index, slashed\\]"
+                        "A proposal was rejected; funds were slashed."
                       ]
                     },
                     {
                       "name": "Burnt",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "burnt_funds",
                           "type": 6,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
@@ -3272,14 +3473,14 @@
                       ],
                       "index": 4,
                       "docs": [
-                        "Some of our funds have been burnt. \\[burn\\]"
+                        "Some of our funds have been burnt."
                       ]
                     },
                     {
                       "name": "Rollover",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "rollover_balance",
                           "type": 6,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
@@ -3287,15 +3488,14 @@
                       ],
                       "index": 5,
                       "docs": [
-                        "Spending has finished; this is the amount that rolls over until next spend.",
-                        "\\[budget_remaining\\]"
+                        "Spending has finished; this is the amount that rolls over until next spend."
                       ]
                     },
                     {
                       "name": "Deposit",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "value",
                           "type": 6,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
@@ -3303,7 +3503,7 @@
                       ],
                       "index": 6,
                       "docs": [
-                        "Some funds have been deposited. \\[deposit\\]"
+                        "Some funds have been deposited."
                       ]
                     }
                   ]
@@ -3315,7 +3515,7 @@
             }
           },
           {
-            "id": 41,
+            "id": 44,
             "type": {
               "path": [
                 "pallet_utility",
@@ -3368,15 +3568,15 @@
                       "name": "DispatchedAs",
                       "fields": [
                         {
-                          "name": null,
-                          "type": 34,
+                          "name": "result",
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
                       ],
                       "index": 3,
                       "docs": [
-                        "A call was dispatched. \\[result\\]"
+                        "A call was dispatched."
                       ]
                     }
                   ]
@@ -3388,7 +3588,7 @@
             }
           },
           {
-            "id": 42,
+            "id": 45,
             "type": {
               "path": [
                 "pallet_vesting",
@@ -3450,7 +3650,7 @@
             }
           },
           {
-            "id": 43,
+            "id": 46,
             "type": {
               "path": [
                 "pallet_scheduler",
@@ -3470,13 +3670,13 @@
                       "name": "Scheduled",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "when",
                           "type": 4,
                           "typeName": "T::BlockNumber",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "index",
                           "type": 7,
                           "typeName": "u32",
                           "docs": []
@@ -3484,20 +3684,20 @@
                       ],
                       "index": 0,
                       "docs": [
-                        "Scheduled some task. \\[when, index\\]"
+                        "Scheduled some task."
                       ]
                     },
                     {
                       "name": "Canceled",
                       "fields": [
                         {
-                          "name": null,
+                          "name": "when",
                           "type": 4,
                           "typeName": "T::BlockNumber",
                           "docs": []
                         },
                         {
-                          "name": null,
+                          "name": "index",
                           "type": 7,
                           "typeName": "u32",
                           "docs": []
@@ -3505,34 +3705,61 @@
                       ],
                       "index": 1,
                       "docs": [
-                        "Canceled some task. \\[when, index\\]"
+                        "Canceled some task."
                       ]
                     },
                     {
                       "name": "Dispatched",
                       "fields": [
                         {
-                          "name": null,
-                          "type": 44,
+                          "name": "task",
+                          "type": 47,
                           "typeName": "TaskAddress<T::BlockNumber>",
                           "docs": []
                         },
                         {
-                          "name": null,
-                          "type": 45,
+                          "name": "id",
+                          "type": 48,
                           "typeName": "Option<Vec<u8>>",
                           "docs": []
                         },
                         {
-                          "name": null,
-                          "type": 34,
+                          "name": "result",
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
                       ],
                       "index": 2,
                       "docs": [
-                        "Dispatched some task. \\[task, id, result\\]"
+                        "Dispatched some task."
+                      ]
+                    },
+                    {
+                      "name": "CallLookupFailed",
+                      "fields": [
+                        {
+                          "name": "task",
+                          "type": 47,
+                          "typeName": "TaskAddress<T::BlockNumber>",
+                          "docs": []
+                        },
+                        {
+                          "name": "id",
+                          "type": 48,
+                          "typeName": "Option<Vec<u8>>",
+                          "docs": []
+                        },
+                        {
+                          "name": "error",
+                          "type": 49,
+                          "typeName": "LookupError",
+                          "docs": []
+                        }
+                      ],
+                      "index": 3,
+                      "docs": [
+                        "The call for the provided hash was not found so the task has been aborted."
                       ]
                     }
                   ]
@@ -3544,7 +3771,7 @@
             }
           },
           {
-            "id": 44,
+            "id": 47,
             "type": {
               "path": [],
               "params": [],
@@ -3558,7 +3785,7 @@
             }
           },
           {
-            "id": 45,
+            "id": 48,
             "type": {
               "path": [
                 "Option"
@@ -3598,7 +3825,300 @@
             }
           },
           {
-            "id": 46,
+            "id": 49,
+            "type": {
+              "path": [
+                "frame_support",
+                "traits",
+                "schedule",
+                "LookupError"
+              ],
+              "params": [],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Unknown",
+                      "fields": [],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "BadFormat",
+                      "fields": [],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 50,
+            "type": {
+              "path": [
+                "pallet_proxy",
+                "pallet",
+                "Event"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "ProxyExecuted",
+                      "fields": [
+                        {
+                          "name": "result",
+                          "type": 35,
+                          "typeName": "DispatchResult",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": [
+                        "A proxy was executed correctly, with the given."
+                      ]
+                    },
+                    {
+                      "name": "AnonymousCreated",
+                      "fields": [
+                        {
+                          "name": "anonymous",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "who",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "proxy_type",
+                          "type": 51,
+                          "typeName": "T::ProxyType",
+                          "docs": []
+                        },
+                        {
+                          "name": "disambiguation_index",
+                          "type": 52,
+                          "typeName": "u16",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": [
+                        "Anonymous account has been created by new proxy with given",
+                        "disambiguation index and proxy type."
+                      ]
+                    },
+                    {
+                      "name": "Announced",
+                      "fields": [
+                        {
+                          "name": "real",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "proxy",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "call_hash",
+                          "type": 9,
+                          "typeName": "CallHashOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 2,
+                      "docs": [
+                        "An announcement was placed to make a call in the future."
+                      ]
+                    },
+                    {
+                      "name": "ProxyAdded",
+                      "fields": [
+                        {
+                          "name": "delegator",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "delegatee",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "proxy_type",
+                          "type": 51,
+                          "typeName": "T::ProxyType",
+                          "docs": []
+                        },
+                        {
+                          "name": "delay",
+                          "type": 4,
+                          "typeName": "T::BlockNumber",
+                          "docs": []
+                        }
+                      ],
+                      "index": 3,
+                      "docs": [
+                        "A proxy was added."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "\n\t\t\tThe [event](https://docs.substrate.io/v3/runtime/events-and-errors) emitted\n\t\t\tby this pallet.\n\t\t\t"
+              ]
+            }
+          },
+          {
+            "id": 51,
+            "type": {
+              "path": [
+                "spiritnet_runtime",
+                "ProxyType"
+              ],
+              "params": [],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Any",
+                      "fields": [],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "NonTransfer",
+                      "fields": [],
+                      "index": 1,
+                      "docs": []
+                    },
+                    {
+                      "name": "Governance",
+                      "fields": [],
+                      "index": 2,
+                      "docs": []
+                    },
+                    {
+                      "name": "ParachainStaking",
+                      "fields": [],
+                      "index": 3,
+                      "docs": []
+                    },
+                    {
+                      "name": "CancelProxy",
+                      "fields": [],
+                      "index": 4,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 52,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "primitive": "U16"
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 53,
+            "type": {
+              "path": [
+                "pallet_preimage",
+                "pallet",
+                "Event"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Noted",
+                      "fields": [
+                        {
+                          "name": "hash",
+                          "type": 9,
+                          "typeName": "T::Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": [
+                        "A preimage has been noted."
+                      ]
+                    },
+                    {
+                      "name": "Requested",
+                      "fields": [
+                        {
+                          "name": "hash",
+                          "type": 9,
+                          "typeName": "T::Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": [
+                        "A preimage has been requested."
+                      ]
+                    },
+                    {
+                      "name": "Cleared",
+                      "fields": [
+                        {
+                          "name": "hash",
+                          "type": 9,
+                          "typeName": "T::Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 2,
+                      "docs": [
+                        "A preimage has ben cleared."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "\n\t\t\tThe [event](https://docs.substrate.io/v3/runtime/events-and-errors) emitted\n\t\t\tby this pallet.\n\t\t\t"
+              ]
+            }
+          },
+          {
+            "id": 54,
             "type": {
               "path": [
                 "kilt_launch",
@@ -3727,7 +4247,7 @@
             }
           },
           {
-            "id": 47,
+            "id": 55,
             "type": {
               "path": [
                 "ctype",
@@ -3774,7 +4294,7 @@
             }
           },
           {
-            "id": 48,
+            "id": 56,
             "type": {
               "path": [
                 "attestation",
@@ -3813,7 +4333,7 @@
                         },
                         {
                           "name": null,
-                          "type": 49,
+                          "type": 57,
                           "typeName": "Option<DelegationNodeIdOf<T>>",
                           "docs": []
                         }
@@ -3899,7 +4419,7 @@
             }
           },
           {
-            "id": 49,
+            "id": 57,
             "type": {
               "path": [
                 "Option"
@@ -3939,7 +4459,7 @@
             }
           },
           {
-            "id": 50,
+            "id": 58,
             "type": {
               "path": [
                 "delegation",
@@ -4062,7 +4582,7 @@
                         },
                         {
                           "name": null,
-                          "type": 51,
+                          "type": 59,
                           "typeName": "Permissions",
                           "docs": []
                         }
@@ -4149,7 +4669,7 @@
             }
           },
           {
-            "id": 51,
+            "id": 59,
             "type": {
               "path": [
                 "delegation",
@@ -4173,7 +4693,7 @@
             }
           },
           {
-            "id": 52,
+            "id": 60,
             "type": {
               "path": [
                 "did",
@@ -4254,7 +4774,7 @@
                         },
                         {
                           "name": null,
-                          "type": 34,
+                          "type": 35,
                           "typeName": "DispatchResult",
                           "docs": []
                         }
@@ -4274,7 +4794,7 @@
             }
           },
           {
-            "id": 53,
+            "id": 61,
             "type": {
               "path": [
                 "pallet_did_lookup",
@@ -4341,7 +4861,175 @@
             }
           },
           {
-            "id": 54,
+            "id": 62,
+            "type": {
+              "path": [
+                "pallet_web3_names",
+                "pallet",
+                "Event"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Web3NameClaimed",
+                      "fields": [
+                        {
+                          "name": "owner",
+                          "type": 0,
+                          "typeName": "Web3NameOwnerOf<T>",
+                          "docs": []
+                        },
+                        {
+                          "name": "name",
+                          "type": 63,
+                          "typeName": "Web3NameOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": [
+                        "A new name has been claimed."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameReleased",
+                      "fields": [
+                        {
+                          "name": "owner",
+                          "type": 0,
+                          "typeName": "Web3NameOwnerOf<T>",
+                          "docs": []
+                        },
+                        {
+                          "name": "name",
+                          "type": 63,
+                          "typeName": "Web3NameOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": [
+                        "A name has been released."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameBanned",
+                      "fields": [
+                        {
+                          "name": "name",
+                          "type": 63,
+                          "typeName": "Web3NameOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 2,
+                      "docs": [
+                        "A name has been banned."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameUnbanned",
+                      "fields": [
+                        {
+                          "name": "name",
+                          "type": 63,
+                          "typeName": "Web3NameOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 3,
+                      "docs": [
+                        "A name has been unbanned."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "\n\t\t\tThe [event](https://docs.substrate.io/v3/runtime/events-and-errors) emitted\n\t\t\tby this pallet.\n\t\t\t"
+              ]
+            }
+          },
+          {
+            "id": 63,
+            "type": {
+              "path": [
+                "pallet_web3_names",
+                "web3_name",
+                "AsciiWeb3Name"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                },
+                {
+                  "name": "MinLength",
+                  "type": null
+                },
+                {
+                  "name": "MaxLength",
+                  "type": null
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 64,
+                      "typeName": "BoundedVec<u8, MaxLength>",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 64,
+            "type": {
+              "path": [
+                "frame_support",
+                "storage",
+                "bounded_vec",
+                "BoundedVec"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 2
+                },
+                {
+                  "name": "S",
+                  "type": null
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 10,
+                      "typeName": "Vec<T>",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 65,
             "type": {
               "path": [
                 "cumulus_pallet_parachain_system",
@@ -4450,7 +5138,7 @@
             }
           },
           {
-            "id": 55,
+            "id": 66,
             "type": {
               "path": [
                 "frame_system",
@@ -4492,7 +5180,7 @@
             }
           },
           {
-            "id": 56,
+            "id": 67,
             "type": {
               "path": [],
               "params": [],
@@ -4505,20 +5193,20 @@
             }
           },
           {
-            "id": 57,
+            "id": 68,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 44
+                  "type": 47
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 58,
+            "id": 69,
             "type": {
               "path": [
                 "frame_system",
@@ -4530,13 +5218,13 @@
                   "fields": [
                     {
                       "name": "spec_version",
-                      "type": 59,
+                      "type": 70,
                       "typeName": "codec::Compact<u32>",
                       "docs": []
                     },
                     {
                       "name": "spec_name",
-                      "type": 60,
+                      "type": 71,
                       "typeName": "sp_runtime::RuntimeString",
                       "docs": []
                     }
@@ -4547,7 +5235,7 @@
             }
           },
           {
-            "id": 59,
+            "id": 70,
             "type": {
               "path": [],
               "params": [],
@@ -4560,7 +5248,7 @@
             }
           },
           {
-            "id": 60,
+            "id": 71,
             "type": {
               "path": [],
               "params": [],
@@ -4571,7 +5259,7 @@
             }
           },
           {
-            "id": 61,
+            "id": 72,
             "type": {
               "path": [
                 "frame_system",
@@ -4592,7 +5280,7 @@
                       "fields": [
                         {
                           "name": "ratio",
-                          "type": 62,
+                          "type": 73,
                           "typeName": "Perbill",
                           "docs": []
                         }
@@ -4690,7 +5378,7 @@
                       "fields": [
                         {
                           "name": "items",
-                          "type": 63,
+                          "type": 74,
                           "typeName": "Vec<KeyValue>",
                           "docs": []
                         }
@@ -4705,7 +5393,7 @@
                       "fields": [
                         {
                           "name": "keys",
-                          "type": 65,
+                          "type": 76,
                           "typeName": "Vec<Key>",
                           "docs": []
                         }
@@ -4751,12 +5439,7 @@
                       ],
                       "index": 8,
                       "docs": [
-                        "Make some on-chain remark and emit event.",
-                        "",
-                        "# <weight>",
-                        "- `O(b)` where b is the length of the remark.",
-                        "- 1 event.",
-                        "# </weight>"
+                        "Make some on-chain remark and emit event."
                       ]
                     }
                   ]
@@ -4768,7 +5451,7 @@
             }
           },
           {
-            "id": 62,
+            "id": 73,
             "type": {
               "path": [
                 "sp_arithmetic",
@@ -4792,20 +5475,20 @@
             }
           },
           {
-            "id": 63,
+            "id": 74,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 64
+                  "type": 75
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 64,
+            "id": 75,
             "type": {
               "path": [],
               "params": [],
@@ -4819,7 +5502,7 @@
             }
           },
           {
-            "id": 65,
+            "id": 76,
             "type": {
               "path": [],
               "params": [],
@@ -4832,7 +5515,7 @@
             }
           },
           {
-            "id": 66,
+            "id": 77,
             "type": {
               "path": [
                 "frame_system",
@@ -4857,7 +5540,7 @@
                     },
                     {
                       "name": "per_class",
-                      "type": 67,
+                      "type": 78,
                       "typeName": "PerDispatchClass<WeightsPerClass>",
                       "docs": []
                     }
@@ -4868,7 +5551,7 @@
             }
           },
           {
-            "id": 67,
+            "id": 78,
             "type": {
               "path": [
                 "frame_support",
@@ -4878,7 +5561,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 68
+                  "type": 79
                 }
               ],
               "def": {
@@ -4886,19 +5569,19 @@
                   "fields": [
                     {
                       "name": "normal",
-                      "type": 68,
+                      "type": 79,
                       "typeName": "T",
                       "docs": []
                     },
                     {
                       "name": "operational",
-                      "type": 68,
+                      "type": 79,
                       "typeName": "T",
                       "docs": []
                     },
                     {
                       "name": "mandatory",
-                      "type": 68,
+                      "type": 79,
                       "typeName": "T",
                       "docs": []
                     }
@@ -4909,7 +5592,7 @@
             }
           },
           {
-            "id": 68,
+            "id": 79,
             "type": {
               "path": [
                 "frame_system",
@@ -4928,19 +5611,19 @@
                     },
                     {
                       "name": "max_extrinsic",
-                      "type": 69,
+                      "type": 80,
                       "typeName": "Option<Weight>",
                       "docs": []
                     },
                     {
                       "name": "max_total",
-                      "type": 69,
+                      "type": 80,
                       "typeName": "Option<Weight>",
                       "docs": []
                     },
                     {
                       "name": "reserved",
-                      "type": 69,
+                      "type": 80,
                       "typeName": "Option<Weight>",
                       "docs": []
                     }
@@ -4951,7 +5634,7 @@
             }
           },
           {
-            "id": 69,
+            "id": 80,
             "type": {
               "path": [
                 "Option"
@@ -4991,7 +5674,7 @@
             }
           },
           {
-            "id": 70,
+            "id": 81,
             "type": {
               "path": [
                 "frame_system",
@@ -5004,7 +5687,7 @@
                   "fields": [
                     {
                       "name": "max",
-                      "type": 71,
+                      "type": 82,
                       "typeName": "PerDispatchClass<u32>",
                       "docs": []
                     }
@@ -5015,7 +5698,7 @@
             }
           },
           {
-            "id": 71,
+            "id": 82,
             "type": {
               "path": [
                 "frame_support",
@@ -5056,7 +5739,7 @@
             }
           },
           {
-            "id": 72,
+            "id": 83,
             "type": {
               "path": [
                 "frame_support",
@@ -5086,7 +5769,7 @@
             }
           },
           {
-            "id": 73,
+            "id": 84,
             "type": {
               "path": [
                 "sp_version",
@@ -5098,13 +5781,13 @@
                   "fields": [
                     {
                       "name": "spec_name",
-                      "type": 60,
+                      "type": 71,
                       "typeName": "RuntimeString",
                       "docs": []
                     },
                     {
                       "name": "impl_name",
-                      "type": 60,
+                      "type": 71,
                       "typeName": "RuntimeString",
                       "docs": []
                     },
@@ -5128,7 +5811,7 @@
                     },
                     {
                       "name": "apis",
-                      "type": 74,
+                      "type": 85,
                       "typeName": "ApisVec",
                       "docs": []
                     },
@@ -5136,6 +5819,12 @@
                       "name": "transaction_version",
                       "type": 7,
                       "typeName": "u32",
+                      "docs": []
+                    },
+                    {
+                      "name": "state_version",
+                      "type": 2,
+                      "typeName": "u8",
                       "docs": []
                     }
                   ]
@@ -5145,7 +5834,7 @@
             }
           },
           {
-            "id": 74,
+            "id": 85,
             "type": {
               "path": [
                 "Cow"
@@ -5153,7 +5842,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 75
+                  "type": 86
                 }
               ],
               "def": {
@@ -5161,7 +5850,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 75,
+                      "type": 86,
                       "typeName": null,
                       "docs": []
                     }
@@ -5172,26 +5861,26 @@
             }
           },
           {
-            "id": 75,
+            "id": 86,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 76
+                  "type": 87
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 76,
+            "id": 87,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  77,
+                  88,
                   7
                 ]
               },
@@ -5199,7 +5888,7 @@
             }
           },
           {
-            "id": 77,
+            "id": 88,
             "type": {
               "path": [],
               "params": [],
@@ -5213,18 +5902,7 @@
             }
           },
           {
-            "id": 78,
-            "type": {
-              "path": [],
-              "params": [],
-              "def": {
-                "primitive": "U16"
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 79,
+            "id": 89,
             "type": {
               "path": [
                 "frame_system",
@@ -5301,7 +5979,41 @@
             }
           },
           {
-            "id": 80,
+            "id": 90,
+            "type": {
+              "path": [
+                "frame_support",
+                "storage",
+                "bounded_vec",
+                "BoundedVec"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 9
+                },
+                {
+                  "name": "S",
+                  "type": null
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 67,
+                      "typeName": "Vec<T>",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 91,
             "type": {
               "path": [
                 "pallet_timestamp",
@@ -5322,7 +6034,7 @@
                       "fields": [
                         {
                           "name": "now",
-                          "type": 81,
+                          "type": 92,
                           "typeName": "T::Moment",
                           "docs": []
                         }
@@ -5356,7 +6068,7 @@
             }
           },
           {
-            "id": 81,
+            "id": 92,
             "type": {
               "path": [],
               "params": [],
@@ -5369,7 +6081,7 @@
             }
           },
           {
-            "id": 82,
+            "id": 93,
             "type": {
               "path": [],
               "params": [],
@@ -5377,14 +6089,14 @@
                 "tuple": [
                   0,
                   6,
-                  37
+                  40
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 83,
+            "id": 94,
             "type": {
               "path": [
                 "pallet_indices",
@@ -5521,7 +6233,7 @@
                         },
                         {
                           "name": "freeze",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         }
@@ -5592,7 +6304,7 @@
             }
           },
           {
-            "id": 84,
+            "id": 95,
             "type": {
               "path": [
                 "pallet_indices",
@@ -5657,7 +6369,7 @@
             }
           },
           {
-            "id": 85,
+            "id": 96,
             "type": {
               "path": [
                 "frame_support",
@@ -5668,7 +6380,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 86
+                  "type": 97
                 },
                 {
                   "name": "S",
@@ -5680,7 +6392,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 88,
+                      "type": 99,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -5691,7 +6403,7 @@
             }
           },
           {
-            "id": 86,
+            "id": 97,
             "type": {
               "path": [
                 "pallet_balances",
@@ -5708,7 +6420,7 @@
                   "fields": [
                     {
                       "name": "id",
-                      "type": 77,
+                      "type": 88,
                       "typeName": "LockIdentifier",
                       "docs": []
                     },
@@ -5720,7 +6432,7 @@
                     },
                     {
                       "name": "reasons",
-                      "type": 87,
+                      "type": 98,
                       "typeName": "Reasons",
                       "docs": []
                     }
@@ -5731,7 +6443,7 @@
             }
           },
           {
-            "id": 87,
+            "id": 98,
             "type": {
               "path": [
                 "pallet_balances",
@@ -5766,20 +6478,20 @@
             }
           },
           {
-            "id": 88,
+            "id": 99,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 86
+                  "type": 97
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 89,
+            "id": 100,
             "type": {
               "path": [
                 "frame_support",
@@ -5790,7 +6502,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 90
+                  "type": 101
                 },
                 {
                   "name": "S",
@@ -5802,7 +6514,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 91,
+                      "type": 102,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -5813,7 +6525,7 @@
             }
           },
           {
-            "id": 90,
+            "id": 101,
             "type": {
               "path": [
                 "pallet_balances",
@@ -5822,7 +6534,7 @@
               "params": [
                 {
                   "name": "ReserveIdentifier",
-                  "type": 77
+                  "type": 88
                 },
                 {
                   "name": "Balance",
@@ -5834,7 +6546,7 @@
                   "fields": [
                     {
                       "name": "id",
-                      "type": 77,
+                      "type": 88,
                       "typeName": "ReserveIdentifier",
                       "docs": []
                     },
@@ -5851,20 +6563,20 @@
             }
           },
           {
-            "id": 91,
+            "id": 102,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 90
+                  "type": 101
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 92,
+            "id": 103,
             "type": {
               "path": [
                 "pallet_balances",
@@ -5893,7 +6605,7 @@
             }
           },
           {
-            "id": 93,
+            "id": 104,
             "type": {
               "path": [
                 "pallet_balances",
@@ -5918,13 +6630,13 @@
                       "fields": [
                         {
                           "name": "dest",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "value",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "T::Balance",
                           "docs": []
                         }
@@ -5934,7 +6646,6 @@
                         "Transfer some liquid free balance to another account.",
                         "",
                         "`transfer` will set the `FreeBalance` of the sender and receiver.",
-                        "It will decrease the total issuance of the system by the `TransferFee`.",
                         "If the sender's account is below the existential deposit as a result",
                         "of the transfer, the account will be reaped.",
                         "",
@@ -5964,19 +6675,19 @@
                       "fields": [
                         {
                           "name": "who",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "new_free",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "T::Balance",
                           "docs": []
                         },
                         {
                           "name": "new_reserved",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "T::Balance",
                           "docs": []
                         }
@@ -5986,7 +6697,7 @@
                         "Set the balances of a given account.",
                         "",
                         "This will alter `FreeBalance` and `ReservedBalance` in storage. it will",
-                        "also decrease the total issuance of the system (`TotalIssuance`).",
+                        "also alter the total issuance of the system (`TotalIssuance`) appropriately.",
                         "If the new free or reserved balance is below the existential deposit,",
                         "it will reset the account nonce (`frame_system::AccountNonce`).",
                         "",
@@ -5998,19 +6709,19 @@
                       "fields": [
                         {
                           "name": "source",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "dest",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "value",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "T::Balance",
                           "docs": []
                         }
@@ -6030,13 +6741,13 @@
                       "fields": [
                         {
                           "name": "dest",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "value",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "T::Balance",
                           "docs": []
                         }
@@ -6056,13 +6767,13 @@
                       "fields": [
                         {
                           "name": "dest",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "keep_alive",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         }
@@ -6093,7 +6804,7 @@
                       "fields": [
                         {
                           "name": "who",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
@@ -6120,7 +6831,7 @@
             }
           },
           {
-            "id": 94,
+            "id": 105,
             "type": {
               "path": [
                 "sp_runtime",
@@ -6134,7 +6845,7 @@
                 },
                 {
                   "name": "AccountIndex",
-                  "type": 35
+                  "type": 36
                 }
               ],
               "def": {
@@ -6158,7 +6869,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 95,
+                          "type": 106,
                           "typeName": "AccountIndex",
                           "docs": []
                         }
@@ -6197,7 +6908,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 96,
+                          "type": 107,
                           "typeName": "[u8; 20]",
                           "docs": []
                         }
@@ -6212,20 +6923,20 @@
             }
           },
           {
-            "id": 95,
+            "id": 106,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "compact": {
-                  "type": 35
+                  "type": 36
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 96,
+            "id": 107,
             "type": {
               "path": [],
               "params": [],
@@ -6239,7 +6950,7 @@
             }
           },
           {
-            "id": 97,
+            "id": 108,
             "type": {
               "path": [],
               "params": [],
@@ -6252,7 +6963,7 @@
             }
           },
           {
-            "id": 98,
+            "id": 109,
             "type": {
               "path": [
                 "pallet_balances",
@@ -6345,7 +7056,7 @@
             }
           },
           {
-            "id": 99,
+            "id": 110,
             "type": {
               "path": [
                 "sp_arithmetic",
@@ -6369,7 +7080,7 @@
             }
           },
           {
-            "id": 100,
+            "id": 111,
             "type": {
               "path": [
                 "pallet_transaction_payment",
@@ -6398,20 +7109,20 @@
             }
           },
           {
-            "id": 101,
+            "id": 112,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 102
+                  "type": 113
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 102,
+            "id": 113,
             "type": {
               "path": [
                 "frame_support",
@@ -6435,13 +7146,13 @@
                     },
                     {
                       "name": "coeff_frac",
-                      "type": 62,
+                      "type": 73,
                       "typeName": "Perbill",
                       "docs": []
                     },
                     {
                       "name": "negative",
-                      "type": 37,
+                      "type": 40,
                       "typeName": "bool",
                       "docs": []
                     },
@@ -6458,20 +7169,20 @@
             }
           },
           {
-            "id": 103,
+            "id": 114,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 104
+                  "type": 115
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 104,
+            "id": 115,
             "type": {
               "path": [
                 "pallet_authorship",
@@ -6518,7 +7229,7 @@
                         },
                         {
                           "name": null,
-                          "type": 105,
+                          "type": 116,
                           "typeName": "Option<Author>",
                           "docs": []
                         }
@@ -6533,7 +7244,7 @@
             }
           },
           {
-            "id": 105,
+            "id": 116,
             "type": {
               "path": [
                 "Option"
@@ -6573,7 +7284,7 @@
             }
           },
           {
-            "id": 106,
+            "id": 117,
             "type": {
               "path": [
                 "pallet_authorship",
@@ -6594,7 +7305,7 @@
                       "fields": [
                         {
                           "name": "new_uncles",
-                          "type": 107,
+                          "type": 118,
                           "typeName": "Vec<T::Header>",
                           "docs": []
                         }
@@ -6613,20 +7324,20 @@
             }
           },
           {
-            "id": 107,
+            "id": 118,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 108
+                  "type": 119
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 108,
+            "id": 119,
             "type": {
               "path": [
                 "sp_runtime",
@@ -6641,7 +7352,7 @@
                 },
                 {
                   "name": "Hash",
-                  "type": 109
+                  "type": 120
                 }
               ],
               "def": {
@@ -6655,7 +7366,7 @@
                     },
                     {
                       "name": "number",
-                      "type": 81,
+                      "type": 92,
                       "typeName": "Number",
                       "docs": []
                     },
@@ -6684,7 +7395,7 @@
             }
           },
           {
-            "id": 109,
+            "id": 120,
             "type": {
               "path": [
                 "sp_runtime",
@@ -6701,7 +7412,7 @@
             }
           },
           {
-            "id": 110,
+            "id": 121,
             "type": {
               "path": [
                 "pallet_authorship",
@@ -6782,61 +7493,7 @@
             }
           },
           {
-            "id": 111,
-            "type": {
-              "path": [
-                "parachain_staking",
-                "migrations",
-                "StakingStorageVersion"
-              ],
-              "params": [],
-              "def": {
-                "variant": {
-                  "variants": [
-                    {
-                      "name": "V1_0_0",
-                      "fields": [],
-                      "index": 0,
-                      "docs": []
-                    },
-                    {
-                      "name": "V2_0_0",
-                      "fields": [],
-                      "index": 1,
-                      "docs": []
-                    },
-                    {
-                      "name": "V3_0_0",
-                      "fields": [],
-                      "index": 2,
-                      "docs": []
-                    },
-                    {
-                      "name": "V4",
-                      "fields": [],
-                      "index": 3,
-                      "docs": []
-                    },
-                    {
-                      "name": "V5",
-                      "fields": [],
-                      "index": 4,
-                      "docs": []
-                    },
-                    {
-                      "name": "V6",
-                      "fields": [],
-                      "index": 5,
-                      "docs": []
-                    }
-                  ]
-                }
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 112,
+            "id": 122,
             "type": {
               "path": [
                 "parachain_staking",
@@ -6877,7 +7534,7 @@
             }
           },
           {
-            "id": 113,
+            "id": 123,
             "type": {
               "path": [
                 "parachain_staking",
@@ -6907,7 +7564,7 @@
             }
           },
           {
-            "id": 114,
+            "id": 124,
             "type": {
               "path": [
                 "parachain_staking",
@@ -6933,7 +7590,7 @@
                   "fields": [
                     {
                       "name": "delegations",
-                      "type": 115,
+                      "type": 125,
                       "typeName": "OrderedSet<Stake<AccountId, Balance>, MaxCollatorsPerDelegator>",
                       "docs": []
                     },
@@ -6950,7 +7607,7 @@
             }
           },
           {
-            "id": 115,
+            "id": 125,
             "type": {
               "path": [
                 "parachain_staking",
@@ -6960,7 +7617,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 116
+                  "type": 126
                 },
                 {
                   "name": "S",
@@ -6972,7 +7629,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 117,
+                      "type": 127,
                       "typeName": "BoundedVec<T, S>",
                       "docs": []
                     }
@@ -6983,7 +7640,7 @@
             }
           },
           {
-            "id": 116,
+            "id": 126,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7022,7 +7679,7 @@
             }
           },
           {
-            "id": 117,
+            "id": 127,
             "type": {
               "path": [
                 "frame_support",
@@ -7033,7 +7690,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 116
+                  "type": 126
                 },
                 {
                   "name": "S",
@@ -7045,7 +7702,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 118,
+                      "type": 128,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -7056,20 +7713,20 @@
             }
           },
           {
-            "id": 118,
+            "id": 128,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 116
+                  "type": 126
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 119,
+            "id": 129,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7107,7 +7764,7 @@
                     },
                     {
                       "name": "delegators",
-                      "type": 120,
+                      "type": 130,
                       "typeName": "OrderedSet<Stake<AccountId, Balance>, MaxDelegatorsPerCandidate>",
                       "docs": []
                     },
@@ -7119,7 +7776,7 @@
                     },
                     {
                       "name": "status",
-                      "type": 122,
+                      "type": 132,
                       "typeName": "CandidateStatus",
                       "docs": []
                     }
@@ -7130,7 +7787,7 @@
             }
           },
           {
-            "id": 120,
+            "id": 130,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7140,7 +7797,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 116
+                  "type": 126
                 },
                 {
                   "name": "S",
@@ -7152,7 +7809,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 121,
+                      "type": 131,
                       "typeName": "BoundedVec<T, S>",
                       "docs": []
                     }
@@ -7163,7 +7820,7 @@
             }
           },
           {
-            "id": 121,
+            "id": 131,
             "type": {
               "path": [
                 "frame_support",
@@ -7174,7 +7831,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 116
+                  "type": 126
                 },
                 {
                   "name": "S",
@@ -7186,7 +7843,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 118,
+                      "type": 128,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -7197,7 +7854,7 @@
             }
           },
           {
-            "id": 122,
+            "id": 132,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7234,7 +7891,7 @@
             }
           },
           {
-            "id": 123,
+            "id": 133,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7269,7 +7926,7 @@
             }
           },
           {
-            "id": 124,
+            "id": 134,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7279,7 +7936,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 116
+                  "type": 126
                 },
                 {
                   "name": "S",
@@ -7291,7 +7948,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 125,
+                      "type": 135,
                       "typeName": "BoundedVec<T, S>",
                       "docs": []
                     }
@@ -7302,7 +7959,7 @@
             }
           },
           {
-            "id": 125,
+            "id": 135,
             "type": {
               "path": [
                 "frame_support",
@@ -7313,7 +7970,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 116
+                  "type": 126
                 },
                 {
                   "name": "S",
@@ -7325,7 +7982,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 118,
+                      "type": 128,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -7336,7 +7993,7 @@
             }
           },
           {
-            "id": 126,
+            "id": 136,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7349,13 +8006,13 @@
                   "fields": [
                     {
                       "name": "collator",
-                      "type": 127,
+                      "type": 137,
                       "typeName": "StakingInfo",
                       "docs": []
                     },
                     {
                       "name": "delegator",
-                      "type": 127,
+                      "type": 137,
                       "typeName": "StakingInfo",
                       "docs": []
                     }
@@ -7366,7 +8023,7 @@
             }
           },
           {
-            "id": 127,
+            "id": 137,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7379,13 +8036,13 @@
                   "fields": [
                     {
                       "name": "max_rate",
-                      "type": 29,
+                      "type": 30,
                       "typeName": "Perquintill",
                       "docs": []
                     },
                     {
                       "name": "reward_rate",
-                      "type": 128,
+                      "type": 138,
                       "typeName": "RewardRate",
                       "docs": []
                     }
@@ -7396,7 +8053,7 @@
             }
           },
           {
-            "id": 128,
+            "id": 138,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7409,13 +8066,13 @@
                   "fields": [
                     {
                       "name": "annual",
-                      "type": 29,
+                      "type": 30,
                       "typeName": "Perquintill",
                       "docs": []
                     },
                     {
                       "name": "per_block",
-                      "type": 29,
+                      "type": 30,
                       "typeName": "Perquintill",
                       "docs": []
                     }
@@ -7426,7 +8083,7 @@
             }
           },
           {
-            "id": 129,
+            "id": 139,
             "type": {
               "path": [
                 "frame_support",
@@ -7453,7 +8110,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 130,
+                      "type": 140,
                       "typeName": "BTreeMap<K, V>",
                       "docs": []
                     }
@@ -7464,7 +8121,7 @@
             }
           },
           {
-            "id": 130,
+            "id": 140,
             "type": {
               "path": [
                 "BTreeMap"
@@ -7484,7 +8141,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 131,
+                      "type": 141,
                       "typeName": null,
                       "docs": []
                     }
@@ -7495,20 +8152,20 @@
             }
           },
           {
-            "id": 131,
+            "id": 141,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 132
+                  "type": 142
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 132,
+            "id": 142,
             "type": {
               "path": [],
               "params": [],
@@ -7522,7 +8179,7 @@
             }
           },
           {
-            "id": 133,
+            "id": 143,
             "type": {
               "path": [
                 "parachain_staking",
@@ -7562,25 +8219,25 @@
                       "fields": [
                         {
                           "name": "collator_max_rate_percentage",
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         },
                         {
                           "name": "collator_annual_reward_rate_percentage",
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         },
                         {
                           "name": "delegator_max_rate_percentage",
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         },
                         {
                           "name": "delegator_annual_reward_rate_percentage",
-                          "type": 29,
+                          "type": 30,
                           "typeName": "Perquintill",
                           "docs": []
                         }
@@ -7707,7 +8364,7 @@
                       "fields": [
                         {
                           "name": "collator",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -7779,9 +8436,7 @@
                         "- Reads: [Origin Account], DelegatorState,",
                         "  MaxCollatorCandidateStake, Locks, TotalCollatorStake,",
                         "  TopCandidates, MaxSelectedCandidates, CandidatePool,",
-                        "  CandidateCount",
                         "- Writes: Locks, TotalCollatorStake, CandidatePool, TopCandidates,",
-                        "  CandidateCount",
                         "# </weight>"
                       ]
                     },
@@ -7834,7 +8489,7 @@
                       "fields": [
                         {
                           "name": "collator",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -7970,7 +8625,7 @@
                       "fields": [
                         {
                           "name": "collator",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
@@ -8022,7 +8677,7 @@
                       "fields": [
                         {
                           "name": "collator",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
@@ -8101,9 +8756,7 @@
                         "which is bounded by by `MaxCollatorsPerDelegator`.",
                         "- Reads: [Origin Account], DelegatorState, BlockNumber, Unstaking,",
                         "  TopCandidates, MaxSelectedCandidates, C * CandidatePool,",
-                        "  CandidateCount",
                         "- Writes: Unstaking, CandidatePool, TotalCollatorStake,",
-                        "  CandidateCount",
                         "- Kills: DelegatorState",
                         "# </weight>"
                       ]
@@ -8113,7 +8766,7 @@
                       "fields": [
                         {
                           "name": "collator",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -8150,7 +8803,7 @@
                       "fields": [
                         {
                           "name": "candidate",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
@@ -8187,7 +8840,7 @@
                       "fields": [
                         {
                           "name": "candidate",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
@@ -8231,7 +8884,7 @@
                       "fields": [
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -8259,7 +8912,7 @@
             }
           },
           {
-            "id": 134,
+            "id": 144,
             "type": {
               "path": [
                 "parachain_staking",
@@ -8551,34 +9204,34 @@
             }
           },
           {
-            "id": 135,
+            "id": 145,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 136
+                  "type": 146
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 136,
+            "id": 146,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
                   0,
-                  137
+                  147
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 137,
+            "id": 147,
             "type": {
               "path": [
                 "spiritnet_runtime",
@@ -8590,7 +9243,7 @@
                   "fields": [
                     {
                       "name": "aura",
-                      "type": 138,
+                      "type": 148,
                       "typeName": "<Aura as $crate::BoundToRuntimeAppPublic>::Public",
                       "docs": []
                     }
@@ -8601,7 +9254,7 @@
             }
           },
           {
-            "id": 138,
+            "id": 148,
             "type": {
               "path": [
                 "sp_consensus_aura",
@@ -8615,7 +9268,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 139,
+                      "type": 149,
                       "typeName": "sr25519::Public",
                       "docs": []
                     }
@@ -8626,7 +9279,7 @@
             }
           },
           {
-            "id": 139,
+            "id": 149,
             "type": {
               "path": [
                 "sp_core",
@@ -8650,7 +9303,7 @@
             }
           },
           {
-            "id": 140,
+            "id": 150,
             "type": {
               "path": [],
               "params": [],
@@ -8663,13 +9316,13 @@
             }
           },
           {
-            "id": 141,
+            "id": 151,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  142,
+                  152,
                   10
                 ]
               },
@@ -8677,7 +9330,7 @@
             }
           },
           {
-            "id": 142,
+            "id": 152,
             "type": {
               "path": [
                 "sp_core",
@@ -8701,7 +9354,7 @@
             }
           },
           {
-            "id": 143,
+            "id": 153,
             "type": {
               "path": [
                 "pallet_session",
@@ -8722,7 +9375,7 @@
                       "fields": [
                         {
                           "name": "keys",
-                          "type": 137,
+                          "type": 147,
                           "typeName": "T::Keys",
                           "docs": []
                         },
@@ -8783,7 +9436,7 @@
             }
           },
           {
-            "id": 144,
+            "id": 154,
             "type": {
               "path": [
                 "pallet_session",
@@ -8848,7 +9501,7 @@
             }
           },
           {
-            "id": 145,
+            "id": 155,
             "type": {
               "path": [
                 "frame_support",
@@ -8859,7 +9512,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 138
+                  "type": 148
                 },
                 {
                   "name": "S",
@@ -8871,7 +9524,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 146,
+                      "type": 156,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -8882,20 +9535,20 @@
             }
           },
           {
-            "id": 146,
+            "id": 156,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 138
+                  "type": 148
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 147,
+            "id": 157,
             "type": {
               "path": [
                 "sp_consensus_slots",
@@ -8918,7 +9571,7 @@
             }
           },
           {
-            "id": 148,
+            "id": 158,
             "type": {
               "path": [
                 "cumulus_pallet_aura_ext",
@@ -8942,20 +9595,20 @@
             }
           },
           {
-            "id": 149,
+            "id": 159,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 150
+                  "type": 160
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 150,
+            "id": 160,
             "type": {
               "path": [],
               "params": [],
@@ -8970,13 +9623,13 @@
             }
           },
           {
-            "id": 151,
+            "id": 161,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  32,
+                  33,
                   6
                 ]
               },
@@ -8984,7 +9637,7 @@
             }
           },
           {
-            "id": 152,
+            "id": 162,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9049,7 +9702,7 @@
                         },
                         {
                           "name": "expiry",
-                          "type": 69,
+                          "type": 80,
                           "typeName": "Option<BlockNumber>",
                           "docs": []
                         }
@@ -9064,7 +9717,7 @@
             }
           },
           {
-            "id": 153,
+            "id": 163,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9093,7 +9746,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 154,
+                          "type": 164,
                           "typeName": "ReferendumStatus<BlockNumber, Hash, Balance>",
                           "docs": []
                         }
@@ -9106,7 +9759,7 @@
                       "fields": [
                         {
                           "name": "approved",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         },
@@ -9127,7 +9780,7 @@
             }
           },
           {
-            "id": 154,
+            "id": 164,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9165,7 +9818,7 @@
                     },
                     {
                       "name": "threshold",
-                      "type": 33,
+                      "type": 34,
                       "typeName": "VoteThreshold",
                       "docs": []
                     },
@@ -9177,7 +9830,7 @@
                     },
                     {
                       "name": "tally",
-                      "type": 155,
+                      "type": 165,
                       "typeName": "Tally<Balance>",
                       "docs": []
                     }
@@ -9188,7 +9841,7 @@
             }
           },
           {
-            "id": 155,
+            "id": 165,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9229,7 +9882,7 @@
             }
           },
           {
-            "id": 156,
+            "id": 166,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9258,19 +9911,19 @@
                       "fields": [
                         {
                           "name": "votes",
-                          "type": 157,
+                          "type": 167,
                           "typeName": "Vec<(ReferendumIndex, AccountVote<Balance>)>",
                           "docs": []
                         },
                         {
                           "name": "delegations",
-                          "type": 161,
+                          "type": 169,
                           "typeName": "Delegations<Balance>",
                           "docs": []
                         },
                         {
                           "name": "prior",
-                          "type": 162,
+                          "type": 170,
                           "typeName": "PriorLock<BlockNumber, Balance>",
                           "docs": []
                         }
@@ -9295,19 +9948,19 @@
                         },
                         {
                           "name": "conviction",
-                          "type": 163,
+                          "type": 171,
                           "typeName": "Conviction",
                           "docs": []
                         },
                         {
                           "name": "delegations",
-                          "type": 161,
+                          "type": 169,
                           "typeName": "Delegations<Balance>",
                           "docs": []
                         },
                         {
                           "name": "prior",
-                          "type": 162,
+                          "type": 170,
                           "typeName": "PriorLock<BlockNumber, Balance>",
                           "docs": []
                         }
@@ -9322,119 +9975,34 @@
             }
           },
           {
-            "id": 157,
+            "id": 167,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 158
+                  "type": 168
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 158,
+            "id": 168,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
                   7,
-                  159
+                  37
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 159,
-            "type": {
-              "path": [
-                "pallet_democracy",
-                "vote",
-                "AccountVote"
-              ],
-              "params": [
-                {
-                  "name": "Balance",
-                  "type": 6
-                }
-              ],
-              "def": {
-                "variant": {
-                  "variants": [
-                    {
-                      "name": "Standard",
-                      "fields": [
-                        {
-                          "name": "vote",
-                          "type": 160,
-                          "typeName": "Vote",
-                          "docs": []
-                        },
-                        {
-                          "name": "balance",
-                          "type": 6,
-                          "typeName": "Balance",
-                          "docs": []
-                        }
-                      ],
-                      "index": 0,
-                      "docs": []
-                    },
-                    {
-                      "name": "Split",
-                      "fields": [
-                        {
-                          "name": "aye",
-                          "type": 6,
-                          "typeName": "Balance",
-                          "docs": []
-                        },
-                        {
-                          "name": "nay",
-                          "type": 6,
-                          "typeName": "Balance",
-                          "docs": []
-                        }
-                      ],
-                      "index": 1,
-                      "docs": []
-                    }
-                  ]
-                }
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 160,
-            "type": {
-              "path": [
-                "pallet_democracy",
-                "vote",
-                "Vote"
-              ],
-              "params": [],
-              "def": {
-                "composite": {
-                  "fields": [
-                    {
-                      "name": null,
-                      "type": 2,
-                      "typeName": null,
-                      "docs": []
-                    }
-                  ]
-                }
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 161,
+            "id": 169,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9469,7 +10037,7 @@
             }
           },
           {
-            "id": 162,
+            "id": 170,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9508,7 +10076,7 @@
             }
           },
           {
-            "id": 163,
+            "id": 171,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9568,13 +10136,27 @@
             }
           },
           {
-            "id": 164,
+            "id": 172,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
                   9,
+                  34
+                ]
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 173,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "tuple": [
+                  4,
                   33
                 ]
               },
@@ -9582,21 +10164,7 @@
             }
           },
           {
-            "id": 165,
-            "type": {
-              "path": [],
-              "params": [],
-              "def": {
-                "tuple": [
-                  4,
-                  32
-                ]
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 166,
+            "id": 174,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9619,7 +10187,7 @@
             }
           },
           {
-            "id": 167,
+            "id": 175,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -9646,7 +10214,7 @@
                         },
                         {
                           "name": "value",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "BalanceOf<T>",
                           "docs": []
                         }
@@ -9671,13 +10239,13 @@
                       "fields": [
                         {
                           "name": "proposal",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "PropIndex",
                           "docs": []
                         },
                         {
                           "name": "seconds_upper_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -9701,13 +10269,13 @@
                       "fields": [
                         {
                           "name": "ref_index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ReferendumIndex",
                           "docs": []
                         },
                         {
                           "name": "vote",
-                          "type": 159,
+                          "type": 37,
                           "typeName": "AccountVote<BalanceOf<T>>",
                           "docs": []
                         }
@@ -9889,7 +10457,7 @@
                       "fields": [
                         {
                           "name": "ref_index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ReferendumIndex",
                           "docs": []
                         }
@@ -9937,7 +10505,7 @@
                         },
                         {
                           "name": "conviction",
-                          "type": 163,
+                          "type": 171,
                           "typeName": "Conviction",
                           "docs": []
                         },
@@ -10094,7 +10662,7 @@
                         },
                         {
                           "name": "proposal_len_upper_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -10247,7 +10815,7 @@
                         },
                         {
                           "name": "maybe_ref_index",
-                          "type": 168,
+                          "type": 176,
                           "typeName": "Option<ReferendumIndex>",
                           "docs": []
                         }
@@ -10276,7 +10844,7 @@
                       "fields": [
                         {
                           "name": "prop_index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "PropIndex",
                           "docs": []
                         }
@@ -10301,7 +10869,7 @@
             }
           },
           {
-            "id": 168,
+            "id": 176,
             "type": {
               "path": [
                 "Option"
@@ -10341,7 +10909,7 @@
             }
           },
           {
-            "id": 169,
+            "id": 177,
             "type": {
               "path": [
                 "pallet_democracy",
@@ -10591,7 +11159,7 @@
             }
           },
           {
-            "id": 170,
+            "id": 178,
             "type": {
               "path": [
                 "frame_support",
@@ -10614,7 +11182,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 56,
+                      "type": 67,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -10625,7 +11193,7 @@
             }
           },
           {
-            "id": 171,
+            "id": 179,
             "type": {
               "path": [
                 "spiritnet_runtime",
@@ -10640,7 +11208,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 61,
+                          "type": 72,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<System, Runtime>",
                           "docs": []
                         }
@@ -10653,7 +11221,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 80,
+                          "type": 91,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Timestamp, Runtime>",
                           "docs": []
                         }
@@ -10666,7 +11234,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 83,
+                          "type": 94,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Indices, Runtime>",
                           "docs": []
                         }
@@ -10679,7 +11247,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 93,
+                          "type": 104,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Balances, Runtime>",
                           "docs": []
                         }
@@ -10692,7 +11260,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 106,
+                          "type": 117,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Authorship, Runtime>",
                           "docs": []
                         }
@@ -10705,7 +11273,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 133,
+                          "type": 143,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<ParachainStaking, Runtime>",
                           "docs": []
                         }
@@ -10718,7 +11286,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 143,
+                          "type": 153,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Session, Runtime>",
                           "docs": []
                         }
@@ -10731,7 +11299,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 148,
+                          "type": 158,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<AuraExt, Runtime>",
                           "docs": []
                         }
@@ -10744,7 +11312,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 167,
+                          "type": 175,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Democracy, Runtime>",
                           "docs": []
                         }
@@ -10757,7 +11325,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 172,
+                          "type": 180,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Council, Runtime>",
                           "docs": []
                         }
@@ -10770,7 +11338,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 173,
+                          "type": 181,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<TechnicalCommittee, Runtime>",
                           "docs": []
                         }
@@ -10783,7 +11351,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 174,
+                          "type": 182,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<TechnicalMembership, Runtime>",
                           "docs": []
                         }
@@ -10796,7 +11364,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 175,
+                          "type": 183,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Treasury, Runtime>",
                           "docs": []
                         }
@@ -10809,7 +11377,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 176,
+                          "type": 184,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Utility, Runtime>",
                           "docs": []
                         }
@@ -10822,7 +11390,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 184,
+                          "type": 192,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Vesting, Runtime>",
                           "docs": []
                         }
@@ -10835,7 +11403,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 186,
+                          "type": 194,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Scheduler, Runtime>",
                           "docs": []
                         }
@@ -10844,11 +11412,37 @@
                       "docs": []
                     },
                     {
+                      "name": "Proxy",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 197,
+                          "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Proxy, Runtime>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 43,
+                      "docs": []
+                    },
+                    {
+                      "name": "Preimage",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 199,
+                          "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Preimage, Runtime>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 44,
+                      "docs": []
+                    },
+                    {
                       "name": "KiltLaunch",
                       "fields": [
                         {
                           "name": null,
-                          "type": 188,
+                          "type": 200,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<KiltLaunch, Runtime>",
                           "docs": []
                         }
@@ -10861,7 +11455,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 190,
+                          "type": 202,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Ctype, Runtime>",
                           "docs": []
                         }
@@ -10874,7 +11468,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 191,
+                          "type": 203,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Attestation, Runtime>",
                           "docs": []
                         }
@@ -10887,7 +11481,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 192,
+                          "type": 204,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Delegation, Runtime>",
                           "docs": []
                         }
@@ -10900,7 +11494,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 199,
+                          "type": 211,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Did, Runtime>",
                           "docs": []
                         }
@@ -10913,7 +11507,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 220,
+                          "type": 232,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<DidLookup, Runtime>",
                           "docs": []
                         }
@@ -10922,11 +11516,24 @@
                       "docs": []
                     },
                     {
+                      "name": "Web3Names",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 234,
+                          "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<Web3Names, Runtime>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 68,
+                      "docs": []
+                    },
+                    {
                       "name": "ParachainSystem",
                       "fields": [
                         {
                           "name": null,
-                          "type": 222,
+                          "type": 235,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::dispatch\n::CallableCallFor<ParachainSystem, Runtime>",
                           "docs": []
                         }
@@ -10941,7 +11548,7 @@
             }
           },
           {
-            "id": 172,
+            "id": 180,
             "type": {
               "path": [
                 "pallet_collective",
@@ -10966,13 +11573,13 @@
                       "fields": [
                         {
                           "name": "new_members",
-                          "type": 32,
+                          "type": 33,
                           "typeName": "Vec<T::AccountId>",
                           "docs": []
                         },
                         {
                           "name": "prime",
-                          "type": 105,
+                          "type": 116,
                           "typeName": "Option<T::AccountId>",
                           "docs": []
                         },
@@ -11024,13 +11631,13 @@
                       "fields": [
                         {
                           "name": "proposal",
-                          "type": 171,
+                          "type": 179,
                           "typeName": "Box<<T as Config<I>>::Proposal>",
                           "docs": []
                         },
                         {
                           "name": "length_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -11055,19 +11662,19 @@
                       "fields": [
                         {
                           "name": "threshold",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "MemberCount",
                           "docs": []
                         },
                         {
                           "name": "proposal",
-                          "type": 171,
+                          "type": 179,
                           "typeName": "Box<<T as Config<I>>::Proposal>",
                           "docs": []
                         },
                         {
                           "name": "length_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -11114,13 +11721,13 @@
                         },
                         {
                           "name": "index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ProposalIndex",
                           "docs": []
                         },
                         {
                           "name": "approve",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         }
@@ -11155,19 +11762,19 @@
                         },
                         {
                           "name": "index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ProposalIndex",
                           "docs": []
                         },
                         {
                           "name": "proposal_weight_bound",
-                          "type": 81,
+                          "type": 92,
                           "typeName": "Weight",
                           "docs": []
                         },
                         {
                           "name": "length_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -11245,7 +11852,7 @@
             }
           },
           {
-            "id": 173,
+            "id": 181,
             "type": {
               "path": [
                 "pallet_collective",
@@ -11270,13 +11877,13 @@
                       "fields": [
                         {
                           "name": "new_members",
-                          "type": 32,
+                          "type": 33,
                           "typeName": "Vec<T::AccountId>",
                           "docs": []
                         },
                         {
                           "name": "prime",
-                          "type": 105,
+                          "type": 116,
                           "typeName": "Option<T::AccountId>",
                           "docs": []
                         },
@@ -11328,13 +11935,13 @@
                       "fields": [
                         {
                           "name": "proposal",
-                          "type": 171,
+                          "type": 179,
                           "typeName": "Box<<T as Config<I>>::Proposal>",
                           "docs": []
                         },
                         {
                           "name": "length_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -11359,19 +11966,19 @@
                       "fields": [
                         {
                           "name": "threshold",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "MemberCount",
                           "docs": []
                         },
                         {
                           "name": "proposal",
-                          "type": 171,
+                          "type": 179,
                           "typeName": "Box<<T as Config<I>>::Proposal>",
                           "docs": []
                         },
                         {
                           "name": "length_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -11418,13 +12025,13 @@
                         },
                         {
                           "name": "index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ProposalIndex",
                           "docs": []
                         },
                         {
                           "name": "approve",
-                          "type": 37,
+                          "type": 40,
                           "typeName": "bool",
                           "docs": []
                         }
@@ -11459,19 +12066,19 @@
                         },
                         {
                           "name": "index",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ProposalIndex",
                           "docs": []
                         },
                         {
                           "name": "proposal_weight_bound",
-                          "type": 81,
+                          "type": 92,
                           "typeName": "Weight",
                           "docs": []
                         },
                         {
                           "name": "length_bound",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "u32",
                           "docs": []
                         }
@@ -11549,7 +12156,7 @@
             }
           },
           {
-            "id": 174,
+            "id": 182,
             "type": {
               "path": [
                 "pallet_membership",
@@ -11633,7 +12240,7 @@
                       "fields": [
                         {
                           "name": "members",
-                          "type": 32,
+                          "type": 33,
                           "typeName": "Vec<T::AccountId>",
                           "docs": []
                         }
@@ -11701,7 +12308,7 @@
             }
           },
           {
-            "id": 175,
+            "id": 183,
             "type": {
               "path": [
                 "pallet_treasury",
@@ -11726,13 +12333,13 @@
                       "fields": [
                         {
                           "name": "value",
-                          "type": 97,
+                          "type": 108,
                           "typeName": "BalanceOf<T, I>",
                           "docs": []
                         },
                         {
                           "name": "beneficiary",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -11755,7 +12362,7 @@
                       "fields": [
                         {
                           "name": "proposal_id",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ProposalIndex",
                           "docs": []
                         }
@@ -11778,7 +12385,7 @@
                       "fields": [
                         {
                           "name": "proposal_id",
-                          "type": 59,
+                          "type": 70,
                           "typeName": "ProposalIndex",
                           "docs": []
                         }
@@ -11806,7 +12413,7 @@
             }
           },
           {
-            "id": 176,
+            "id": 184,
             "type": {
               "path": [
                 "pallet_utility",
@@ -11827,7 +12434,7 @@
                       "fields": [
                         {
                           "name": "calls",
-                          "type": 177,
+                          "type": 185,
                           "typeName": "Vec<<T as Config>::Call>",
                           "docs": []
                         }
@@ -11860,13 +12467,13 @@
                       "fields": [
                         {
                           "name": "index",
-                          "type": 78,
+                          "type": 52,
                           "typeName": "u16",
                           "docs": []
                         },
                         {
                           "name": "call",
-                          "type": 171,
+                          "type": 179,
                           "typeName": "Box<<T as Config>::Call>",
                           "docs": []
                         }
@@ -11893,7 +12500,7 @@
                       "fields": [
                         {
                           "name": "calls",
-                          "type": 177,
+                          "type": 185,
                           "typeName": "Vec<<T as Config>::Call>",
                           "docs": []
                         }
@@ -11921,13 +12528,13 @@
                       "fields": [
                         {
                           "name": "as_origin",
-                          "type": 178,
+                          "type": 186,
                           "typeName": "Box<T::PalletsOrigin>",
                           "docs": []
                         },
                         {
                           "name": "call",
-                          "type": 171,
+                          "type": 179,
                           "typeName": "Box<<T as Config>::Call>",
                           "docs": []
                         }
@@ -11955,20 +12562,20 @@
             }
           },
           {
-            "id": 177,
+            "id": 185,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 171
+                  "type": 179
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 178,
+            "id": 186,
             "type": {
               "path": [
                 "spiritnet_runtime",
@@ -11983,7 +12590,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 179,
+                          "type": 187,
                           "typeName": "frame_system::Origin<Runtime>",
                           "docs": []
                         }
@@ -11996,7 +12603,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 180,
+                          "type": 188,
                           "typeName": "pallet_collective::Origin<Runtime, pallet_collective::Instance1>",
                           "docs": []
                         }
@@ -12009,7 +12616,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 181,
+                          "type": 189,
                           "typeName": "pallet_collective::Origin<Runtime, pallet_collective::Instance2>",
                           "docs": []
                         }
@@ -12022,7 +12629,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 182,
+                          "type": 190,
                           "typeName": "did::Origin<Runtime>",
                           "docs": []
                         }
@@ -12035,7 +12642,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 183,
+                          "type": 191,
                           "typeName": "self::sp_api_hidden_includes_construct_runtime::hidden_include::Void",
                           "docs": []
                         }
@@ -12050,10 +12657,11 @@
             }
           },
           {
-            "id": 179,
+            "id": 187,
             "type": {
               "path": [
-                "frame_system",
+                "frame_support",
+                "dispatch",
                 "RawOrigin"
               ],
               "params": [
@@ -12097,7 +12705,7 @@
             }
           },
           {
-            "id": 180,
+            "id": 188,
             "type": {
               "path": [
                 "pallet_collective",
@@ -12161,7 +12769,7 @@
             }
           },
           {
-            "id": 181,
+            "id": 189,
             "type": {
               "path": [
                 "pallet_collective",
@@ -12225,7 +12833,7 @@
             }
           },
           {
-            "id": 182,
+            "id": 190,
             "type": {
               "path": [
                 "did",
@@ -12264,7 +12872,7 @@
             }
           },
           {
-            "id": 183,
+            "id": 191,
             "type": {
               "path": [
                 "sp_core",
@@ -12280,7 +12888,7 @@
             }
           },
           {
-            "id": 184,
+            "id": 192,
             "type": {
               "path": [
                 "pallet_vesting",
@@ -12321,7 +12929,7 @@
                       "fields": [
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -12350,13 +12958,13 @@
                       "fields": [
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "schedule",
-                          "type": 185,
+                          "type": 193,
                           "typeName": "VestingInfo<BalanceOf<T>, T::BlockNumber>",
                           "docs": []
                         }
@@ -12387,19 +12995,19 @@
                       "fields": [
                         {
                           "name": "source",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "schedule",
-                          "type": 185,
+                          "type": 193,
                           "typeName": "VestingInfo<BalanceOf<T>, T::BlockNumber>",
                           "docs": []
                         }
@@ -12476,7 +13084,7 @@
             }
           },
           {
-            "id": 185,
+            "id": 193,
             "type": {
               "path": [
                 "pallet_vesting",
@@ -12521,7 +13129,7 @@
             }
           },
           {
-            "id": 186,
+            "id": 194,
             "type": {
               "path": [
                 "pallet_scheduler",
@@ -12548,7 +13156,7 @@
                         },
                         {
                           "name": "maybe_periodic",
-                          "type": 187,
+                          "type": 195,
                           "typeName": "Option<schedule::Period<T::BlockNumber>>",
                           "docs": []
                         },
@@ -12560,8 +13168,8 @@
                         },
                         {
                           "name": "call",
-                          "type": 171,
-                          "typeName": "Box<<T as Config>::Call>",
+                          "type": 196,
+                          "typeName": "Box<CallOrHashOf<T>>",
                           "docs": []
                         }
                       ],
@@ -12608,7 +13216,7 @@
                         },
                         {
                           "name": "maybe_periodic",
-                          "type": 187,
+                          "type": 195,
                           "typeName": "Option<schedule::Period<T::BlockNumber>>",
                           "docs": []
                         },
@@ -12620,8 +13228,8 @@
                         },
                         {
                           "name": "call",
-                          "type": 171,
-                          "typeName": "Box<<T as Config>::Call>",
+                          "type": 196,
+                          "typeName": "Box<CallOrHashOf<T>>",
                           "docs": []
                         }
                       ],
@@ -12656,7 +13264,7 @@
                         },
                         {
                           "name": "maybe_periodic",
-                          "type": 187,
+                          "type": 195,
                           "typeName": "Option<schedule::Period<T::BlockNumber>>",
                           "docs": []
                         },
@@ -12668,8 +13276,8 @@
                         },
                         {
                           "name": "call",
-                          "type": 171,
-                          "typeName": "Box<<T as Config>::Call>",
+                          "type": 196,
+                          "typeName": "Box<CallOrHashOf<T>>",
                           "docs": []
                         }
                       ],
@@ -12699,7 +13307,7 @@
                         },
                         {
                           "name": "maybe_periodic",
-                          "type": 187,
+                          "type": 195,
                           "typeName": "Option<schedule::Period<T::BlockNumber>>",
                           "docs": []
                         },
@@ -12711,8 +13319,8 @@
                         },
                         {
                           "name": "call",
-                          "type": 171,
-                          "typeName": "Box<<T as Config>::Call>",
+                          "type": 196,
+                          "typeName": "Box<CallOrHashOf<T>>",
                           "docs": []
                         }
                       ],
@@ -12734,7 +13342,7 @@
             }
           },
           {
-            "id": 187,
+            "id": 195,
             "type": {
               "path": [
                 "Option"
@@ -12742,7 +13350,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 44
+                  "type": 47
                 }
               ],
               "def": {
@@ -12759,7 +13367,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 44,
+                          "type": 47,
                           "typeName": null,
                           "docs": []
                         }
@@ -12774,7 +13382,622 @@
             }
           },
           {
-            "id": 188,
+            "id": 196,
+            "type": {
+              "path": [
+                "frame_support",
+                "traits",
+                "schedule",
+                "MaybeHashed"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 179
+                },
+                {
+                  "name": "Hash",
+                  "type": 9
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Value",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 179,
+                          "typeName": "T",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "Hash",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 9,
+                          "typeName": "Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 197,
+            "type": {
+              "path": [
+                "pallet_proxy",
+                "pallet",
+                "Call"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "proxy",
+                      "fields": [
+                        {
+                          "name": "real",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "force_proxy_type",
+                          "type": 198,
+                          "typeName": "Option<T::ProxyType>",
+                          "docs": []
+                        },
+                        {
+                          "name": "call",
+                          "type": 179,
+                          "typeName": "Box<<T as Config>::Call>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": [
+                        "Dispatch the given `call` from an account that the sender is authorised for through",
+                        "`add_proxy`.",
+                        "",
+                        "Removes any corresponding announcement(s).",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "Parameters:",
+                        "- `real`: The account that the proxy will make a call on behalf of.",
+                        "- `force_proxy_type`: Specify the exact proxy type to be used and checked for this call.",
+                        "- `call`: The call to be made by the `real` account.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of the number of proxies the user has (P).",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "add_proxy",
+                      "fields": [
+                        {
+                          "name": "delegate",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "proxy_type",
+                          "type": 51,
+                          "typeName": "T::ProxyType",
+                          "docs": []
+                        },
+                        {
+                          "name": "delay",
+                          "type": 4,
+                          "typeName": "T::BlockNumber",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": [
+                        "Register a proxy account for the sender that is able to make calls on its behalf.",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "Parameters:",
+                        "- `proxy`: The account that the `caller` would like to make a proxy.",
+                        "- `proxy_type`: The permissions allowed for this proxy account.",
+                        "- `delay`: The announcement period required of the initial proxy. Will generally be",
+                        "zero.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of the number of proxies the user has (P).",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "remove_proxy",
+                      "fields": [
+                        {
+                          "name": "delegate",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "proxy_type",
+                          "type": 51,
+                          "typeName": "T::ProxyType",
+                          "docs": []
+                        },
+                        {
+                          "name": "delay",
+                          "type": 4,
+                          "typeName": "T::BlockNumber",
+                          "docs": []
+                        }
+                      ],
+                      "index": 2,
+                      "docs": [
+                        "Unregister a proxy account for the sender.",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "Parameters:",
+                        "- `proxy`: The account that the `caller` would like to remove as a proxy.",
+                        "- `proxy_type`: The permissions currently enabled for the removed proxy account.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of the number of proxies the user has (P).",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "remove_proxies",
+                      "fields": [],
+                      "index": 3,
+                      "docs": [
+                        "Unregister all proxy accounts for the sender.",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "WARNING: This may be called on accounts created by `anonymous`, however if done, then",
+                        "the unreserved fees will be inaccessible. **All access to this account will be lost.**",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of the number of proxies the user has (P).",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "anonymous",
+                      "fields": [
+                        {
+                          "name": "proxy_type",
+                          "type": 51,
+                          "typeName": "T::ProxyType",
+                          "docs": []
+                        },
+                        {
+                          "name": "delay",
+                          "type": 4,
+                          "typeName": "T::BlockNumber",
+                          "docs": []
+                        },
+                        {
+                          "name": "index",
+                          "type": 52,
+                          "typeName": "u16",
+                          "docs": []
+                        }
+                      ],
+                      "index": 4,
+                      "docs": [
+                        "Spawn a fresh new account that is guaranteed to be otherwise inaccessible, and",
+                        "initialize it with a proxy of `proxy_type` for `origin` sender.",
+                        "",
+                        "Requires a `Signed` origin.",
+                        "",
+                        "- `proxy_type`: The type of the proxy that the sender will be registered as over the",
+                        "new account. This will almost always be the most permissive `ProxyType` possible to",
+                        "allow for maximum flexibility.",
+                        "- `index`: A disambiguation index, in case this is called multiple times in the same",
+                        "transaction (e.g. with `utility::batch`). Unless you're using `batch` you probably just",
+                        "want to use `0`.",
+                        "- `delay`: The announcement period required of the initial proxy. Will generally be",
+                        "zero.",
+                        "",
+                        "Fails with `Duplicate` if this has already been called in this transaction, from the",
+                        "same sender, with the same parameters.",
+                        "",
+                        "Fails if there are insufficient funds to pay for deposit.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of the number of proxies the user has (P).",
+                        "# </weight>",
+                        "TODO: Might be over counting 1 read"
+                      ]
+                    },
+                    {
+                      "name": "kill_anonymous",
+                      "fields": [
+                        {
+                          "name": "spawner",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "proxy_type",
+                          "type": 51,
+                          "typeName": "T::ProxyType",
+                          "docs": []
+                        },
+                        {
+                          "name": "index",
+                          "type": 52,
+                          "typeName": "u16",
+                          "docs": []
+                        },
+                        {
+                          "name": "height",
+                          "type": 92,
+                          "typeName": "T::BlockNumber",
+                          "docs": []
+                        },
+                        {
+                          "name": "ext_index",
+                          "type": 70,
+                          "typeName": "u32",
+                          "docs": []
+                        }
+                      ],
+                      "index": 5,
+                      "docs": [
+                        "Removes a previously spawned anonymous proxy.",
+                        "",
+                        "WARNING: **All access to this account will be lost.** Any funds held in it will be",
+                        "inaccessible.",
+                        "",
+                        "Requires a `Signed` origin, and the sender account must have been created by a call to",
+                        "`anonymous` with corresponding parameters.",
+                        "",
+                        "- `spawner`: The account that originally called `anonymous` to create this account.",
+                        "- `index`: The disambiguation index originally passed to `anonymous`. Probably `0`.",
+                        "- `proxy_type`: The proxy type originally passed to `anonymous`.",
+                        "- `height`: The height of the chain when the call to `anonymous` was processed.",
+                        "- `ext_index`: The extrinsic index in which the call to `anonymous` was processed.",
+                        "",
+                        "Fails with `NoPermission` in case the caller is not a previously created anonymous",
+                        "account whose `anonymous` call has corresponding parameters.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of the number of proxies the user has (P).",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "announce",
+                      "fields": [
+                        {
+                          "name": "real",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "call_hash",
+                          "type": 9,
+                          "typeName": "CallHashOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 6,
+                      "docs": [
+                        "Publish the hash of a proxy-call that will be made in the future.",
+                        "",
+                        "This must be called some number of blocks before the corresponding `proxy` is attempted",
+                        "if the delay associated with the proxy relationship is greater than zero.",
+                        "",
+                        "No more than `MaxPending` announcements may be made at any one time.",
+                        "",
+                        "This will take a deposit of `AnnouncementDepositFactor` as well as",
+                        "`AnnouncementDepositBase` if there are no other pending announcements.",
+                        "",
+                        "The dispatch origin for this call must be _Signed_ and a proxy of `real`.",
+                        "",
+                        "Parameters:",
+                        "- `real`: The account that the proxy will make a call on behalf of.",
+                        "- `call_hash`: The hash of the call to be made by the `real` account.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of:",
+                        "- A: the number of announcements made.",
+                        "- P: the number of proxies the user has.",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "remove_announcement",
+                      "fields": [
+                        {
+                          "name": "real",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "call_hash",
+                          "type": 9,
+                          "typeName": "CallHashOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 7,
+                      "docs": [
+                        "Remove a given announcement.",
+                        "",
+                        "May be called by a proxy account to remove a call they previously announced and return",
+                        "the deposit.",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "Parameters:",
+                        "- `real`: The account that the proxy will make a call on behalf of.",
+                        "- `call_hash`: The hash of the call to be made by the `real` account.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of:",
+                        "- A: the number of announcements made.",
+                        "- P: the number of proxies the user has.",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "reject_announcement",
+                      "fields": [
+                        {
+                          "name": "delegate",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "call_hash",
+                          "type": 9,
+                          "typeName": "CallHashOf<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 8,
+                      "docs": [
+                        "Remove the given announcement of a delegate.",
+                        "",
+                        "May be called by a target (proxied) account to remove a call that one of their delegates",
+                        "(`delegate`) has announced they want to execute. The deposit is returned.",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "Parameters:",
+                        "- `delegate`: The account that previously announced the call.",
+                        "- `call_hash`: The hash of the call to be made.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of:",
+                        "- A: the number of announcements made.",
+                        "- P: the number of proxies the user has.",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "proxy_announced",
+                      "fields": [
+                        {
+                          "name": "delegate",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "real",
+                          "type": 0,
+                          "typeName": "T::AccountId",
+                          "docs": []
+                        },
+                        {
+                          "name": "force_proxy_type",
+                          "type": 198,
+                          "typeName": "Option<T::ProxyType>",
+                          "docs": []
+                        },
+                        {
+                          "name": "call",
+                          "type": 179,
+                          "typeName": "Box<<T as Config>::Call>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 9,
+                      "docs": [
+                        "Dispatch the given `call` from an account that the sender is authorized for through",
+                        "`add_proxy`.",
+                        "",
+                        "Removes any corresponding announcement(s).",
+                        "",
+                        "The dispatch origin for this call must be _Signed_.",
+                        "",
+                        "Parameters:",
+                        "- `real`: The account that the proxy will make a call on behalf of.",
+                        "- `force_proxy_type`: Specify the exact proxy type to be used and checked for this call.",
+                        "- `call`: The call to be made by the `real` account.",
+                        "",
+                        "# <weight>",
+                        "Weight is a function of:",
+                        "- A: the number of announcements made.",
+                        "- P: the number of proxies the user has.",
+                        "# </weight>"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "Contains one variant per dispatchable that can be called by an extrinsic."
+              ]
+            }
+          },
+          {
+            "id": 198,
+            "type": {
+              "path": [
+                "Option"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 51
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "None",
+                      "fields": [],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "Some",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 51,
+                          "typeName": null,
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 199,
+            "type": {
+              "path": [
+                "pallet_preimage",
+                "pallet",
+                "Call"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "note_preimage",
+                      "fields": [
+                        {
+                          "name": "bytes",
+                          "type": 10,
+                          "typeName": "Vec<u8>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": [
+                        "Register a preimage on-chain.",
+                        "",
+                        "If the preimage was previously requested, no fees or deposits are taken for providing",
+                        "the preimage. Otherwise, a deposit is taken proportional to the size of the preimage."
+                      ]
+                    },
+                    {
+                      "name": "unnote_preimage",
+                      "fields": [
+                        {
+                          "name": "hash",
+                          "type": 9,
+                          "typeName": "T::Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": [
+                        "Clear an unrequested preimage from the runtime storage."
+                      ]
+                    },
+                    {
+                      "name": "request_preimage",
+                      "fields": [
+                        {
+                          "name": "hash",
+                          "type": 9,
+                          "typeName": "T::Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 2,
+                      "docs": [
+                        "Request a preimage be uploaded to the chain without paying any fees or deposits.",
+                        "",
+                        "If the preimage requests has already been provided on-chain, we unreserve any deposit",
+                        "a user may have paid, and take the control of the preimage out of their hands."
+                      ]
+                    },
+                    {
+                      "name": "unrequest_preimage",
+                      "fields": [
+                        {
+                          "name": "hash",
+                          "type": 9,
+                          "typeName": "T::Hash",
+                          "docs": []
+                        }
+                      ],
+                      "index": 3,
+                      "docs": [
+                        "Clear a previously made request for a preimage.",
+                        "",
+                        "NOTE: THIS MUST NOT BE CALLED ON `hash` MORE TIMES THAN `request_preimage`."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "Contains one variant per dispatchable that can be called by an extrinsic."
+              ]
+            }
+          },
+          {
+            "id": 200,
             "type": {
               "path": [
                 "kilt_launch",
@@ -12827,7 +14050,7 @@
                       "fields": [
                         {
                           "name": "transfer_account",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -12850,13 +14073,13 @@
                       "fields": [
                         {
                           "name": "source",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -12907,13 +14130,13 @@
                       "fields": [
                         {
                           "name": "sources",
-                          "type": 189,
+                          "type": 201,
                           "typeName": "Vec<<T::Lookup as StaticLookup>::Source>",
                           "docs": []
                         },
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         }
@@ -12951,7 +14174,7 @@
                       "fields": [
                         {
                           "name": "target",
-                          "type": 94,
+                          "type": 105,
                           "typeName": "<T::Lookup as StaticLookup>::Source",
                           "docs": []
                         },
@@ -12994,20 +14217,20 @@
             }
           },
           {
-            "id": 189,
+            "id": 201,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 94
+                  "type": 105
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 190,
+            "id": 202,
             "type": {
               "path": [
                 "ctype",
@@ -13058,7 +14281,7 @@
             }
           },
           {
-            "id": 191,
+            "id": 203,
             "type": {
               "path": [
                 "attestation",
@@ -13091,7 +14314,7 @@
                         },
                         {
                           "name": "delegation_id",
-                          "type": 49,
+                          "type": 57,
                           "typeName": "Option<DelegationNodeIdOf<T>>",
                           "docs": []
                         }
@@ -13227,7 +14450,7 @@
             }
           },
           {
-            "id": 192,
+            "id": 204,
             "type": {
               "path": [
                 "delegation",
@@ -13311,13 +14534,13 @@
                         },
                         {
                           "name": "permissions",
-                          "type": 51,
+                          "type": 59,
                           "typeName": "Permissions",
                           "docs": []
                         },
                         {
                           "name": "delegate_signature",
-                          "type": 193,
+                          "type": 205,
                           "typeName": "DelegateSignatureTypeOf<T>",
                           "docs": []
                         }
@@ -13514,7 +14737,7 @@
             }
           },
           {
-            "id": 193,
+            "id": 205,
             "type": {
               "path": [
                 "did",
@@ -13530,7 +14753,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 194,
+                          "type": 206,
                           "typeName": "ed25519::Signature",
                           "docs": []
                         }
@@ -13543,7 +14766,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 196,
+                          "type": 208,
                           "typeName": "sr25519::Signature",
                           "docs": []
                         }
@@ -13556,7 +14779,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 197,
+                          "type": 209,
                           "typeName": "ecdsa::Signature",
                           "docs": []
                         }
@@ -13571,7 +14794,7 @@
             }
           },
           {
-            "id": 194,
+            "id": 206,
             "type": {
               "path": [
                 "sp_core",
@@ -13584,7 +14807,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 195,
+                      "type": 207,
                       "typeName": "[u8; 64]",
                       "docs": []
                     }
@@ -13595,7 +14818,7 @@
             }
           },
           {
-            "id": 195,
+            "id": 207,
             "type": {
               "path": [],
               "params": [],
@@ -13609,7 +14832,7 @@
             }
           },
           {
-            "id": 196,
+            "id": 208,
             "type": {
               "path": [
                 "sp_core",
@@ -13622,7 +14845,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 195,
+                      "type": 207,
                       "typeName": "[u8; 64]",
                       "docs": []
                     }
@@ -13633,7 +14856,7 @@
             }
           },
           {
-            "id": 197,
+            "id": 209,
             "type": {
               "path": [
                 "sp_core",
@@ -13646,7 +14869,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 198,
+                      "type": 210,
                       "typeName": "[u8; 65]",
                       "docs": []
                     }
@@ -13657,7 +14880,7 @@
             }
           },
           {
-            "id": 198,
+            "id": 210,
             "type": {
               "path": [],
               "params": [],
@@ -13671,7 +14894,7 @@
             }
           },
           {
-            "id": 199,
+            "id": 211,
             "type": {
               "path": [
                 "did",
@@ -13692,13 +14915,13 @@
                       "fields": [
                         {
                           "name": "details",
-                          "type": 200,
+                          "type": 212,
                           "typeName": "Box<DidCreationDetails<T>>",
                           "docs": []
                         },
                         {
                           "name": "signature",
-                          "type": 193,
+                          "type": 205,
                           "typeName": "DidSignature",
                           "docs": []
                         }
@@ -13743,7 +14966,7 @@
                       "fields": [
                         {
                           "name": "new_key",
-                          "type": 206,
+                          "type": 218,
                           "typeName": "DidVerificationKey",
                           "docs": []
                         }
@@ -13773,7 +14996,7 @@
                       "fields": [
                         {
                           "name": "new_key",
-                          "type": 206,
+                          "type": 218,
                           "typeName": "DidVerificationKey",
                           "docs": []
                         }
@@ -13825,7 +15048,7 @@
                       "fields": [
                         {
                           "name": "new_key",
-                          "type": 206,
+                          "type": 218,
                           "typeName": "DidVerificationKey",
                           "docs": []
                         }
@@ -13877,7 +15100,7 @@
                       "fields": [
                         {
                           "name": "new_key",
-                          "type": 202,
+                          "type": 214,
                           "typeName": "DidEncryptionKey",
                           "docs": []
                         }
@@ -13932,7 +15155,7 @@
                       "fields": [
                         {
                           "name": "service_endpoint",
-                          "type": 211,
+                          "type": 223,
                           "typeName": "DidEndpoint<T>",
                           "docs": []
                         }
@@ -13958,7 +15181,7 @@
                       "fields": [
                         {
                           "name": "service_id",
-                          "type": 212,
+                          "type": 224,
                           "typeName": "ServiceEndpointId<T>",
                           "docs": []
                         }
@@ -14063,13 +15286,13 @@
                       "fields": [
                         {
                           "name": "did_call",
-                          "type": 219,
+                          "type": 231,
                           "typeName": "Box<DidAuthorizedCallOperation<T>>",
                           "docs": []
                         },
                         {
                           "name": "signature",
-                          "type": 193,
+                          "type": 205,
                           "typeName": "DidSignature",
                           "docs": []
                         }
@@ -14122,7 +15345,7 @@
             }
           },
           {
-            "id": 200,
+            "id": 212,
             "type": {
               "path": [
                 "did",
@@ -14152,25 +15375,25 @@
                     },
                     {
                       "name": "new_key_agreement_keys",
-                      "type": 201,
+                      "type": 213,
                       "typeName": "DidNewKeyAgreementKeySet<T>",
                       "docs": []
                     },
                     {
                       "name": "new_attestation_key",
-                      "type": 205,
+                      "type": 217,
                       "typeName": "Option<DidVerificationKey>",
                       "docs": []
                     },
                     {
                       "name": "new_delegation_key",
-                      "type": 205,
+                      "type": 217,
                       "typeName": "Option<DidVerificationKey>",
                       "docs": []
                     },
                     {
                       "name": "new_service_details",
-                      "type": 210,
+                      "type": 222,
                       "typeName": "Vec<DidEndpoint<T>>",
                       "docs": []
                     }
@@ -14181,7 +15404,7 @@
             }
           },
           {
-            "id": 201,
+            "id": 213,
             "type": {
               "path": [
                 "frame_support",
@@ -14192,7 +15415,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 202
+                  "type": 214
                 },
                 {
                   "name": "S",
@@ -14204,7 +15427,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 203,
+                      "type": 215,
                       "typeName": "BTreeSet<T>",
                       "docs": []
                     }
@@ -14215,7 +15438,7 @@
             }
           },
           {
-            "id": 202,
+            "id": 214,
             "type": {
               "path": [
                 "did",
@@ -14246,7 +15469,7 @@
             }
           },
           {
-            "id": 203,
+            "id": 215,
             "type": {
               "path": [
                 "BTreeSet"
@@ -14254,7 +15477,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 202
+                  "type": 214
                 }
               ],
               "def": {
@@ -14262,7 +15485,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 204,
+                      "type": 216,
                       "typeName": null,
                       "docs": []
                     }
@@ -14273,20 +15496,20 @@
             }
           },
           {
-            "id": 204,
+            "id": 216,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 202
+                  "type": 214
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 205,
+            "id": 217,
             "type": {
               "path": [
                 "Option"
@@ -14294,7 +15517,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 206
+                  "type": 218
                 }
               ],
               "def": {
@@ -14311,7 +15534,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 206,
+                          "type": 218,
                           "typeName": null,
                           "docs": []
                         }
@@ -14326,7 +15549,7 @@
             }
           },
           {
-            "id": 206,
+            "id": 218,
             "type": {
               "path": [
                 "did",
@@ -14342,7 +15565,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 207,
+                          "type": 219,
                           "typeName": "ed25519::Public",
                           "docs": []
                         }
@@ -14355,7 +15578,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 139,
+                          "type": 149,
                           "typeName": "sr25519::Public",
                           "docs": []
                         }
@@ -14368,7 +15591,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 208,
+                          "type": 220,
                           "typeName": "ecdsa::Public",
                           "docs": []
                         }
@@ -14383,7 +15606,7 @@
             }
           },
           {
-            "id": 207,
+            "id": 219,
             "type": {
               "path": [
                 "sp_core",
@@ -14407,7 +15630,7 @@
             }
           },
           {
-            "id": 208,
+            "id": 220,
             "type": {
               "path": [
                 "sp_core",
@@ -14420,7 +15643,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 209,
+                      "type": 221,
                       "typeName": "[u8; 33]",
                       "docs": []
                     }
@@ -14431,7 +15654,7 @@
             }
           },
           {
-            "id": 209,
+            "id": 221,
             "type": {
               "path": [],
               "params": [],
@@ -14445,20 +15668,20 @@
             }
           },
           {
-            "id": 210,
+            "id": 222,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 211
+                  "type": 223
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 211,
+            "id": 223,
             "type": {
               "path": [
                 "did",
@@ -14476,19 +15699,19 @@
                   "fields": [
                     {
                       "name": "id",
-                      "type": 212,
+                      "type": 224,
                       "typeName": "ServiceEndpointId<T>",
                       "docs": []
                     },
                     {
                       "name": "service_types",
-                      "type": 213,
+                      "type": 225,
                       "typeName": "ServiceEndpointTypeEntries<T>",
                       "docs": []
                     },
                     {
                       "name": "urls",
-                      "type": 216,
+                      "type": 228,
                       "typeName": "ServiceEndpointUrlEntries<T>",
                       "docs": []
                     }
@@ -14499,7 +15722,7 @@
             }
           },
           {
-            "id": 212,
+            "id": 224,
             "type": {
               "path": [
                 "frame_support",
@@ -14533,7 +15756,7 @@
             }
           },
           {
-            "id": 213,
+            "id": 225,
             "type": {
               "path": [
                 "frame_support",
@@ -14544,7 +15767,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 214
+                  "type": 226
                 },
                 {
                   "name": "S",
@@ -14556,7 +15779,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 215,
+                      "type": 227,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -14567,7 +15790,7 @@
             }
           },
           {
-            "id": 214,
+            "id": 226,
             "type": {
               "path": [
                 "frame_support",
@@ -14601,20 +15824,20 @@
             }
           },
           {
-            "id": 215,
+            "id": 227,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 214
+                  "type": 226
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 216,
+            "id": 228,
             "type": {
               "path": [
                 "frame_support",
@@ -14625,7 +15848,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 217
+                  "type": 229
                 },
                 {
                   "name": "S",
@@ -14637,7 +15860,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 218,
+                      "type": 230,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -14648,7 +15871,7 @@
             }
           },
           {
-            "id": 217,
+            "id": 229,
             "type": {
               "path": [
                 "frame_support",
@@ -14682,20 +15905,20 @@
             }
           },
           {
-            "id": 218,
+            "id": 230,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 217
+                  "type": 229
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 219,
+            "id": 231,
             "type": {
               "path": [
                 "did",
@@ -14725,7 +15948,7 @@
                     },
                     {
                       "name": "call",
-                      "type": 171,
+                      "type": 179,
                       "typeName": "DidCallableOf<T>",
                       "docs": []
                     },
@@ -14748,7 +15971,7 @@
             }
           },
           {
-            "id": 220,
+            "id": 232,
             "type": {
               "path": [
                 "pallet_did_lookup",
@@ -14781,7 +16004,7 @@
                         },
                         {
                           "name": "proof",
-                          "type": 221,
+                          "type": 233,
                           "typeName": "SignatureOf<T>",
                           "docs": []
                         }
@@ -14901,7 +16124,7 @@
             }
           },
           {
-            "id": 221,
+            "id": 233,
             "type": {
               "path": [
                 "sp_runtime",
@@ -14916,7 +16139,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 194,
+                          "type": 206,
                           "typeName": "ed25519::Signature",
                           "docs": []
                         }
@@ -14929,7 +16152,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 196,
+                          "type": 208,
                           "typeName": "sr25519::Signature",
                           "docs": []
                         }
@@ -14942,7 +16165,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 197,
+                          "type": 209,
                           "typeName": "ecdsa::Signature",
                           "docs": []
                         }
@@ -14957,7 +16180,164 @@
             }
           },
           {
-            "id": 222,
+            "id": 234,
+            "type": {
+              "path": [
+                "pallet_web3_names",
+                "pallet",
+                "Call"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "claim",
+                      "fields": [
+                        {
+                          "name": "name",
+                          "type": 64,
+                          "typeName": "Web3NameInput<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": [
+                        "Assign the specified name to the owner as specified in the",
+                        "origin.",
+                        "",
+                        "The name must not have already been claimed by someone else and the",
+                        "owner must not already own another name.",
+                        "",
+                        "Emits `Web3NameClaimed` if the operation is carried out",
+                        "successfully.",
+                        "",
+                        "# <weight>",
+                        "Weight: O(1)",
+                        "- Reads: Names, Owner, Banned storage entries + available currency",
+                        "  check + origin check",
+                        "- Writes: Names, Owner storage entries + currency deposit reserve",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "release_by_owner",
+                      "fields": [],
+                      "index": 1,
+                      "docs": [
+                        "Release the provided name from its owner.",
+                        "",
+                        "The origin must be the owner of the specified name.",
+                        "",
+                        "Emits `Web3NameReleased` if the operation is carried out",
+                        "successfully.",
+                        "",
+                        "# <weight>",
+                        "Weight: O(1)",
+                        "- Reads: Names storage entry + origin check",
+                        "- Writes: Names, Owner storage entries + currency deposit release",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "reclaim_deposit",
+                      "fields": [
+                        {
+                          "name": "name",
+                          "type": 64,
+                          "typeName": "Web3NameInput<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 2,
+                      "docs": [
+                        "Release the provided name from its owner.",
+                        "",
+                        "The origin must be the account that paid for the name's deposit.",
+                        "",
+                        "Emits `Web3NameReleased` if the operation is carried out",
+                        "successfully.",
+                        "",
+                        "# <weight>",
+                        "Weight: O(1)",
+                        "- Reads: Owner storage entry + origin check",
+                        "- Writes: Names, Owner storage entries + currency deposit release",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "ban",
+                      "fields": [
+                        {
+                          "name": "name",
+                          "type": 64,
+                          "typeName": "Web3NameInput<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 3,
+                      "docs": [
+                        "Ban a name.",
+                        "",
+                        "A banned name cannot be claimed by anyone. The name's deposit",
+                        "is returned to the original payer.",
+                        "",
+                        "The origin must be the ban origin.",
+                        "",
+                        "Emits `Web3NameBanned` if the operation is carried out",
+                        "successfully.",
+                        "",
+                        "# <weight>",
+                        "Weight: O(1)",
+                        "- Reads: Banned, Owner, Names storage entries + origin check",
+                        "- Writes: Names, Owner, Banned storage entries + currency deposit",
+                        "  release",
+                        "# </weight>"
+                      ]
+                    },
+                    {
+                      "name": "unban",
+                      "fields": [
+                        {
+                          "name": "name",
+                          "type": 64,
+                          "typeName": "Web3NameInput<T>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 4,
+                      "docs": [
+                        "Unban a name.",
+                        "",
+                        "Make a name claimable again.",
+                        "",
+                        "The origin must be the ban origin.",
+                        "",
+                        "Emits `Web3NameUnbanned` if the operation is carried out",
+                        "successfully.",
+                        "",
+                        "# <weight>",
+                        "Weight: O(1)",
+                        "- Reads: Banned storage entry + origin check",
+                        "- Writes: Banned storage entry deposit release",
+                        "# </weight>"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "Contains one variant per dispatchable that can be called by an extrinsic."
+              ]
+            }
+          },
+          {
+            "id": 235,
             "type": {
               "path": [
                 "cumulus_pallet_parachain_system",
@@ -14978,7 +16358,7 @@
                       "fields": [
                         {
                           "name": "data",
-                          "type": 223,
+                          "type": 236,
                           "typeName": "ParachainInherentData",
                           "docs": []
                         }
@@ -15044,7 +16424,7 @@
             }
           },
           {
-            "id": 223,
+            "id": 236,
             "type": {
               "path": [
                 "cumulus_primitives_parachain_inherent",
@@ -15056,25 +16436,25 @@
                   "fields": [
                     {
                       "name": "validation_data",
-                      "type": 224,
+                      "type": 237,
                       "typeName": "PersistedValidationData",
                       "docs": []
                     },
                     {
                       "name": "relay_chain_state",
-                      "type": 226,
+                      "type": 239,
                       "typeName": "sp_trie::StorageProof",
                       "docs": []
                     },
                     {
                       "name": "downward_messages",
-                      "type": 227,
+                      "type": 240,
                       "typeName": "Vec<InboundDownwardMessage>",
                       "docs": []
                     },
                     {
                       "name": "horizontal_messages",
-                      "type": 229,
+                      "type": 242,
                       "typeName": "BTreeMap<ParaId, Vec<InboundHrmpMessage>>",
                       "docs": []
                     }
@@ -15085,7 +16465,7 @@
             }
           },
           {
-            "id": 224,
+            "id": 237,
             "type": {
               "path": [
                 "polkadot_primitives",
@@ -15107,7 +16487,7 @@
                   "fields": [
                     {
                       "name": "parent_head",
-                      "type": 225,
+                      "type": 238,
                       "typeName": "HeadData",
                       "docs": []
                     },
@@ -15136,7 +16516,7 @@
             }
           },
           {
-            "id": 225,
+            "id": 238,
             "type": {
               "path": [
                 "polkadot_parachain",
@@ -15160,7 +16540,7 @@
             }
           },
           {
-            "id": 226,
+            "id": 239,
             "type": {
               "path": [
                 "sp_trie",
@@ -15173,7 +16553,7 @@
                   "fields": [
                     {
                       "name": "trie_nodes",
-                      "type": 65,
+                      "type": 76,
                       "typeName": "Vec<Vec<u8>>",
                       "docs": []
                     }
@@ -15184,20 +16564,20 @@
             }
           },
           {
-            "id": 227,
+            "id": 240,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 228
+                  "type": 241
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 228,
+            "id": 241,
             "type": {
               "path": [
                 "polkadot_core_primitives",
@@ -15231,7 +16611,7 @@
             }
           },
           {
-            "id": 229,
+            "id": 242,
             "type": {
               "path": [
                 "BTreeMap"
@@ -15239,11 +16619,11 @@
               "params": [
                 {
                   "name": "K",
-                  "type": 230
+                  "type": 243
                 },
                 {
                   "name": "V",
-                  "type": 231
+                  "type": 244
                 }
               ],
               "def": {
@@ -15251,7 +16631,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 233,
+                      "type": 246,
                       "typeName": null,
                       "docs": []
                     }
@@ -15262,7 +16642,7 @@
             }
           },
           {
-            "id": 230,
+            "id": 243,
             "type": {
               "path": [
                 "polkadot_parachain",
@@ -15286,20 +16666,20 @@
             }
           },
           {
-            "id": 231,
+            "id": 244,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 232
+                  "type": 245
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 232,
+            "id": 245,
             "type": {
               "path": [
                 "polkadot_core_primitives",
@@ -15333,34 +16713,34 @@
             }
           },
           {
-            "id": 233,
+            "id": 246,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 234
+                  "type": 247
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 234,
+            "id": 247,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  230,
-                  231
+                  243,
+                  244
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 235,
+            "id": 248,
             "type": {
               "path": [
                 "pallet_collective",
@@ -15393,13 +16773,13 @@
                     },
                     {
                       "name": "ayes",
-                      "type": 32,
+                      "type": 33,
                       "typeName": "Vec<AccountId>",
                       "docs": []
                     },
                     {
                       "name": "nays",
-                      "type": 32,
+                      "type": 33,
                       "typeName": "Vec<AccountId>",
                       "docs": []
                     },
@@ -15416,7 +16796,7 @@
             }
           },
           {
-            "id": 236,
+            "id": 249,
             "type": {
               "path": [
                 "pallet_collective",
@@ -15525,7 +16905,7 @@
             }
           },
           {
-            "id": 237,
+            "id": 250,
             "type": {
               "path": [
                 "frame_support",
@@ -15548,7 +16928,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 56,
+                      "type": 67,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -15559,7 +16939,7 @@
             }
           },
           {
-            "id": 238,
+            "id": 251,
             "type": {
               "path": [
                 "pallet_collective",
@@ -15668,7 +17048,7 @@
             }
           },
           {
-            "id": 239,
+            "id": 252,
             "type": {
               "path": [
                 "pallet_membership",
@@ -15713,7 +17093,7 @@
             }
           },
           {
-            "id": 240,
+            "id": 253,
             "type": {
               "path": [
                 "pallet_treasury",
@@ -15763,7 +17143,7 @@
             }
           },
           {
-            "id": 241,
+            "id": 254,
             "type": {
               "path": [
                 "frame_support",
@@ -15786,7 +17166,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 140,
+                      "type": 150,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -15797,7 +17177,7 @@
             }
           },
           {
-            "id": 242,
+            "id": 255,
             "type": {
               "path": [
                 "sp_arithmetic",
@@ -15821,7 +17201,47 @@
             }
           },
           {
-            "id": 243,
+            "id": 256,
+            "type": {
+              "path": [
+                "Option"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 6
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "None",
+                      "fields": [],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "Some",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 6,
+                          "typeName": null,
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 257,
             "type": {
               "path": [
                 "frame_support",
@@ -15833,7 +17253,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 77,
+                      "type": 88,
                       "typeName": "[u8; 8]",
                       "docs": []
                     }
@@ -15844,7 +17264,7 @@
             }
           },
           {
-            "id": 244,
+            "id": 258,
             "type": {
               "path": [
                 "pallet_treasury",
@@ -15897,7 +17317,7 @@
             }
           },
           {
-            "id": 245,
+            "id": 259,
             "type": {
               "path": [
                 "pallet_utility",
@@ -15930,7 +17350,7 @@
             }
           },
           {
-            "id": 246,
+            "id": 260,
             "type": {
               "path": [
                 "frame_support",
@@ -15941,7 +17361,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 185
+                  "type": 193
                 },
                 {
                   "name": "S",
@@ -15953,7 +17373,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 247,
+                      "type": 261,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -15964,20 +17384,20 @@
             }
           },
           {
-            "id": 247,
+            "id": 261,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 185
+                  "type": 193
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 248,
+            "id": 262,
             "type": {
               "path": [
                 "pallet_vesting",
@@ -16006,7 +17426,7 @@
             }
           },
           {
-            "id": 249,
+            "id": 263,
             "type": {
               "path": [
                 "pallet_vesting",
@@ -16072,20 +17492,20 @@
             }
           },
           {
-            "id": 250,
+            "id": 264,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 251
+                  "type": 265
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 251,
+            "id": 265,
             "type": {
               "path": [
                 "Option"
@@ -16093,7 +17513,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 252
+                  "type": 266
                 }
               ],
               "def": {
@@ -16110,7 +17530,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 252,
+                          "type": 266,
                           "typeName": null,
                           "docs": []
                         }
@@ -16125,16 +17545,16 @@
             }
           },
           {
-            "id": 252,
+            "id": 266,
             "type": {
               "path": [
                 "pallet_scheduler",
-                "ScheduledV2"
+                "ScheduledV3"
               ],
               "params": [
                 {
                   "name": "Call",
-                  "type": 171
+                  "type": 196
                 },
                 {
                   "name": "BlockNumber",
@@ -16142,7 +17562,7 @@
                 },
                 {
                   "name": "PalletsOrigin",
-                  "type": 178
+                  "type": 186
                 },
                 {
                   "name": "AccountId",
@@ -16154,7 +17574,7 @@
                   "fields": [
                     {
                       "name": "maybe_id",
-                      "type": 45,
+                      "type": 48,
                       "typeName": "Option<Vec<u8>>",
                       "docs": []
                     },
@@ -16166,19 +17586,19 @@
                     },
                     {
                       "name": "call",
-                      "type": 171,
+                      "type": 196,
                       "typeName": "Call",
                       "docs": []
                     },
                     {
                       "name": "maybe_periodic",
-                      "type": 187,
+                      "type": 195,
                       "typeName": "Option<schedule::Period<BlockNumber>>",
                       "docs": []
                     },
                     {
                       "name": "origin",
-                      "type": 178,
+                      "type": 186,
                       "typeName": "PalletsOrigin",
                       "docs": []
                     }
@@ -16189,36 +17609,7 @@
             }
           },
           {
-            "id": 253,
-            "type": {
-              "path": [
-                "pallet_scheduler",
-                "Releases"
-              ],
-              "params": [],
-              "def": {
-                "variant": {
-                  "variants": [
-                    {
-                      "name": "V1",
-                      "fields": [],
-                      "index": 0,
-                      "docs": []
-                    },
-                    {
-                      "name": "V2",
-                      "fields": [],
-                      "index": 1,
-                      "docs": []
-                    }
-                  ]
-                }
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 254,
+            "id": 267,
             "type": {
               "path": [
                 "pallet_scheduler",
@@ -16275,7 +17666,527 @@
             }
           },
           {
-            "id": 255,
+            "id": 268,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "tuple": [
+                  269,
+                  6
+                ]
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 269,
+            "type": {
+              "path": [
+                "frame_support",
+                "storage",
+                "bounded_vec",
+                "BoundedVec"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 270
+                },
+                {
+                  "name": "S",
+                  "type": null
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 271,
+                      "typeName": "Vec<T>",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 270,
+            "type": {
+              "path": [
+                "pallet_proxy",
+                "ProxyDefinition"
+              ],
+              "params": [
+                {
+                  "name": "AccountId",
+                  "type": 0
+                },
+                {
+                  "name": "ProxyType",
+                  "type": 51
+                },
+                {
+                  "name": "BlockNumber",
+                  "type": 4
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": "delegate",
+                      "type": 0,
+                      "typeName": "AccountId",
+                      "docs": []
+                    },
+                    {
+                      "name": "proxy_type",
+                      "type": 51,
+                      "typeName": "ProxyType",
+                      "docs": []
+                    },
+                    {
+                      "name": "delay",
+                      "type": 4,
+                      "typeName": "BlockNumber",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 271,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "sequence": {
+                  "type": 270
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 272,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "tuple": [
+                  273,
+                  6
+                ]
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 273,
+            "type": {
+              "path": [
+                "frame_support",
+                "storage",
+                "bounded_vec",
+                "BoundedVec"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 274
+                },
+                {
+                  "name": "S",
+                  "type": null
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 275,
+                      "typeName": "Vec<T>",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 274,
+            "type": {
+              "path": [
+                "pallet_proxy",
+                "Announcement"
+              ],
+              "params": [
+                {
+                  "name": "AccountId",
+                  "type": 0
+                },
+                {
+                  "name": "Hash",
+                  "type": 9
+                },
+                {
+                  "name": "BlockNumber",
+                  "type": 4
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": "real",
+                      "type": 0,
+                      "typeName": "AccountId",
+                      "docs": []
+                    },
+                    {
+                      "name": "call_hash",
+                      "type": 9,
+                      "typeName": "Hash",
+                      "docs": []
+                    },
+                    {
+                      "name": "height",
+                      "type": 4,
+                      "typeName": "BlockNumber",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 275,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "sequence": {
+                  "type": 274
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 276,
+            "type": {
+              "path": [
+                "pallet_proxy",
+                "pallet",
+                "Error"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "TooMany",
+                      "fields": [],
+                      "index": 0,
+                      "docs": [
+                        "There are too many proxies registered or too many announcements pending."
+                      ]
+                    },
+                    {
+                      "name": "NotFound",
+                      "fields": [],
+                      "index": 1,
+                      "docs": [
+                        "Proxy registration not found."
+                      ]
+                    },
+                    {
+                      "name": "NotProxy",
+                      "fields": [],
+                      "index": 2,
+                      "docs": [
+                        "Sender is not a proxy of the account to be proxied."
+                      ]
+                    },
+                    {
+                      "name": "Unproxyable",
+                      "fields": [],
+                      "index": 3,
+                      "docs": [
+                        "A call which is incompatible with the proxy type's filter was attempted."
+                      ]
+                    },
+                    {
+                      "name": "Duplicate",
+                      "fields": [],
+                      "index": 4,
+                      "docs": [
+                        "Account is already a proxy."
+                      ]
+                    },
+                    {
+                      "name": "NoPermission",
+                      "fields": [],
+                      "index": 5,
+                      "docs": [
+                        "Call may not be made by proxy because it may escalate its privileges."
+                      ]
+                    },
+                    {
+                      "name": "Unannounced",
+                      "fields": [],
+                      "index": 6,
+                      "docs": [
+                        "Announcement, if made at all, was made too recently."
+                      ]
+                    },
+                    {
+                      "name": "NoSelfProxy",
+                      "fields": [],
+                      "index": 7,
+                      "docs": [
+                        "Cannot add self as proxy."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/v3/runtime/events-and-errors)\n\t\t\tof this pallet.\n\t\t\t"
+              ]
+            }
+          },
+          {
+            "id": 277,
+            "type": {
+              "path": [
+                "pallet_preimage",
+                "RequestStatus"
+              ],
+              "params": [
+                {
+                  "name": "AccountId",
+                  "type": 0
+                },
+                {
+                  "name": "Balance",
+                  "type": 6
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "Unrequested",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 278,
+                          "typeName": "Option<(AccountId, Balance)>",
+                          "docs": []
+                        }
+                      ],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "Requested",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 7,
+                          "typeName": "u32",
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 278,
+            "type": {
+              "path": [
+                "Option"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 279
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "None",
+                      "fields": [],
+                      "index": 0,
+                      "docs": []
+                    },
+                    {
+                      "name": "Some",
+                      "fields": [
+                        {
+                          "name": null,
+                          "type": 279,
+                          "typeName": null,
+                          "docs": []
+                        }
+                      ],
+                      "index": 1,
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 279,
+            "type": {
+              "path": [],
+              "params": [],
+              "def": {
+                "tuple": [
+                  0,
+                  6
+                ]
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 280,
+            "type": {
+              "path": [
+                "frame_support",
+                "storage",
+                "bounded_vec",
+                "BoundedVec"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": 2
+                },
+                {
+                  "name": "S",
+                  "type": null
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "type": 10,
+                      "typeName": "Vec<T>",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 281,
+            "type": {
+              "path": [
+                "pallet_preimage",
+                "pallet",
+                "Error"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "TooLarge",
+                      "fields": [],
+                      "index": 0,
+                      "docs": [
+                        "Preimage is too large to store on-chain."
+                      ]
+                    },
+                    {
+                      "name": "AlreadyNoted",
+                      "fields": [],
+                      "index": 1,
+                      "docs": [
+                        "Preimage has already been noted on-chain."
+                      ]
+                    },
+                    {
+                      "name": "NotAuthorized",
+                      "fields": [],
+                      "index": 2,
+                      "docs": [
+                        "The user is not authorized to perform this action."
+                      ]
+                    },
+                    {
+                      "name": "NotNoted",
+                      "fields": [],
+                      "index": 3,
+                      "docs": [
+                        "The preimage cannot be removed since it has not yet been noted."
+                      ]
+                    },
+                    {
+                      "name": "Requested",
+                      "fields": [],
+                      "index": 4,
+                      "docs": [
+                        "A preimage may not be removed when there are outstanding requests."
+                      ]
+                    },
+                    {
+                      "name": "NotRequested",
+                      "fields": [],
+                      "index": 5,
+                      "docs": [
+                        "The preimage request cannot be removed since no outstanding requests exist."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/v3/runtime/events-and-errors)\n\t\t\tof this pallet.\n\t\t\t"
+              ]
+            }
+          },
+          {
+            "id": 282,
             "type": {
               "path": [
                 "frame_support",
@@ -16298,7 +18209,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 32,
+                      "type": 33,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -16309,7 +18220,7 @@
             }
           },
           {
-            "id": 256,
+            "id": 283,
             "type": {
               "path": [
                 "kilt_launch",
@@ -16328,7 +18239,7 @@
                     {
                       "name": "block",
                       "type": 4,
-                      "typeName": "T::BlockNumber",
+                      "typeName": "<T as frame_system::Config>::BlockNumber",
                       "docs": []
                     },
                     {
@@ -16344,7 +18255,7 @@
             }
           },
           {
-            "id": 257,
+            "id": 284,
             "type": {
               "path": [
                 "kilt_launch",
@@ -16474,7 +18385,7 @@
             }
           },
           {
-            "id": 258,
+            "id": 285,
             "type": {
               "path": [
                 "ctype",
@@ -16523,7 +18434,7 @@
             }
           },
           {
-            "id": 259,
+            "id": 286,
             "type": {
               "path": [
                 "attestation",
@@ -16553,19 +18464,19 @@
                     },
                     {
                       "name": "delegation_id",
-                      "type": 49,
+                      "type": 57,
                       "typeName": "Option<DelegationNodeIdOf<T>>",
                       "docs": []
                     },
                     {
                       "name": "revoked",
-                      "type": 37,
+                      "type": 40,
                       "typeName": "bool",
                       "docs": []
                     },
                     {
                       "name": "deposit",
-                      "type": 260,
+                      "type": 287,
                       "typeName": "Deposit<AccountIdOf<T>, BalanceOf<T>>",
                       "docs": []
                     }
@@ -16576,7 +18487,7 @@
             }
           },
           {
-            "id": 260,
+            "id": 287,
             "type": {
               "path": [
                 "kilt_support",
@@ -16615,7 +18526,7 @@
             }
           },
           {
-            "id": 261,
+            "id": 288,
             "type": {
               "path": [
                 "frame_support",
@@ -16638,7 +18549,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 56,
+                      "type": 67,
                       "typeName": "Vec<T>",
                       "docs": []
                     }
@@ -16649,7 +18560,7 @@
             }
           },
           {
-            "id": 262,
+            "id": 289,
             "type": {
               "path": [
                 "attestation",
@@ -16753,37 +18664,7 @@
             }
           },
           {
-            "id": 263,
-            "type": {
-              "path": [
-                "delegation",
-                "migrations",
-                "DelegationStorageVersion"
-              ],
-              "params": [],
-              "def": {
-                "variant": {
-                  "variants": [
-                    {
-                      "name": "V1",
-                      "fields": [],
-                      "index": 0,
-                      "docs": []
-                    },
-                    {
-                      "name": "V2",
-                      "fields": [],
-                      "index": 1,
-                      "docs": []
-                    }
-                  ]
-                }
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 264,
+            "id": 290,
             "type": {
               "path": [
                 "delegation",
@@ -16807,25 +18688,25 @@
                     },
                     {
                       "name": "parent",
-                      "type": 49,
+                      "type": 57,
                       "typeName": "Option<DelegationNodeIdOf<T>>",
                       "docs": []
                     },
                     {
                       "name": "children",
-                      "type": 265,
+                      "type": 291,
                       "typeName": "BoundedBTreeSet<DelegationNodeIdOf<T>, T::MaxChildren>",
                       "docs": []
                     },
                     {
                       "name": "details",
-                      "type": 267,
+                      "type": 293,
                       "typeName": "DelegationDetails<T>",
                       "docs": []
                     },
                     {
                       "name": "deposit",
-                      "type": 260,
+                      "type": 287,
                       "typeName": "Deposit<AccountIdOf<T>, BalanceOf<T>>",
                       "docs": []
                     }
@@ -16836,7 +18717,7 @@
             }
           },
           {
-            "id": 265,
+            "id": 291,
             "type": {
               "path": [
                 "frame_support",
@@ -16859,7 +18740,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 266,
+                      "type": 292,
                       "typeName": "BTreeSet<T>",
                       "docs": []
                     }
@@ -16870,7 +18751,7 @@
             }
           },
           {
-            "id": 266,
+            "id": 292,
             "type": {
               "path": [
                 "BTreeSet"
@@ -16886,7 +18767,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 56,
+                      "type": 67,
                       "typeName": null,
                       "docs": []
                     }
@@ -16897,7 +18778,7 @@
             }
           },
           {
-            "id": 267,
+            "id": 293,
             "type": {
               "path": [
                 "delegation",
@@ -16921,13 +18802,13 @@
                     },
                     {
                       "name": "revoked",
-                      "type": 37,
+                      "type": 40,
                       "typeName": "bool",
                       "docs": []
                     },
                     {
                       "name": "permissions",
-                      "type": 51,
+                      "type": 59,
                       "typeName": "Permissions",
                       "docs": []
                     }
@@ -16938,7 +18819,7 @@
             }
           },
           {
-            "id": 268,
+            "id": 294,
             "type": {
               "path": [
                 "delegation",
@@ -16967,7 +18848,7 @@
             }
           },
           {
-            "id": 269,
+            "id": 295,
             "type": {
               "path": [
                 "delegation",
@@ -17166,7 +19047,7 @@
             }
           },
           {
-            "id": 270,
+            "id": 296,
             "type": {
               "path": [
                 "did",
@@ -17190,25 +19071,25 @@
                     },
                     {
                       "name": "key_agreement_keys",
-                      "type": 271,
+                      "type": 297,
                       "typeName": "DidKeyAgreementKeySet<T>",
                       "docs": []
                     },
                     {
                       "name": "delegation_key",
-                      "type": 49,
+                      "type": 57,
                       "typeName": "Option<KeyIdOf<T>>",
                       "docs": []
                     },
                     {
                       "name": "attestation_key",
-                      "type": 49,
+                      "type": 57,
                       "typeName": "Option<KeyIdOf<T>>",
                       "docs": []
                     },
                     {
                       "name": "public_keys",
-                      "type": 272,
+                      "type": 298,
                       "typeName": "DidPublicKeyMap<T>",
                       "docs": []
                     },
@@ -17220,7 +19101,7 @@
                     },
                     {
                       "name": "deposit",
-                      "type": 260,
+                      "type": 287,
                       "typeName": "Deposit<AccountIdOf<T>, BalanceOf<T>>",
                       "docs": []
                     }
@@ -17231,7 +19112,7 @@
             }
           },
           {
-            "id": 271,
+            "id": 297,
             "type": {
               "path": [
                 "frame_support",
@@ -17254,7 +19135,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 266,
+                      "type": 292,
                       "typeName": "BTreeSet<T>",
                       "docs": []
                     }
@@ -17265,7 +19146,7 @@
             }
           },
           {
-            "id": 272,
+            "id": 298,
             "type": {
               "path": [
                 "frame_support",
@@ -17280,7 +19161,7 @@
                 },
                 {
                   "name": "V",
-                  "type": 273
+                  "type": 299
                 },
                 {
                   "name": "S",
@@ -17292,7 +19173,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 275,
+                      "type": 301,
                       "typeName": "BTreeMap<K, V>",
                       "docs": []
                     }
@@ -17303,7 +19184,7 @@
             }
           },
           {
-            "id": 273,
+            "id": 299,
             "type": {
               "path": [
                 "did",
@@ -17321,7 +19202,7 @@
                   "fields": [
                     {
                       "name": "key",
-                      "type": 274,
+                      "type": 300,
                       "typeName": "DidPublicKey",
                       "docs": []
                     },
@@ -17338,7 +19219,7 @@
             }
           },
           {
-            "id": 274,
+            "id": 300,
             "type": {
               "path": [
                 "did",
@@ -17354,7 +19235,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 206,
+                          "type": 218,
                           "typeName": "DidVerificationKey",
                           "docs": []
                         }
@@ -17367,7 +19248,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 202,
+                          "type": 214,
                           "typeName": "DidEncryptionKey",
                           "docs": []
                         }
@@ -17382,7 +19263,7 @@
             }
           },
           {
-            "id": 275,
+            "id": 301,
             "type": {
               "path": [
                 "BTreeMap"
@@ -17394,7 +19275,7 @@
                 },
                 {
                   "name": "V",
-                  "type": 273
+                  "type": 299
                 }
               ],
               "def": {
@@ -17402,7 +19283,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 276,
+                      "type": 302,
                       "typeName": null,
                       "docs": []
                     }
@@ -17413,84 +19294,48 @@
             }
           },
           {
-            "id": 276,
+            "id": 302,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 277
+                  "type": 303
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 277,
+            "id": 303,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
                   9,
-                  273
+                  299
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 278,
+            "id": 304,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
                   0,
-                  212
+                  224
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 279,
-            "type": {
-              "path": [
-                "did",
-                "migrations",
-                "DidStorageVersion"
-              ],
-              "params": [],
-              "def": {
-                "variant": {
-                  "variants": [
-                    {
-                      "name": "V1",
-                      "fields": [],
-                      "index": 0,
-                      "docs": []
-                    },
-                    {
-                      "name": "V2",
-                      "fields": [],
-                      "index": 1,
-                      "docs": []
-                    },
-                    {
-                      "name": "V3",
-                      "fields": [],
-                      "index": 2,
-                      "docs": []
-                    }
-                  ]
-                }
-              },
-              "docs": []
-            }
-          },
-          {
-            "id": 280,
+            "id": 305,
             "type": {
               "path": [
                 "did",
@@ -17742,7 +19587,7 @@
             }
           },
           {
-            "id": 281,
+            "id": 306,
             "type": {
               "path": [
                 "pallet_did_lookup",
@@ -17774,7 +19619,7 @@
                     },
                     {
                       "name": "deposit",
-                      "type": 260,
+                      "type": 287,
                       "typeName": "Deposit<Account, Balance>",
                       "docs": []
                     }
@@ -17785,7 +19630,7 @@
             }
           },
           {
-            "id": 282,
+            "id": 307,
             "type": {
               "path": [
                 "pallet_did_lookup",
@@ -17844,7 +19689,178 @@
             }
           },
           {
-            "id": 283,
+            "id": 308,
+            "type": {
+              "path": [
+                "pallet_web3_names",
+                "web3_name",
+                "Web3NameOwnership"
+              ],
+              "params": [
+                {
+                  "name": "Owner",
+                  "type": 0
+                },
+                {
+                  "name": "Deposit",
+                  "type": 287
+                },
+                {
+                  "name": "BlockNumber",
+                  "type": 4
+                }
+              ],
+              "def": {
+                "composite": {
+                  "fields": [
+                    {
+                      "name": "owner",
+                      "type": 0,
+                      "typeName": "Owner",
+                      "docs": []
+                    },
+                    {
+                      "name": "claimed_at",
+                      "type": 4,
+                      "typeName": "BlockNumber",
+                      "docs": []
+                    },
+                    {
+                      "name": "deposit",
+                      "type": 287,
+                      "typeName": "Deposit",
+                      "docs": []
+                    }
+                  ]
+                }
+              },
+              "docs": []
+            }
+          },
+          {
+            "id": 309,
+            "type": {
+              "path": [
+                "pallet_web3_names",
+                "pallet",
+                "Error"
+              ],
+              "params": [
+                {
+                  "name": "T",
+                  "type": null
+                }
+              ],
+              "def": {
+                "variant": {
+                  "variants": [
+                    {
+                      "name": "InsufficientFunds",
+                      "fields": [],
+                      "index": 0,
+                      "docs": [
+                        "The tx submitter does not have enough funds to pay for the deposit."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameAlreadyClaimed",
+                      "fields": [],
+                      "index": 1,
+                      "docs": [
+                        "The specified name has already been previously claimed."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameNotFound",
+                      "fields": [],
+                      "index": 2,
+                      "docs": [
+                        "The specified name does not exist."
+                      ]
+                    },
+                    {
+                      "name": "OwnerAlreadyExists",
+                      "fields": [],
+                      "index": 3,
+                      "docs": [
+                        "The specified owner already owns a name."
+                      ]
+                    },
+                    {
+                      "name": "OwnerNotFound",
+                      "fields": [],
+                      "index": 4,
+                      "docs": [
+                        "The specified owner does not own any names."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameBanned",
+                      "fields": [],
+                      "index": 5,
+                      "docs": [
+                        "The specified name has been banned and cannot be interacted",
+                        "with."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameNotBanned",
+                      "fields": [],
+                      "index": 6,
+                      "docs": [
+                        "The specified name is not currently banned."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameAlreadyBanned",
+                      "fields": [],
+                      "index": 7,
+                      "docs": [
+                        "The specified name has already been previously banned."
+                      ]
+                    },
+                    {
+                      "name": "NotAuthorized",
+                      "fields": [],
+                      "index": 8,
+                      "docs": [
+                        "The actor cannot performed the specified operation."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameTooShort",
+                      "fields": [],
+                      "index": 9,
+                      "docs": [
+                        "A name that is too short is being claimed."
+                      ]
+                    },
+                    {
+                      "name": "Web3NameTooLong",
+                      "fields": [],
+                      "index": 10,
+                      "docs": [
+                        "A name that is too long is being claimed."
+                      ]
+                    },
+                    {
+                      "name": "InvalidWeb3NameCharacter",
+                      "fields": [],
+                      "index": 11,
+                      "docs": [
+                        "A name that contains not allowed characters is being claimed."
+                      ]
+                    }
+                  ]
+                }
+              },
+              "docs": [
+                "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/v3/runtime/events-and-errors)\n\t\t\tof this pallet.\n\t\t\t"
+              ]
+            }
+          },
+          {
+            "id": 310,
             "type": {
               "path": [
                 "Option"
@@ -17852,7 +19868,7 @@
               "params": [
                 {
                   "name": "T",
-                  "type": 284
+                  "type": 311
                 }
               ],
               "def": {
@@ -17869,7 +19885,7 @@
                       "fields": [
                         {
                           "name": null,
-                          "type": 284,
+                          "type": 311,
                           "typeName": null,
                           "docs": []
                         }
@@ -17884,7 +19900,7 @@
             }
           },
           {
-            "id": 284,
+            "id": 311,
             "type": {
               "path": [
                 "polkadot_primitives",
@@ -17908,7 +19924,7 @@
             }
           },
           {
-            "id": 285,
+            "id": 312,
             "type": {
               "path": [
                 "cumulus_pallet_parachain_system",
@@ -17927,19 +19943,19 @@
                     },
                     {
                       "name": "relay_dispatch_queue_size",
-                      "type": 286,
+                      "type": 313,
                       "typeName": "(u32, u32)",
                       "docs": []
                     },
                     {
                       "name": "ingress_channels",
-                      "type": 287,
+                      "type": 314,
                       "typeName": "Vec<(ParaId, AbridgedHrmpChannel)>",
                       "docs": []
                     },
                     {
                       "name": "egress_channels",
-                      "type": 287,
+                      "type": 314,
                       "typeName": "Vec<(ParaId, AbridgedHrmpChannel)>",
                       "docs": []
                     }
@@ -17950,7 +19966,7 @@
             }
           },
           {
-            "id": 286,
+            "id": 313,
             "type": {
               "path": [],
               "params": [],
@@ -17964,34 +19980,34 @@
             }
           },
           {
-            "id": 287,
+            "id": 314,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 288
+                  "type": 315
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 288,
+            "id": 315,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  230,
-                  289
+                  243,
+                  316
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 289,
+            "id": 316,
             "type": {
               "path": [
                 "polkadot_primitives",
@@ -18034,7 +20050,7 @@
                     },
                     {
                       "name": "mqc_head",
-                      "type": 49,
+                      "type": 57,
                       "typeName": "Option<Hash>",
                       "docs": []
                     }
@@ -18045,7 +20061,7 @@
             }
           },
           {
-            "id": 290,
+            "id": 317,
             "type": {
               "path": [
                 "polkadot_primitives",
@@ -18099,7 +20115,7 @@
                       "docs": []
                     },
                     {
-                      "name": "validation_upgrade_frequency",
+                      "name": "validation_upgrade_cooldown",
                       "type": 7,
                       "typeName": "BlockNumber",
                       "docs": []
@@ -18117,10 +20133,10 @@
             }
           },
           {
-            "id": 291,
+            "id": 318,
             "type": {
               "path": [
-                "cumulus_pallet_parachain_system",
+                "cumulus_primitives_parachain_inherent",
                 "MessageQueueChain"
               ],
               "params": [],
@@ -18130,7 +20146,7 @@
                     {
                       "name": null,
                       "type": 9,
-                      "typeName": "relay_chain::Hash",
+                      "typeName": "RelayHash",
                       "docs": []
                     }
                   ]
@@ -18140,7 +20156,7 @@
             }
           },
           {
-            "id": 292,
+            "id": 319,
             "type": {
               "path": [
                 "BTreeMap"
@@ -18148,11 +20164,11 @@
               "params": [
                 {
                   "name": "K",
-                  "type": 230
+                  "type": 243
                 },
                 {
                   "name": "V",
-                  "type": 291
+                  "type": 318
                 }
               ],
               "def": {
@@ -18160,7 +20176,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 293,
+                      "type": 320,
                       "typeName": null,
                       "docs": []
                     }
@@ -18171,47 +20187,47 @@
             }
           },
           {
-            "id": 293,
+            "id": 320,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 294
+                  "type": 321
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 294,
+            "id": 321,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  230,
-                  291
+                  243,
+                  318
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 295,
+            "id": 322,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "sequence": {
-                  "type": 296
+                  "type": 323
                 }
               },
               "docs": []
             }
           },
           {
-            "id": 296,
+            "id": 323,
             "type": {
               "path": [
                 "polkadot_core_primitives",
@@ -18220,7 +20236,7 @@
               "params": [
                 {
                   "name": "Id",
-                  "type": 230
+                  "type": 243
                 }
               ],
               "def": {
@@ -18228,7 +20244,7 @@
                   "fields": [
                     {
                       "name": "recipient",
-                      "type": 230,
+                      "type": 243,
                       "typeName": "Id",
                       "docs": []
                     },
@@ -18245,7 +20261,7 @@
             }
           },
           {
-            "id": 297,
+            "id": 324,
             "type": {
               "path": [
                 "cumulus_pallet_parachain_system",
@@ -18335,7 +20351,7 @@
             }
           },
           {
-            "id": 298,
+            "id": 325,
             "type": {
               "path": [
                 "sp_runtime",
@@ -18346,19 +20362,19 @@
               "params": [
                 {
                   "name": "Address",
-                  "type": 94
+                  "type": 105
                 },
                 {
                   "name": "Call",
-                  "type": 171
+                  "type": 179
                 },
                 {
                   "name": "Signature",
-                  "type": 221
+                  "type": 233
                 },
                 {
                   "name": "Extra",
-                  "type": 299
+                  "type": 326
                 }
               ],
               "def": {
@@ -18377,26 +20393,26 @@
             }
           },
           {
-            "id": 299,
+            "id": 326,
             "type": {
               "path": [],
               "params": [],
               "def": {
                 "tuple": [
-                  300,
-                  301,
-                  302,
-                  303,
-                  305,
-                  306,
-                  307
+                  327,
+                  328,
+                  329,
+                  330,
+                  332,
+                  333,
+                  334
                 ]
               },
               "docs": []
             }
           },
           {
-            "id": 300,
+            "id": 327,
             "type": {
               "path": [
                 "frame_system",
@@ -18419,7 +20435,7 @@
             }
           },
           {
-            "id": 301,
+            "id": 328,
             "type": {
               "path": [
                 "frame_system",
@@ -18442,7 +20458,7 @@
             }
           },
           {
-            "id": 302,
+            "id": 329,
             "type": {
               "path": [
                 "frame_system",
@@ -18465,7 +20481,7 @@
             }
           },
           {
-            "id": 303,
+            "id": 330,
             "type": {
               "path": [
                 "frame_system",
@@ -18484,7 +20500,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 304,
+                      "type": 331,
                       "typeName": "Era",
                       "docs": []
                     }
@@ -18495,7 +20511,7 @@
             }
           },
           {
-            "id": 304,
+            "id": 331,
             "type": {
               "path": [
                 "sp_runtime",
@@ -21835,7 +23851,7 @@
             }
           },
           {
-            "id": 305,
+            "id": 332,
             "type": {
               "path": [
                 "frame_system",
@@ -21854,7 +23870,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 81,
+                      "type": 92,
                       "typeName": "T::Index",
                       "docs": []
                     }
@@ -21865,7 +23881,7 @@
             }
           },
           {
-            "id": 306,
+            "id": 333,
             "type": {
               "path": [
                 "frame_system",
@@ -21888,7 +23904,7 @@
             }
           },
           {
-            "id": 307,
+            "id": 334,
             "type": {
               "path": [
                 "pallet_transaction_payment",
@@ -21905,7 +23921,7 @@
                   "fields": [
                     {
                       "name": null,
-                      "type": 97,
+                      "type": 108,
                       "typeName": "BalanceOf<T>",
                       "docs": []
                     }
@@ -21916,7 +23932,7 @@
             }
           },
           {
-            "id": 308,
+            "id": 335,
             "type": {
               "path": [
                 "spiritnet_runtime",
@@ -22090,7 +24106,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 9,
-                    "value": 57
+                    "value": 68
                   }
                 },
                 "fallback": "0x00",
@@ -22111,7 +24127,7 @@
                 "name": "LastRuntimeUpgrade",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 58
+                  "plain": 69
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22122,7 +24138,7 @@
                 "name": "UpgradedToU32RefCount",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22133,7 +24149,7 @@
                 "name": "UpgradedToTripleRefCount",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22145,7 +24161,7 @@
                 "name": "ExecutionPhase",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 55
+                  "plain": 66
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22155,7 +24171,7 @@
             ]
           },
           "calls": {
-            "type": 61
+            "type": 72
           },
           "events": {
             "type": 18
@@ -22163,7 +24179,7 @@
           "constants": [
             {
               "name": "BlockWeights",
-              "type": 66,
+              "type": 77,
               "value": "0x00f2052a010000000088526a74000000405973070000000001c0180fa44b0000000100e6bd4f57000000010000000000000000405973070000000001c0baa3be68000000010088526a740000000100a2941a1d0000004059730700000000000000",
               "docs": [
                 " Block & extrinsics weights: base values and limits."
@@ -22171,7 +24187,7 @@
             },
             {
               "name": "BlockLength",
-              "type": 70,
+              "type": 81,
               "value": "0x00003c000000500000005000",
               "docs": [
                 " The maximum length of a block (in bytes)."
@@ -22187,7 +24203,7 @@
             },
             {
               "name": "DbWeight",
-              "type": 72,
+              "type": 83,
               "value": "0x40787d010000000000e1f50500000000",
               "docs": [
                 " The weight of runtime database operations the runtime can invoke."
@@ -22195,15 +24211,15 @@
             },
             {
               "name": "Version",
-              "type": 73,
-              "value": "0x386b696c742d7370697269746e6574386b696c742d7370697269746e657401000000a02800000000000028df6acb689907609b0300000037e397fc7c91f5e401000000bc9d89904f5b923f0100000037c8bb1350a9a2a80100000040fe3ad401f8959a05000000d2bc9897eed08f1503000000f78b278be53f454c02000000ab3c0572291feb8b01000000dd718d5cc53262d401000000ea93e3f16f3d69620100000001000000",
+              "type": 84,
+              "value": "0x386b696c742d7370697269746e6574386b696c742d7370697269746e657401000000042900000000000028df6acb689907609b0400000037e397fc7c91f5e401000000bc9d89904f5b923f0100000037c8bb1350a9a2a80100000040fe3ad401f8959a05000000d2bc9897eed08f1503000000f78b278be53f454c02000000ab3c0572291feb8b01000000dd718d5cc53262d401000000ea93e3f16f3d6962020000000100000000",
               "docs": [
                 " Get the chain's current version."
               ]
             },
             {
               "name": "SS58Prefix",
-              "type": 78,
+              "type": 52,
               "value": "0x2600",
               "docs": [
                 " The designated SS85 prefix of this chain.",
@@ -22215,7 +24231,7 @@
             }
           ],
           "errors": {
-            "type": 79
+            "type": 89
           },
           "index": 0
         },
@@ -22228,7 +24244,7 @@
                 "name": "RandomMaterial",
                 "modifier": "Default",
                 "type": {
-                  "plain": 56
+                  "plain": 90
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22265,7 +24281,7 @@
                 "name": "DidUpdate",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22275,7 +24291,7 @@
             ]
           },
           "calls": {
-            "type": 80
+            "type": 91
           },
           "events": null,
           "constants": [
@@ -22308,7 +24324,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 4,
-                    "value": 82
+                    "value": 93
                   }
                 },
                 "fallback": "0x00",
@@ -22319,23 +24335,23 @@
             ]
           },
           "calls": {
-            "type": 83
+            "type": 94
           },
           "events": {
-            "type": 25
+            "type": 26
           },
           "constants": [
             {
               "name": "Deposit",
               "type": 6,
-              "value": "0x00a0724e180900000000000000000000",
+              "value": "0x00b47cf3283500000000000000000000",
               "docs": [
                 " The deposit needed for reserving an index."
               ]
             }
           ],
           "errors": {
-            "type": 84
+            "type": 95
           },
           "index": 5
         },
@@ -22369,8 +24385,29 @@
                 },
                 "fallback": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                 "docs": [
-                  " The balance of an account.",
+                  " The Balances pallet example of storing the balance of an account.",
                   "",
+                  " # Example",
+                  "",
+                  " ```nocompile",
+                  "  impl pallet_balances::Config for Runtime {",
+                  "    type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>",
+                  "  }",
+                  " ```",
+                  "",
+                  " You can also store the balance of an account in the `System` pallet.",
+                  "",
+                  " # Example",
+                  "",
+                  " ```nocompile",
+                  "  impl pallet_balances::Config for Runtime {",
+                  "   type AccountStore = System",
+                  "  }",
+                  " ```",
+                  "",
+                  " But this comes with tradeoffs, storing account balances in the system pallet stores",
+                  " `frame_system` data alongside the account data contrary to storing account balances in the",
+                  " `Balances` pallet, which uses a `StorageMap` to store balances data only.",
                   " NOTE: This is only used in the case that this pallet is used to store balances."
                 ]
               },
@@ -22383,7 +24420,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 85
+                    "value": 96
                   }
                 },
                 "fallback": "0x00",
@@ -22401,7 +24438,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 89
+                    "value": 100
                   }
                 },
                 "fallback": "0x00",
@@ -22413,7 +24450,7 @@
                 "name": "StorageVersion",
                 "modifier": "Default",
                 "type": {
-                  "plain": 92
+                  "plain": 103
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22425,10 +24462,10 @@
             ]
           },
           "calls": {
-            "type": 93
+            "type": 104
           },
           "events": {
-            "type": 26
+            "type": 27
           },
           "constants": [
             {
@@ -22458,7 +24495,7 @@
             }
           ],
           "errors": {
-            "type": 98
+            "type": 109
           },
           "index": 6
         },
@@ -22471,7 +24508,7 @@
                 "name": "NextFeeMultiplier",
                 "modifier": "Default",
                 "type": {
-                  "plain": 99
+                  "plain": 110
                 },
                 "fallback": "0x000064a7b3b6e00d0000000000000000",
                 "docs": []
@@ -22480,7 +24517,7 @@
                 "name": "StorageVersion",
                 "modifier": "Default",
                 "type": {
-                  "plain": 100
+                  "plain": 111
                 },
                 "fallback": "0x00",
                 "docs": []
@@ -22528,7 +24565,7 @@
             },
             {
               "name": "WeightToFee",
-              "type": 101,
+              "type": 112,
               "value": "0x04037b000000000000000000000000000038761c2e0001",
               "docs": [
                 " The polynomial that is applied in order to derive fee from weight."
@@ -22547,7 +24584,7 @@
                 "name": "Uncles",
                 "modifier": "Default",
                 "type": {
-                  "plain": 103
+                  "plain": 114
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22569,7 +24606,7 @@
                 "name": "DidSetUncles",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22579,7 +24616,7 @@
             ]
           },
           "calls": {
-            "type": 106
+            "type": 117
           },
           "events": null,
           "constants": [
@@ -22595,7 +24632,7 @@
             }
           ],
           "errors": {
-            "type": 110
+            "type": 121
           },
           "index": 20
         },
@@ -22604,20 +24641,6 @@
           "storage": {
             "prefix": "ParachainStaking",
             "items": [
-              {
-                "name": "StorageVersion",
-                "modifier": "Default",
-                "type": {
-                  "plain": 111
-                },
-                "fallback": "0x05",
-                "docs": [
-                  " True if network has been upgraded to this version.",
-                  " Storage version of the pallet.",
-                  "",
-                  " This is set to v4 for new networks."
-                ]
-              },
               {
                 "name": "MaxSelectedCandidates",
                 "modifier": "Default",
@@ -22633,7 +24656,7 @@
                 "name": "Round",
                 "modifier": "Default",
                 "type": {
-                  "plain": 112
+                  "plain": 122
                 },
                 "fallback": "0x0000000000000000000000001400000000000000",
                 "docs": [
@@ -22649,7 +24672,7 @@
                       "Twox64Concat"
                     ],
                     "key": 0,
-                    "value": 113
+                    "value": 123
                   }
                 },
                 "fallback": "0x0000000000000000",
@@ -22670,7 +24693,7 @@
                       "Twox64Concat"
                     ],
                     "key": 0,
-                    "value": 114
+                    "value": 124
                   }
                 },
                 "fallback": "0x00",
@@ -22689,32 +24712,33 @@
                       "Twox64Concat"
                     ],
                     "key": 0,
-                    "value": 119
+                    "value": 129
                   }
                 },
                 "fallback": "0x00",
                 "docs": [
                   " The staking information for a candidate.",
                   "",
-                  " It maps from an account to its information."
+                  " It maps from an account to its information.",
+                  " Moreover, it counts the number of candidates."
                 ]
               },
               {
-                "name": "CandidateCount",
+                "name": "CounterForCandidatePool",
                 "modifier": "Default",
                 "type": {
                   "plain": 7
                 },
                 "fallback": "0x00000000",
                 "docs": [
-                  " The number of candidates in the pool."
+                  "Counter for the related counted storage map"
                 ]
               },
               {
                 "name": "TotalCollatorStake",
                 "modifier": "Default",
                 "type": {
-                  "plain": 123
+                  "plain": 133
                 },
                 "fallback": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "docs": [
@@ -22729,7 +24753,7 @@
                 "name": "TopCandidates",
                 "modifier": "Default",
                 "type": {
-                  "plain": 124
+                  "plain": 134
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -22749,7 +24773,7 @@
                 "name": "InflationConfig",
                 "modifier": "Default",
                 "type": {
-                  "plain": 126
+                  "plain": 136
                 },
                 "fallback": "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                 "docs": [
@@ -22765,7 +24789,7 @@
                       "Twox64Concat"
                     ],
                     "key": 0,
-                    "value": 129
+                    "value": 139
                   }
                 },
                 "fallback": "0x00",
@@ -22806,7 +24830,7 @@
                 "name": "ForceNewRound",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": []
@@ -22814,10 +24838,10 @@
             ]
           },
           "calls": {
-            "type": 133
+            "type": 143
           },
           "events": {
-            "type": 28
+            "type": 29
           },
           "constants": [
             {
@@ -22973,7 +24997,7 @@
             },
             {
               "name": "NetworkRewardRate",
-              "type": 29,
+              "type": 30,
               "value": "0x00008a5d78456301",
               "docs": [
                 " The rate in percent for the network rewards which are based on the",
@@ -22983,7 +25007,7 @@
             }
           ],
           "errors": {
-            "type": 134
+            "type": 144
           },
           "index": 21
         },
@@ -22996,7 +25020,7 @@
                 "name": "Validators",
                 "modifier": "Default",
                 "type": {
-                  "plain": 32
+                  "plain": 33
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23018,7 +25042,7 @@
                 "name": "QueuedChanged",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23030,7 +25054,7 @@
                 "name": "QueuedKeys",
                 "modifier": "Default",
                 "type": {
-                  "plain": 135
+                  "plain": 145
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23042,7 +25066,7 @@
                 "name": "DisabledValidators",
                 "modifier": "Default",
                 "type": {
-                  "plain": 140
+                  "plain": 150
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23062,7 +25086,7 @@
                       "Twox64Concat"
                     ],
                     "key": 0,
-                    "value": 137
+                    "value": 147
                   }
                 },
                 "fallback": "0x00",
@@ -23078,7 +25102,7 @@
                     "hashers": [
                       "Twox64Concat"
                     ],
-                    "key": 141,
+                    "key": 151,
                     "value": 0
                   }
                 },
@@ -23090,14 +25114,14 @@
             ]
           },
           "calls": {
-            "type": 143
+            "type": 153
           },
           "events": {
-            "type": 30
+            "type": 31
           },
           "constants": [],
           "errors": {
-            "type": 144
+            "type": 154
           },
           "index": 22
         },
@@ -23110,7 +25134,7 @@
                 "name": "Authorities",
                 "modifier": "Default",
                 "type": {
-                  "plain": 145
+                  "plain": 155
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23121,7 +25145,7 @@
                 "name": "CurrentSlot",
                 "modifier": "Default",
                 "type": {
-                  "plain": 147
+                  "plain": 157
                 },
                 "fallback": "0x0000000000000000",
                 "docs": [
@@ -23147,7 +25171,7 @@
                 "name": "Authorities",
                 "modifier": "Default",
                 "type": {
-                  "plain": 146
+                  "plain": 156
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23161,7 +25185,7 @@
             ]
           },
           "calls": {
-            "type": 148
+            "type": 158
           },
           "events": null,
           "constants": [],
@@ -23188,7 +25212,7 @@
                 "name": "PublicProps",
                 "modifier": "Default",
                 "type": {
-                  "plain": 149
+                  "plain": 159
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23204,7 +25228,7 @@
                       "Twox64Concat"
                     ],
                     "key": 7,
-                    "value": 151
+                    "value": 161
                   }
                 },
                 "fallback": "0x00",
@@ -23223,7 +25247,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 152
+                    "value": 162
                   }
                 },
                 "fallback": "0x00",
@@ -23264,7 +25288,7 @@
                       "Twox64Concat"
                     ],
                     "key": 7,
-                    "value": 153
+                    "value": 163
                   }
                 },
                 "fallback": "0x00",
@@ -23283,7 +25307,7 @@
                       "Twox64Concat"
                     ],
                     "key": 0,
-                    "value": 156
+                    "value": 166
                   }
                 },
                 "fallback": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -23295,30 +25319,10 @@
                 ]
               },
               {
-                "name": "Locks",
-                "modifier": "Optional",
-                "type": {
-                  "map": {
-                    "hashers": [
-                      "Twox64Concat"
-                    ],
-                    "key": 0,
-                    "value": 4
-                  }
-                },
-                "fallback": "0x00",
-                "docs": [
-                  " Accounts for which there are locks in action which may be removed at some point in the",
-                  " future. The value is the block number at which the lock expires and may be removed.",
-                  "",
-                  " TWOX-NOTE: OK ― `AccountId` is a secure hash."
-                ]
-              },
-              {
                 "name": "LastTabledWasExternal",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23330,7 +25334,7 @@
                 "name": "NextExternal",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 164
+                  "plain": 172
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23349,7 +25353,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 165
+                    "value": 173
                   }
                 },
                 "fallback": "0x00",
@@ -23367,7 +25371,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 37
+                    "value": 40
                   }
                 },
                 "fallback": "0x00",
@@ -23379,7 +25383,7 @@
                 "name": "StorageVersion",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 166
+                  "plain": 174
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23391,10 +25395,10 @@
             ]
           },
           "calls": {
-            "type": 167
+            "type": 175
           },
           "events": {
-            "type": 31
+            "type": 32
           },
           "constants": [
             {
@@ -23446,7 +25450,7 @@
             },
             {
               "name": "InstantAllowed",
-              "type": 37,
+              "type": 40,
               "value": "0x01",
               "docs": [
                 " Indicator for whether an emergency origin is even allowed to happen. Some chains may",
@@ -23473,7 +25477,7 @@
             {
               "name": "PreimageByteDeposit",
               "type": 6,
-              "value": "0x00a0724e180900000000000000000000",
+              "value": "0x00743ba40b0000000000000000000000",
               "docs": [
                 " The amount of balance that must be deposited per byte of preimage stored."
               ]
@@ -23499,7 +25503,7 @@
             }
           ],
           "errors": {
-            "type": 169
+            "type": 177
           },
           "index": 30
         },
@@ -23512,7 +25516,7 @@
                 "name": "Proposals",
                 "modifier": "Default",
                 "type": {
-                  "plain": 170
+                  "plain": 178
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23528,7 +25532,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 171
+                    "value": 179
                   }
                 },
                 "fallback": "0x00",
@@ -23545,7 +25549,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 235
+                    "value": 248
                   }
                 },
                 "fallback": "0x00",
@@ -23568,7 +25572,7 @@
                 "name": "Members",
                 "modifier": "Default",
                 "type": {
-                  "plain": 32
+                  "plain": 33
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23589,14 +25593,14 @@
             ]
           },
           "calls": {
-            "type": 172
+            "type": 180
           },
           "events": {
-            "type": 36
+            "type": 39
           },
           "constants": [],
           "errors": {
-            "type": 236
+            "type": 249
           },
           "index": 31
         },
@@ -23609,7 +25613,7 @@
                 "name": "Proposals",
                 "modifier": "Default",
                 "type": {
-                  "plain": 237
+                  "plain": 250
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23625,7 +25629,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 171
+                    "value": 179
                   }
                 },
                 "fallback": "0x00",
@@ -23642,7 +25646,7 @@
                       "Identity"
                     ],
                     "key": 9,
-                    "value": 235
+                    "value": 248
                   }
                 },
                 "fallback": "0x00",
@@ -23665,7 +25669,7 @@
                 "name": "Members",
                 "modifier": "Default",
                 "type": {
-                  "plain": 32
+                  "plain": 33
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23686,14 +25690,14 @@
             ]
           },
           "calls": {
-            "type": 173
+            "type": 181
           },
           "events": {
-            "type": 38
+            "type": 41
           },
           "constants": [],
           "errors": {
-            "type": 238
+            "type": 251
           },
           "index": 32
         },
@@ -23706,7 +25710,7 @@
                 "name": "Members",
                 "modifier": "Default",
                 "type": {
-                  "plain": 32
+                  "plain": 33
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23727,14 +25731,14 @@
             ]
           },
           "calls": {
-            "type": 174
+            "type": 182
           },
           "events": {
-            "type": 39
+            "type": 42
           },
           "constants": [],
           "errors": {
-            "type": 239
+            "type": 252
           },
           "index": 34
         },
@@ -23763,7 +25767,7 @@
                       "Twox64Concat"
                     ],
                     "key": 7,
-                    "value": 240
+                    "value": 253
                   }
                 },
                 "fallback": "0x00",
@@ -23775,7 +25779,7 @@
                 "name": "Approvals",
                 "modifier": "Default",
                 "type": {
-                  "plain": 241
+                  "plain": 254
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23785,15 +25789,15 @@
             ]
           },
           "calls": {
-            "type": 175
+            "type": 183
           },
           "events": {
-            "type": 40
+            "type": 43
           },
           "constants": [
             {
               "name": "ProposalBond",
-              "type": 242,
+              "type": 255,
               "value": "0x50c30000",
               "docs": [
                 " Fraction of a proposal's value that should be bonded in order to place the proposal.",
@@ -23809,6 +25813,14 @@
               ]
             },
             {
+              "name": "ProposalBondMaximum",
+              "type": 256,
+              "value": "0x00",
+              "docs": [
+                " Maximum amount of funds that should be placed in a deposit for making a proposal."
+              ]
+            },
+            {
               "name": "SpendPeriod",
               "type": 4,
               "value": "0xc0a8000000000000",
@@ -23818,7 +25830,7 @@
             },
             {
               "name": "Burn",
-              "type": 242,
+              "type": 255,
               "value": "0x00000000",
               "docs": [
                 " Percentage of spare funds (if any) that are burnt per spend period."
@@ -23826,7 +25838,7 @@
             },
             {
               "name": "PalletId",
-              "type": 243,
+              "type": 257,
               "value": "0x6b696c742f747379",
               "docs": [
                 " The treasury's pallet id, used for deriving its sovereign account ID."
@@ -23837,12 +25849,14 @@
               "type": 7,
               "value": "0x64000000",
               "docs": [
-                " The maximum number of approvals that can wait in the spending queue."
+                " The maximum number of approvals that can wait in the spending queue.",
+                "",
+                " NOTE: This parameter is also used within the Bounties Pallet extension if enabled."
               ]
             }
           ],
           "errors": {
-            "type": 244
+            "type": 258
           },
           "index": 35
         },
@@ -23850,10 +25864,10 @@
           "name": "Utility",
           "storage": null,
           "calls": {
-            "type": 176
+            "type": 184
           },
           "events": {
-            "type": 41
+            "type": 44
           },
           "constants": [
             {
@@ -23866,7 +25880,7 @@
             }
           ],
           "errors": {
-            "type": 245
+            "type": 259
           },
           "index": 40
         },
@@ -23884,7 +25898,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 246
+                    "value": 260
                   }
                 },
                 "fallback": "0x00",
@@ -23896,7 +25910,7 @@
                 "name": "StorageVersion",
                 "modifier": "Default",
                 "type": {
-                  "plain": 248
+                  "plain": 262
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -23908,10 +25922,10 @@
             ]
           },
           "calls": {
-            "type": 184
+            "type": 192
           },
           "events": {
-            "type": 42
+            "type": 45
           },
           "constants": [
             {
@@ -23930,7 +25944,7 @@
             }
           ],
           "errors": {
-            "type": 249
+            "type": 263
           },
           "index": 41
         },
@@ -23948,7 +25962,7 @@
                       "Twox64Concat"
                     ],
                     "key": 4,
-                    "value": 250
+                    "value": 264
                   }
                 },
                 "fallback": "0x00",
@@ -23965,34 +25979,21 @@
                       "Twox64Concat"
                     ],
                     "key": 10,
-                    "value": 44
+                    "value": 47
                   }
                 },
                 "fallback": "0x00",
                 "docs": [
                   " Lookup from identity to the block number and index of the task."
                 ]
-              },
-              {
-                "name": "StorageVersion",
-                "modifier": "Default",
-                "type": {
-                  "plain": 253
-                },
-                "fallback": "0x00",
-                "docs": [
-                  " Storage version of the pallet.",
-                  "",
-                  " New networks start with last version."
-                ]
               }
             ]
           },
           "calls": {
-            "type": 186
+            "type": 194
           },
           "events": {
-            "type": 43
+            "type": 46
           },
           "constants": [
             {
@@ -24015,9 +26016,178 @@
             }
           ],
           "errors": {
-            "type": 254
+            "type": 267
           },
           "index": 42
+        },
+        {
+          "name": "Proxy",
+          "storage": {
+            "prefix": "Proxy",
+            "items": [
+              {
+                "name": "Proxies",
+                "modifier": "Default",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Twox64Concat"
+                    ],
+                    "key": 0,
+                    "value": 268
+                  }
+                },
+                "fallback": "0x0000000000000000000000000000000000",
+                "docs": [
+                  " The set of account proxies. Maps the account which has delegated to the accounts",
+                  " which are being delegated to, together with the amount held on deposit."
+                ]
+              },
+              {
+                "name": "Announcements",
+                "modifier": "Default",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Twox64Concat"
+                    ],
+                    "key": 0,
+                    "value": 272
+                  }
+                },
+                "fallback": "0x0000000000000000000000000000000000",
+                "docs": [
+                  " The announcements made by the proxy (key)."
+                ]
+              }
+            ]
+          },
+          "calls": {
+            "type": 197
+          },
+          "events": {
+            "type": 50
+          },
+          "constants": [
+            {
+              "name": "ProxyDepositBase",
+              "type": 6,
+              "value": "0x0020f7a54b3300000000000000000000",
+              "docs": [
+                " The base amount of currency needed to reserve for creating a proxy.",
+                "",
+                " This is held for an additional storage item whose value size is",
+                " `sizeof(Balance)` bytes and whose key size is `sizeof(AccountId)` bytes."
+              ]
+            },
+            {
+              "name": "ProxyDepositFactor",
+              "type": 6,
+              "value": "0x00f4a92b800100000000000000000000",
+              "docs": [
+                " The amount of currency needed per proxy added.",
+                "",
+                " This is held for adding 32 bytes plus an instance of `ProxyType` more into a",
+                " pre-existing storage value. Thus, when configuring `ProxyDepositFactor` one should take",
+                " into account `32 + proxy_type.encode().len()` bytes of data."
+              ]
+            },
+            {
+              "name": "MaxProxies",
+              "type": 7,
+              "value": "0x0a000000",
+              "docs": [
+                " The maximum amount of proxies allowed for a single account."
+              ]
+            },
+            {
+              "name": "MaxPending",
+              "type": 7,
+              "value": "0x0a000000",
+              "docs": [
+                " The maximum amount of time-delayed announcements that are allowed to be pending."
+              ]
+            },
+            {
+              "name": "AnnouncementDepositBase",
+              "type": 6,
+              "value": "0x0020f7a54b3300000000000000000000",
+              "docs": [
+                " The base amount of currency needed to reserve for creating an announcement.",
+                "",
+                " This is held when a new storage item holding a `Balance` is created (typically 16",
+                " bytes)."
+              ]
+            },
+            {
+              "name": "AnnouncementDepositFactor",
+              "type": 6,
+              "value": "0x00e85357000300000000000000000000",
+              "docs": [
+                " The amount of currency needed per announcement made.",
+                "",
+                " This is held for adding an `AccountId`, `Hash` and `BlockNumber` (typically 68 bytes)",
+                " into a pre-existing storage value."
+              ]
+            }
+          ],
+          "errors": {
+            "type": 276
+          },
+          "index": 43
+        },
+        {
+          "name": "Preimage",
+          "storage": {
+            "prefix": "Preimage",
+            "items": [
+              {
+                "name": "StatusFor",
+                "modifier": "Optional",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Identity"
+                    ],
+                    "key": 9,
+                    "value": 277
+                  }
+                },
+                "fallback": "0x00",
+                "docs": [
+                  " The request status of a given hash."
+                ]
+              },
+              {
+                "name": "PreimageFor",
+                "modifier": "Optional",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Identity"
+                    ],
+                    "key": 9,
+                    "value": 280
+                  }
+                },
+                "fallback": "0x00",
+                "docs": [
+                  " The preimages stored by this pallet."
+                ]
+              }
+            ]
+          },
+          "calls": {
+            "type": 199
+          },
+          "events": {
+            "type": 53
+          },
+          "constants": [],
+          "errors": {
+            "type": 281
+          },
+          "index": 44
         },
         {
           "name": "KiltLaunch",
@@ -24046,7 +26216,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 4,
-                    "value": 255
+                    "value": 282
                   }
                 },
                 "fallback": "0x00",
@@ -24066,7 +26236,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 256
+                    "value": 283
                   }
                 },
                 "fallback": "0x00",
@@ -24086,7 +26256,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 35
+                    "value": 36
                   }
                 },
                 "fallback": "0x00",
@@ -24100,10 +26270,10 @@
             ]
           },
           "calls": {
-            "type": 188
+            "type": 200
           },
           "events": {
-            "type": 46
+            "type": 54
           },
           "constants": [
             {
@@ -24138,7 +26308,7 @@
             },
             {
               "name": "PalletId",
-              "type": 243,
+              "type": 257,
               "value": "0x6b696c742f6c6368",
               "docs": [
                 " The kilt launch's pallet id, used for deriving its sovereign account",
@@ -24147,7 +26317,7 @@
             }
           ],
           "errors": {
-            "type": 257
+            "type": 284
           },
           "index": 60
         },
@@ -24178,14 +26348,14 @@
             ]
           },
           "calls": {
-            "type": 190
+            "type": 202
           },
           "events": {
-            "type": 47
+            "type": 55
           },
           "constants": [],
           "errors": {
-            "type": 258
+            "type": 285
           },
           "index": 61
         },
@@ -24203,7 +26373,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 9,
-                    "value": 259
+                    "value": 286
                   }
                 },
                 "fallback": "0x00",
@@ -24222,7 +26392,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 9,
-                    "value": 261
+                    "value": 288
                   }
                 },
                 "fallback": "0x00",
@@ -24235,16 +26405,16 @@
             ]
           },
           "calls": {
-            "type": 191
+            "type": 203
           },
           "events": {
-            "type": 48
+            "type": 56
           },
           "constants": [
             {
               "name": "Deposit",
               "type": 6,
-              "value": "0x0080c6a47e8d03000000000000000000",
+              "value": "0x00a88d39f56d00000000000000000000",
               "docs": [
                 " The deposit that is required for storing an attestation."
               ]
@@ -24260,7 +26430,7 @@
             }
           ],
           "errors": {
-            "type": 262
+            "type": 289
           },
           "index": 62
         },
@@ -24270,17 +26440,6 @@
             "prefix": "Delegation",
             "items": [
               {
-                "name": "StorageVersion",
-                "modifier": "Default",
-                "type": {
-                  "plain": 263
-                },
-                "fallback": "0x01",
-                "docs": [
-                  " Contains the latest storage version deployed."
-                ]
-              },
-              {
                 "name": "DelegationNodes",
                 "modifier": "Optional",
                 "type": {
@@ -24289,7 +26448,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 9,
-                    "value": 264
+                    "value": 290
                   }
                 },
                 "fallback": "0x00",
@@ -24308,7 +26467,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 9,
-                    "value": 268
+                    "value": 294
                   }
                 },
                 "fallback": "0x00",
@@ -24321,10 +26480,10 @@
             ]
           },
           "calls": {
-            "type": 192
+            "type": 204
           },
           "events": {
-            "type": 50
+            "type": 58
           },
           "constants": [
             {
@@ -24337,7 +26496,7 @@
             },
             {
               "name": "MaxSignatureByteLength",
-              "type": 78,
+              "type": 52,
               "value": "0x4000",
               "docs": []
             },
@@ -24378,7 +26537,7 @@
             }
           ],
           "errors": {
-            "type": 269
+            "type": 295
           },
           "index": 63
         },
@@ -24396,7 +26555,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 270
+                    "value": 296
                   }
                 },
                 "fallback": "0x00",
@@ -24415,8 +26574,8 @@
                       "Twox64Concat",
                       "Blake2_128Concat"
                     ],
-                    "key": 278,
-                    "value": 211
+                    "key": 304,
+                    "value": 223
                   }
                 },
                 "fallback": "0x00",
@@ -24454,7 +26613,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 35
+                    "value": 36
                   }
                 },
                 "fallback": "0x00",
@@ -24465,31 +26624,20 @@
                   " It maps from a DID identifier to a unit tuple, for the sake of tracking",
                   " DID identifiers."
                 ]
-              },
-              {
-                "name": "StorageVersion",
-                "modifier": "Default",
-                "type": {
-                  "plain": 279
-                },
-                "fallback": "0x01",
-                "docs": [
-                  " Contains the latest storage version deployed."
-                ]
               }
             ]
           },
           "calls": {
-            "type": 199
+            "type": 211
           },
           "events": {
-            "type": 52
+            "type": 60
           },
           "constants": [
             {
               "name": "Deposit",
               "type": 6,
-              "value": "0x00008d49fd1a07000000000000000000",
+              "value": "0x00983ea62c2207000000000000000000",
               "docs": [
                 " The amount of balance that will be taken for each DID as a deposit",
                 " to incentivise fair use of the on chain storage. The deposit can be",
@@ -24580,7 +26728,7 @@
             {
               "name": "MaxServiceUrlLength",
               "type": 7,
-              "value": "0x64000000",
+              "value": "0xc8000000",
               "docs": [
                 " The maximum length of a service URL."
               ]
@@ -24595,7 +26743,7 @@
             }
           ],
           "errors": {
-            "type": 280
+            "type": 305
           },
           "index": 64
         },
@@ -24642,7 +26790,7 @@
                       "Blake2_128Concat"
                     ],
                     "key": 0,
-                    "value": 281
+                    "value": 306
                   }
                 },
                 "fallback": "0x00",
@@ -24653,16 +26801,16 @@
             ]
           },
           "calls": {
-            "type": 220
+            "type": 232
           },
           "events": {
-            "type": 53
+            "type": 61
           },
           "constants": [
             {
               "name": "Deposit",
               "type": 6,
-              "value": "0x0080c6a47e8d03000000000000000000",
+              "value": "0x00c0afd6913600000000000000000000",
               "docs": [
                 " The amount of balance that will be taken for each DID as a deposit",
                 " to incentivise fair use of the on chain storage. The deposit can be",
@@ -24671,9 +26819,106 @@
             }
           ],
           "errors": {
-            "type": 282
+            "type": 307
           },
           "index": 67
+        },
+        {
+          "name": "Web3Names",
+          "storage": {
+            "prefix": "Web3Names",
+            "items": [
+              {
+                "name": "Owner",
+                "modifier": "Optional",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Blake2_128Concat"
+                    ],
+                    "key": 63,
+                    "value": 308
+                  }
+                },
+                "fallback": "0x00",
+                "docs": [
+                  " Map of name -> ownership details."
+                ]
+              },
+              {
+                "name": "Names",
+                "modifier": "Optional",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Blake2_128Concat"
+                    ],
+                    "key": 0,
+                    "value": 63
+                  }
+                },
+                "fallback": "0x00",
+                "docs": [
+                  " Map of owner -> name."
+                ]
+              },
+              {
+                "name": "Banned",
+                "modifier": "Optional",
+                "type": {
+                  "map": {
+                    "hashers": [
+                      "Blake2_128Concat"
+                    ],
+                    "key": 63,
+                    "value": 36
+                  }
+                },
+                "fallback": "0x00",
+                "docs": [
+                  " Map of name -> ().",
+                  "",
+                  " If a name key is present, the name is currently banned."
+                ]
+              }
+            ]
+          },
+          "calls": {
+            "type": 234
+          },
+          "events": {
+            "type": 62
+          },
+          "constants": [
+            {
+              "name": "Deposit",
+              "type": 6,
+              "value": "0x00d450a85d6b00000000000000000000",
+              "docs": [
+                " The amount of KILT to deposit to claim a name."
+              ]
+            },
+            {
+              "name": "MinNameLength",
+              "type": 7,
+              "value": "0x03000000",
+              "docs": [
+                " The min encoded length of a name."
+              ]
+            },
+            {
+              "name": "MaxNameLength",
+              "type": 7,
+              "value": "0x20000000",
+              "docs": [
+                " The max encoded length of a name."
+              ]
+            }
+          ],
+          "errors": {
+            "type": 309
+          },
+          "index": 68
         },
         {
           "name": "ParachainSystem",
@@ -24715,7 +26960,7 @@
                 "name": "ValidationData",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 224
+                  "plain": 237
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24728,7 +26973,7 @@
                 "name": "DidSetValidationCode",
                 "modifier": "Default",
                 "type": {
-                  "plain": 37
+                  "plain": 40
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24739,7 +26984,7 @@
                 "name": "UpgradeRestrictionSignal",
                 "modifier": "Default",
                 "type": {
-                  "plain": 283
+                  "plain": 310
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24756,7 +27001,7 @@
                 "name": "RelevantMessagingState",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 285
+                  "plain": 312
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24773,7 +27018,7 @@
                 "name": "HostConfiguration",
                 "modifier": "Optional",
                 "type": {
-                  "plain": 290
+                  "plain": 317
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24789,7 +27034,7 @@
                 "name": "LastDmqMqcHead",
                 "modifier": "Default",
                 "type": {
-                  "plain": 291
+                  "plain": 318
                 },
                 "fallback": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "docs": [
@@ -24803,7 +27048,7 @@
                 "name": "LastHrmpMqcHeads",
                 "modifier": "Default",
                 "type": {
-                  "plain": 292
+                  "plain": 319
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24843,7 +27088,7 @@
                 "name": "HrmpOutboundMessages",
                 "modifier": "Default",
                 "type": {
-                  "plain": 295
+                  "plain": 322
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24856,7 +27101,7 @@
                 "name": "UpwardMessages",
                 "modifier": "Default",
                 "type": {
-                  "plain": 65
+                  "plain": 76
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24869,7 +27114,7 @@
                 "name": "PendingUpwardMessages",
                 "modifier": "Default",
                 "type": {
-                  "plain": 65
+                  "plain": 76
                 },
                 "fallback": "0x00",
                 "docs": [
@@ -24922,18 +27167,31 @@
                 "docs": [
                   " The next authorized upgrade, if there is one."
                 ]
+              },
+              {
+                "name": "CustomValidationHeadData",
+                "modifier": "Optional",
+                "type": {
+                  "plain": 10
+                },
+                "fallback": "0x00",
+                "docs": [
+                  " A custom head data that should be returned as result of `validate_block`.",
+                  "",
+                  " See [`Pallet::set_custom_validation_head_data`] for more information."
+                ]
               }
             ]
           },
           "calls": {
-            "type": 222
+            "type": 235
           },
           "events": {
-            "type": 54
+            "type": 65
           },
           "constants": [],
           "errors": {
-            "type": 297
+            "type": 324
           },
           "index": 80
         },
@@ -24946,7 +27204,7 @@
                 "name": "ParachainId",
                 "modifier": "Default",
                 "type": {
-                  "plain": 230
+                  "plain": 243
                 },
                 "fallback": "0x64000000",
                 "docs": []
@@ -24961,47 +27219,47 @@
         }
       ],
       "extrinsic": {
-        "type": 298,
+        "type": 325,
         "version": 4,
         "signedExtensions": [
           {
             "identifier": "CheckSpecVersion",
-            "type": 300,
+            "type": 327,
             "additionalSigned": 7
           },
           {
             "identifier": "CheckTxVersion",
-            "type": 301,
+            "type": 328,
             "additionalSigned": 7
           },
           {
             "identifier": "CheckGenesis",
-            "type": 302,
+            "type": 329,
             "additionalSigned": 9
           },
           {
             "identifier": "CheckMortality",
-            "type": 303,
+            "type": 330,
             "additionalSigned": 9
           },
           {
             "identifier": "CheckNonce",
-            "type": 305,
-            "additionalSigned": 35
+            "type": 332,
+            "additionalSigned": 36
           },
           {
             "identifier": "CheckWeight",
-            "type": 306,
-            "additionalSigned": 35
+            "type": 333,
+            "additionalSigned": 36
           },
           {
             "identifier": "ChargeTransactionPayment",
-            "type": 307,
-            "additionalSigned": 35
+            "type": 334,
+            "additionalSigned": 36
           }
         ]
       },
-      "type": 308
+      "type": 335
     }
   }
 }


### PR DESCRIPTION
## fixes #512

Because master currently still has the updateMetadata script set to an unreliable endpoint and we check out master in scheduled tests, this still fails.
By forcing the endpoint from the workflow file (which is executed from develop) this would be fixed. 