### PR TITLE
feat: add renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     ":preserveSemverRanges",
     ":disableDevDependencies",
-    ":disablePeerDependencies"
+    ":disablePeerDependencies",
+    ":semanticCommits"
   ],
   "enabledManagers": ["npm"],
   "semanticCommitType": "chore",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     "yarnDedupeHighest"
   ],
   "prConcurrentLimit": 10,
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 10,
   "packageRules": [
     {
       "matchUpdateTypes": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,5 @@
 {
   "extends": [
-    ":prHourlyLimit2",
-    ":prConcurrentLimit10",
     ":preserveSemverRanges",
     ":disableDevDependencies",
     ":disablePeerDependencies"
@@ -16,6 +14,8 @@
   "postUpdateOptions": [
     "yarnDedupeHighest"
   ],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "matchUpdateTypes": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,7 @@
       "separateMajorMinor": false,
       "separateMultipleMajor": false,
       "separateMinorPatch": false,
-      "groupName": "polkadot updates",
+      "groupName": "polkadot dependencies",
       "groupSlug": "polkadot"
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     "yarnDedupeHighest"
   ],
   "prConcurrentLimit": 10,
-  "prHourlyLimit": 10,
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "matchUpdateTypes": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,40 @@
+{
+  "extends": [
+    ":prHourlyLimit2",
+    ":prConcurrentLimit10",
+    ":preserveSemverRanges",
+    ":disableDevDependencies",
+    ":disablePeerDependencies"
+  ],
+  "enabledManagers": ["npm"],
+  "semanticCommitType": "chore",
+  "labels": [
+    "dependencies"
+  ],
+  "dependencyDashboard": false,
+  "updateLockFiles": true,
+  "postUpdateOptions": [
+    "yarnDedupeHighest"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackagePatterns": [
+        "^@polkadot/*"
+      ],
+      "separateMajorMinor": false,
+      "separateMultipleMajor": false,
+      "separateMinorPatch": false,
+      "groupName": "polkadot updates",
+      "groupSlug": "polkadot"
+    }
+  ]
+}


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1832

This adds a renovate config to the repo. Repo maintainers would have to add the [renovate app](https://github.com/marketplace/renovate) to the repo for this to have an effect.

## How to test:
I set this up on a fork so I can test it. Look at the PRs it has created, works quite nicely.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
