### PR TITLE
refactor: no throw in verify

### DIFF
--- a/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
@@ -429,10 +429,10 @@ describe('RequestForAttestation', () => {
     )
     expect(
       RequestForAttestationUtils.verifyStructure(builtRequest, testCType)
-    ).toBeTruthy()
+    ).toBe(true)
     builtRequest.claim.contents.name = 123
-    expect(() =>
+    expect(
       RequestForAttestationUtils.verifyStructure(builtRequest, testCType)
-    ).toThrowErrorWithCode(SDKErrors.ErrorCode.ERROR_NO_PROOF_FOR_STATEMENT)
+    ).toBe(false)
   })
 })

--- a/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
@@ -31,7 +31,10 @@ import { RequestForAttestation } from './RequestForAttestation.js'
  *  Throws on invalid input.
  *
  * @param input - A potentially only partial [[IRequestForAttestation]].
- * @throws [[ERROR_CLAIM_NOT_PROVIDED]], [[ERROR_LEGITIMATIONS_NOT_PROVIDED]], [[ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED]] or [[ERROR_DELEGATION_ID_TYPE]] when either the input's claim, legitimations, claimHashTree or DelegationId are not provided or of the wrong type, respectively.
+ * @throws [[ERROR_CLAIM_NOT_PROVIDED]], [[ERROR_LEGITIMATIONS_NOT_PROVIDED]],
+ *         [[ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED]] or [[ERROR_DELEGATION_ID_TYPE]] when either the
+ *         input's claim, legitimations, claimHashTree or DelegationId are not provided or of the
+ *         wrong type, respectively.
  * @throws [[ERROR_CLAIM_NONCE_MAP_MALFORMED]] when any of the input's claimHashTree's keys missing their hash.
  *
  */
@@ -159,7 +162,11 @@ export function verifyStructure(
   requestForAttestation: IRequestForAttestation,
   ctype: ICType
 ): boolean {
-  errorCheck(requestForAttestation)
+  try {
+    errorCheck(requestForAttestation)
+  } catch {
+    return false
+  }
   return CTypeUtils.verifyClaimStructure(
     requestForAttestation.claim.contents,
     ctype.schema

--- a/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
@@ -31,10 +31,7 @@ import { RequestForAttestation } from './RequestForAttestation.js'
  *  Throws on invalid input.
  *
  * @param input - A potentially only partial [[IRequestForAttestation]].
- * @throws [[ERROR_CLAIM_NOT_PROVIDED]], [[ERROR_LEGITIMATIONS_NOT_PROVIDED]],
- *         [[ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED]] or [[ERROR_DELEGATION_ID_TYPE]] when either the
- *         input's claim, legitimations, claimHashTree or DelegationId are not provided or of the
- *         wrong type, respectively.
+ * @throws [[ERROR_CLAIM_NOT_PROVIDED]], [[ERROR_LEGITIMATIONS_NOT_PROVIDED]], [[ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED]] or [[ERROR_DELEGATION_ID_TYPE]] when either the input's claim, legitimations, claimHashTree or DelegationId are not provided or of the wrong type, respectively.
  * @throws [[ERROR_CLAIM_NONCE_MAP_MALFORMED]] when any of the input's claimHashTree's keys missing their hash.
  *
  */


### PR DESCRIPTION
Don't throw an error in verify method.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
