### PR TITLE
refactor: consistent naming

### DIFF
--- a/packages/core/src/__integrationtests__/AccountLinking.spec.ts
+++ b/packages/core/src/__integrationtests__/AccountLinking.spec.ts
@@ -180,11 +180,12 @@ describe('When there is an on-chain DID', () => {
       }, 40_000)
 
       it('should be possible to associate the account while the sender pays the deposit', async () => {
-        const linkAuthorisation = await AccountLinks.authorizeLinkWithAccount(
-          keypair.address,
-          did.identifier,
-          signingCallback
-        )
+        const linkAuthorisation =
+          await AccountLinks.getAuthorizeLinkWithAccountTx(
+            keypair.address,
+            did.identifier,
+            signingCallback
+          )
         const signedTx = await did.authorizeExtrinsic(
           linkAuthorisation,
           keystore,
@@ -222,11 +223,12 @@ describe('When there is an on-chain DID', () => {
         ).resolves.toBeTruthy()
       })
       it('should be possible to associate the account to a new DID while the sender pays the deposit', async () => {
-        const linkAuthorisation = await AccountLinks.authorizeLinkWithAccount(
-          keypair.address,
-          newDid.identifier,
-          signingCallback
-        )
+        const linkAuthorisation =
+          await AccountLinks.getAuthorizeLinkWithAccountTx(
+            keypair.address,
+            newDid.identifier,
+            signingCallback
+          )
         const signedTx = await newDid.authorizeExtrinsic(
           linkAuthorisation,
           keystore,
@@ -334,11 +336,12 @@ describe('When there is an on-chain DID', () => {
     }, 40_000)
 
     it('should be possible to associate the account while the sender pays the deposit', async () => {
-      const linkAuthorisation = await AccountLinks.authorizeLinkWithAccount(
-        genericAccount.address,
-        did.identifier,
-        signingCallback
-      )
+      const linkAuthorisation =
+        await AccountLinks.getAuthorizeLinkWithAccountTx(
+          genericAccount.address,
+          did.identifier,
+          signingCallback
+        )
       const signedTx = await did.authorizeExtrinsic(
         linkAuthorisation,
         keystore,

--- a/packages/core/src/__integrationtests__/AccountLinking.spec.ts
+++ b/packages/core/src/__integrationtests__/AccountLinking.spec.ts
@@ -69,7 +69,7 @@ describe('When there is an on-chain DID', () => {
         AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
       ).resolves.toBeFalsy()
 
-      const associateSenderTx = await AccountLinks.getAssociateSenderTx()
+      const associateSenderTx = await AccountLinks.getAssociateSenderExtrinsic()
       const signedTx = await did.authorizeExtrinsic(
         associateSenderTx,
         keystore,
@@ -102,7 +102,7 @@ describe('When there is an on-chain DID', () => {
       ).resolves.toBeTruthy()
     }, 30_000)
     it('should be possible to associate the tx sender to a new DID', async () => {
-      const associateSenderTx = await AccountLinks.getAssociateSenderTx()
+      const associateSenderTx = await AccountLinks.getAssociateSenderExtrinsic()
       const signedTx = await newDid.authorizeExtrinsic(
         associateSenderTx,
         keystore,
@@ -181,7 +181,7 @@ describe('When there is an on-chain DID', () => {
 
       it('should be possible to associate the account while the sender pays the deposit', async () => {
         const linkAuthorisation =
-          await AccountLinks.getAuthorizeLinkWithAccountTx(
+          await AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
             keypair.address,
             did.identifier,
             signingCallback
@@ -224,7 +224,7 @@ describe('When there is an on-chain DID', () => {
       })
       it('should be possible to associate the account to a new DID while the sender pays the deposit', async () => {
         const linkAuthorisation =
-          await AccountLinks.getAuthorizeLinkWithAccountTx(
+          await AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
             keypair.address,
             newDid.identifier,
             signingCallback
@@ -275,7 +275,7 @@ describe('When there is an on-chain DID', () => {
         ).resolves.toBeTruthy()
       })
       it('should be possible for the DID to remove the link', async () => {
-        const removeLinkTx = await AccountLinks.getLinkRemovalByDidTx(
+        const removeLinkTx = await AccountLinks.getLinkRemovalByDidExtrinsic(
           keypair.address
         )
         const signedTx = await newDid.authorizeExtrinsic(
@@ -337,7 +337,7 @@ describe('When there is an on-chain DID', () => {
 
     it('should be possible to associate the account while the sender pays the deposit', async () => {
       const linkAuthorisation =
-        await AccountLinks.getAuthorizeLinkWithAccountTx(
+        await AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
           genericAccount.address,
           did.identifier,
           signingCallback

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -277,7 +277,7 @@ export function defaultSignerCallback(keyring: Keyring): LinkingSignerCallback {
  * @param nBlocksValid How many blocks into the future should the account-signed proof be considered valid?
  * @returns An Extrinsic that must be did-authorized by the [[FullDid]] whose identifier was used.
  */
-export async function authorizeLinkWithAccount(
+export async function getAuthorizeLinkWithAccountTx(
   accountAddress: Address,
   didIdentifier: DidIdentifier,
   signingCallback: LinkingSignerCallback,

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -167,7 +167,7 @@ export async function queryDepositAmount(): Promise<BN> {
  *
  * @returns An [[Extrinsic]] that must be did-authorized.
  */
-export async function getAssociateSenderTx(): Promise<Extrinsic> {
+export async function getAssociateSenderExtrinsic(): Promise<Extrinsic> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
   return api.tx.didLookup.associateSender()
 }
@@ -185,7 +185,7 @@ export async function getAssociateSenderTx(): Promise<Extrinsic> {
  * @param sigType The type of key/substrate account which produced the `signature`.
  * @returns An [[Extrinsic]] that must be did-authorized.
  */
-export async function getAccountSignedAssociationTx(
+export async function getAccountSignedAssociationExtrinsic(
   account: Address,
   signatureValidUntilBlock: AnyNumber,
   signature: Uint8Array | HexString,
@@ -229,7 +229,7 @@ export async function getLinkRemovalByAccountTx(): Promise<SubmittableExtrinsic>
  * @param linkedAccount An account linked to the FullDid which should be unlinked.
  * @returns An Extrinsic that must be did-authorized by the FullDid linked to `linkedAccount`.
  */
-export async function getLinkRemovalByDidTx(
+export async function getLinkRemovalByDidExtrinsic(
   linkedAccount: Address
 ): Promise<Extrinsic> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
@@ -277,7 +277,7 @@ export function defaultSignerCallback(keyring: Keyring): LinkingSignerCallback {
  * @param nBlocksValid How many blocks into the future should the account-signed proof be considered valid?
  * @returns An Extrinsic that must be did-authorized by the [[FullDid]] whose identifier was used.
  */
-export async function getAuthorizeLinkWithAccountTx(
+export async function getAuthorizeLinkWithAccountExtrinsic(
   accountAddress: Address,
   didIdentifier: DidIdentifier,
   signingCallback: LinkingSignerCallback,
@@ -326,7 +326,7 @@ export async function getAuthorizeLinkWithAccountTx(
   const { crypto } = result
 
   const sigType = getMultiSignatureTypeFromKeypairType(crypto as KeypairType)
-  return getAccountSignedAssociationTx(
+  return getAccountSignedAssociationExtrinsic(
     accountAddress,
     validTill,
     signature,


### PR DESCRIPTION
BREAKING CHANGE: rename `authorizeLinkWithAccount` to `getAuthorizeLinkWithAccountTx`

## No Ticket

One is not like the others!

```
function getAssociateSenderTx(): Promise<Extrinsic>
function getAccountSignedAssociationTx(): Promise<Extrinsic>
function getReclaimDepositTx(): Promise<SubmittableExtrinsic>
function getLinkRemovalByAccountTx(): Promise<SubmittableExtrinsic>
function getLinkRemovalByDidTx(): Promise<Extrinsic>
function authorizeLinkWithAccount(): Promise<Extrinsic>
```

All function that return an extrinsic are called `get...Tx` except this one, which is confusing. I expected that this does something else. 😅

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
