### PR TITLE
chore: remove all @example jsdocs

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -49,14 +49,6 @@ On top of the the linting rules mentioned above (must document all parameters, m
 * `@param` and `@returns` fields: don't add types, since this is automatically added into the API doc;
 * Make sure you explain opaque abbreviations or jargon (example: TxStatus = transaction status);
 * When referring to SDK Classes and methods, make sure you link them in, using `[[]]`;
-* `@example`:
-  * Create it as valid **JS** code, to make it simple for both TS and JS developers;
-  * Keep it really short, illustrate only this method's functionality;
-  * Provide minimal context;
-  * Avoid printing the output of full objects;
-  * Don't use `console.log()`;
-  * No need to write `Kilt` to signify that a class comes from Kilt (e.g.: ~~`Kilt.Identity`~~, just write `Identity` instead);
-  * Include comments as needed 😎.
 
 💡The linting rules for the example snippet are **not** the same as the SDK codebase linting rules. For example, the example snippet should make use of semicolumns. You can see the full ruleset in `.eslintrc-jsdoc.json`, but the linter should be enough to help you figure the rules out.
 
@@ -68,13 +60,6 @@ Example of a method docBlock that follows these guidelines:
   *
   * @param phraseArg - [[BIP39]](https://www.npmjs.com/package/bip39) Mnemonic word phrase (Secret phrase).
   * @returns An [[Identity]].
-  *
-  * @example ```javascript
-  * const mnemonic = Identity.generateMnemonic();
-  * // mnemonic: "coast ugly state lunch repeat step armed goose together pottery bind mention"
-  *
-  * Identity.buildFromMnemonic(mnemonic);
-  * ```
   */
 ```
 

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -44,11 +44,6 @@ export class Attestation implements IAttestation {
    *
    * @param claimHash - The hash of the claim that corresponds to the attestation to query.
    * @returns A promise containing the [[Attestation]] or null.
-   * @example ```javascript
-   * Attestation.query('0xd8024cdc147c4fa9221cd177').then((attestation) => {
-   *   // now we can for example revoke `attestation`
-   * });
-   * ```
    */
   public static async query(
     claimHash: IAttestation['claimHash']
@@ -62,19 +57,6 @@ export class Attestation implements IAttestation {
    * @param claimHash - The hash of the claim that corresponds to the attestation to revoke.
    * @param maxDepth - The number of levels to walk up the delegation hierarchy until the delegation node is found.
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * Attestation.getRevokeTx('0xd8024cdc147c4fa9221cd177', 3).then(
-   *   (revocationExtrinsic) => {
-   *     // The attestation revocation tx was created, and it can now be signed by the attestation owner.
-   *     attestationOwnerDid
-   *       .authorizeExtrinsic(revocationExtrinsic, keystore, submitter.address)
-   *       .then((authorizedExtrinsic) => {
-   *         // The DID-authorized tx is ready to be submitted!
-   *         BlockchainUtils.signAndSendTx(authorizedExtrinsic, submitter);
-   *       });
-   *   }
-   * );
-   * ```
    */
   public static async getRevokeTx(
     claimHash: IRequestForAttestation['rootHash'],
@@ -89,19 +71,6 @@ export class Attestation implements IAttestation {
    * @param claimHash - The hash of the claim that corresponds to the attestation to remove.
    * @param maxDepth - The number of levels to walk up the delegation hierarchy until the delegation node is found.
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * Attestation.getRemoveTx('0xd8024cdc147c4fa9221cd177', 3).then(
-   *   (removalExtrinsic) => {
-   *     // The attestation removal tx was created, and it can now be signed by the attestation owner.
-   *     attestationOwnerDid
-   *       .authorizeExtrinsic(removalExtrinsic, keystore, submitter.address)
-   *       .then((authorizedExtrinsic) => {
-   *         // The DID-authorized tx is ready to be submitted!
-   *         BlockchainUtils.signAndSendTx(authorizedExtrinsic, submitter);
-   *       });
-   *   }
-   * );
-   * ```
    */
   public static async getRemoveTx(
     claimHash: IRequestForAttestation['rootHash'],
@@ -117,14 +86,6 @@ export class Attestation implements IAttestation {
    *
    * @param claimHash - The hash of the claim that corresponds to the attestation to remove and its deposit to be returned to the original payer.
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * Attestation.getReclaimDepositTx('0xd8024cdc147c4fa9221cd177').then(
-   *   (claimExtrinsic) => {
-   *     // The deposit claiming tx was created, and it can now be submitted by the attestation deposit payer ONLY.
-   *     BlockchainUtils.signAndSendTx(claimExtrinsic, submitter);
-   *   }
-   * );
-   * ```
    */
   public static async getReclaimDepositTx(
     claimHash: IRequestForAttestation['rootHash']
@@ -138,10 +99,6 @@ export class Attestation implements IAttestation {
    *
    * @param attestationInput - The base object from which to create the attestation.
    * @returns A new [[Attestation]] object.
-   * @example ```javascript
-   * // create an Attestation object, so we can call methods on it (`serialized` is a serialized Attestation object )
-   * Attestation.fromAttestation(JSON.parse(serialized));
-   * ```
    */
   public static fromAttestation(attestationInput: IAttestation): Attestation {
     return new Attestation(attestationInput)
@@ -153,10 +110,6 @@ export class Attestation implements IAttestation {
    * @param request - The base request for attestation.
    * @param attesterDid - The attester's DID, used to attest to the underlying claim.
    * @returns A new [[Attestation]] object.
-   * @example ```javascript
-   * // create a complete new attestation from the `RequestForAttestation` and all other needed properties
-   * Attestation.fromRequestAndDid(request, attesterDid);
-   * ```
    */
   public static fromRequestAndDid(
     request: IRequestForAttestation,
@@ -221,10 +174,6 @@ export class Attestation implements IAttestation {
    * Builds a new [[Attestation]] instance.
    *
    * @param attestationInput - The base object from which to create the attestation.
-   * @example ```javascript
-   * // create an attestation, e.g. to store it on-chain
-   * const attestation = new Attestation(attestationInput);
-   * ```
    */
   public constructor(attestationInput: IAttestation) {
     AttestationUtils.errorCheck(attestationInput)
@@ -239,26 +188,6 @@ export class Attestation implements IAttestation {
    * [ASYNC] Prepares an extrinsic to store the attestation on chain.
    *
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * // Use `store` to store an attestation on chain, and to create a `Credential` upon success:
-   * attestation.getStoreTx().then((creationExtrinsic) => {
-   *   // the attestation store tx was successfully prepared, so now we can sign and send it and subsequently create a `Credential`.
-   *   attestationOwnerDid
-   *     .authorizeExtrinsic(creationExtrinsic, keystore, submitter.address)
-   *     .then((authorizedExtrinsic) => {
-   *       // The DID-authorized tx is ready to be submitted!
-   *       BlockchainUtils.signAndSendTx(authorizedExtrinsic, submitter);
-   *     });
-   * });
-   * // The attestation creation tx was created, and it can now be signed by a DID owner.
-   * const authorizedExtrinsic = await attestationOwnerDid.authorizeExtrinsic(
-   *   creationExtrinsic,
-   *   keystore,
-   *   submitter.address
-   * );
-   * // The DID-authorized tx is ready to be submitted!
-   * BlockchainUtils.signAndSendTx(authorizedExtrinsic, submitter);
-   * ```
    */
   public async getStoreTx(): Promise<SubmittableExtrinsic> {
     return getStoreTx(this)
@@ -269,17 +198,6 @@ export class Attestation implements IAttestation {
    *
    * @param maxDepth - The number of levels to walk up the delegation hierarchy until the delegation node is found.
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * attestation.getRevokeTx(3).then((revocationExtrinsic) => {
-   *   // The attestation revocation tx was created, and it can now be signed by the attestation owner.
-   *   attestationOwnerDid
-   *     .authorizeExtrinsic(revocationExtrinsic, keystore, submitter.address)
-   *     .then((authorizedExtrinsic) => {
-   *       // The DID-authorized tx is ready to be submitted!
-   *       BlockchainUtils.signAndSendTx(authorizedExtrinsic, submitter);
-   *     });
-   * });
-   * ```
    */
   public async getRevokeTx(maxDepth: number): Promise<SubmittableExtrinsic> {
     return getRevokeTx(this.claimHash, maxDepth)
@@ -290,17 +208,6 @@ export class Attestation implements IAttestation {
    *
    * @param maxDepth - The number of levels to walk up the delegation hierarchy until the delegation node is found.
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * attestation.getRemoveTx(3).then((removalExtrinsic) => {
-   *   // The attestation removal tx was created, and it can now be signed by the attestation owner.
-   *   attestationOwnerDid
-   *     .authorizeExtrinsic(removalExtrinsic, keystore, submitter.address)
-   *     .then((authorizedExtrinsic) => {
-   *       // The DID-authorized tx is ready to be submitted!
-   *       BlockchainUtils.signAndSendTx(authorizedExtrinsic, submitter);
-   *     });
-   * });
-   * ```
    */
   public async getRemoveTx(maxDepth: number): Promise<SubmittableExtrinsic> {
     return getRemoveTx(this.claimHash, maxDepth)
@@ -312,12 +219,6 @@ export class Attestation implements IAttestation {
    * This call can only be successfully executed if the submitter of the transaction is the original payer of the attestation deposit.
    *
    * @returns A promise containing the unsigned SubmittableExtrinsic (submittable transaction).
-   * @example ```javascript
-   * attestation.getReclaimDepositTx().then((claimExtrinsic) => {
-   *   // The deposit claiming tx was created, and it can now be submitted by the attestation deposit payer ONLY.
-   *   BlockchainUtils.signAndSendTx(claimExtrinsic, submitter);
-   * });
-   * ```
    */
   public async getReclaimDepositTx(): Promise<SubmittableExtrinsic> {
     return getReclaimDepositTx(this.claimHash)
@@ -329,11 +230,6 @@ export class Attestation implements IAttestation {
    * @param attestation - The Attestation to verify.
    * @param claimHash - The hash of the claim that corresponds to the attestation to check. Defaults to the claimHash for the attestation onto which "verify" is called.
    * @returns A promise containing whether the attestation is valid.
-   * @example ```javascript
-   * Attestation.checkValidity(attestation).then((isVerified) => {
-   *   // `isVerified` is true if the attestation is verified, false otherwise
-   * });
-   * ```
    */
   public static async checkValidity(
     attestation: IAttestation,

--- a/packages/core/src/balance/Balance.chain.ts
+++ b/packages/core/src/balance/Balance.chain.ts
@@ -31,18 +31,6 @@ import * as BalanceUtils from './Balance.utils.js'
  *
  * @param accountAddress Address of the account for which to get the balances.
  * @returns A promise containing the current balances of the account.
- *
- * @example
- * <BR>
- *
- * ```javascript
- *
- * const address = ...
- * sdk.Balance.getBalances(address)
- *   .then((balanceData: AccountData) => {
- *     console.log(`free balances is ${balanceData.free.toNumber()}`)
- *   })
- * ```
  */
 export async function getBalances(
   accountAddress: KeyringPair['address']
@@ -59,19 +47,6 @@ export async function getBalances(
  * @param accountAddress Address of the account on which to listen for all balance changes.
  * @param listener Listener to receive all balance change updates.
  * @returns A promise containing a function that let's you unsubscribe from all balance changes.
- *
- * @example
- * <BR>
- *
- * ```javascript
- * const address = ...
- * const unsubscribe = await sdk.Balance.listenToBalanceChanges(address,
- *   (account: KeyringPair['address'], balances: Balances, changes: Balances) => {
- *     console.log(`Balance has changed by ${changes.free.toNumber()} to ${balances.free.toNumber()}`)
- *   });
- * // later
- * unsubscribe();
- * ```
  */
 export async function listenToBalanceChanges(
   accountAddress: KeyringPair['address'],
@@ -115,22 +90,6 @@ export async function listenToBalanceChanges(
  * @param amount Amount of Units to transfer.
  * @param exponent Magnitude of the amount. Default magnitude of -15 represents Femto-Kilt. Use 0 for KILT.
  * @returns Promise containing unsigned SubmittableExtrinsic.
- *
- * @example
- * <BR>
- *
- * ```javascript
- * const identity = ...
- * const address = ...
- * const amount: BN = new BN(42)
- * const blockchain = await sdk.getConnectionOrConnect()
- * sdk.Balance.getTransferTx(address, amount, 0) // transfer 42 KILT
- *   .then(tx => sdk.BlockchainUtils.signAndSubmitTx(tx, identity))
- *   .then(() => console.log(`Successfully transferred ${amount.toNumber()} tokens`))
- *   .catch(err => {
- *     console.log('Transfer failed')
- *   })
- * ```
  */
 export async function getTransferTx(
   accountAddressTo: KeyringPair['address'],

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -43,10 +43,6 @@ export class Credential implements ICredential {
    *
    * @param credentialInput - The base object from which to create the credential.
    * @returns A new instantiated [[Credential]] object.
-   * @example ```javascript
-   * // create n Credential object, so we can call methods on it (`serialized` is a serialized Credential object)
-   * Credential.fromCredential(JSON.parse(serialized));
-   * ```
    */
   public static fromCredential(credentialInput: ICredential): Credential {
     return new Credential(credentialInput)
@@ -58,10 +54,6 @@ export class Credential implements ICredential {
    * @param request - The request for attestation for the claim that was attested.
    * @param attestation - The attestation for the claim by the attester.
    * @returns A new [[Credential]] object.
-   * @example ```javascript
-   * // create a Credential object after receiving the attestation from the attester
-   * Credential.fromRequestAndAttestation(request, attestation);
-   * ```
    */
   public static fromRequestAndAttestation(
     request: IRequestForAttestation,
@@ -96,10 +88,6 @@ export class Credential implements ICredential {
    * Builds a new [[Credential]] instance.
    *
    * @param credentialInput - The base object with all required input, from which to create the credential.
-   * @example ```javascript
-   * // Create a `Credential` upon successful `Attestation` creation:
-   * const credential = new Credential(credentialInput);
-   * ```
    */
   public constructor(credentialInput: ICredential) {
     CredentialUtils.errorCheck(credentialInput)
@@ -121,11 +109,6 @@ export class Credential implements ICredential {
    * Defaults to [[DidResolver]].
    * @param verificationOpts.challenge - The expected value of the challenge. Verification will fail in case of a mismatch.
    * @returns A promise containing whether the provided credential is valid.
-   * @example ```javascript
-   * Credential.verify().then((isVerified) => {
-   *   // `isVerified` is true if the credential is verified, false otherwise
-   * });
-   * ```
    */
   public static async verify(
     credential: ICredential,
@@ -161,9 +144,6 @@ export class Credential implements ICredential {
    *
    * @param credential - The credential to verify.
    * @returns Whether the credential's data is valid.
-   * @example ```javascript
-   * const verificationResult = Credential.verifyData(credential);
-   * ```
    */
   public static verifyData(credential: ICredential): boolean {
     if (credential.request.claim.cTypeHash !== credential.attestation.cTypeHash)
@@ -199,9 +179,6 @@ export class Credential implements ICredential {
    * Gets the hash of the claim that corresponds to this attestation.
    *
    * @returns The hash of the claim for this attestation (claimHash).
-   * @example ```javascript
-   * attestation.getHash();
-   * ```
    */
   public getHash(): IAttestation['claimHash'] {
     return this.attestation.claimHash

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -278,23 +278,6 @@ export class DelegationNode implements IDelegationNode {
    * @param signer The keystore responsible for signing the delegation creation details for the delegee.
    * @param options The additional signing options.
    * @param options.keySelection The logic to select the right key to sign for the delegee. It defaults to picking the first key from the set of valid keys.
-   * @example
-   * ```
-   * // Sign the hash of the delegation node...
-   * let myNewDelegation: DelegationNode
-   * let myDidDetails: DidDetails
-   * let myKeyStore: Keystore
-   * const signature:string = await myNewDelegation.delegeeSign(myDidDetails, myKeyStore)
-   *
-   * // produce the extrinsic that stores the delegation node on the Kilt chain
-   * const extrinsic = await newDelegationNode.store(signature)
-   *
-   * // now the delegating DID must sign as well
-   * const submittable = await delegator.authorizeExtrinsic(extrinsic, delegtorsKeystore, submitterAccount)
-   *
-   * // and we can put it on chain
-   * await submittable.signAndSend()
-   * ```
    * @returns The DID signature over the delegation **as a hex string**.
    */
   public async delegeeSign(

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -63,12 +63,6 @@ export class RequestForAttestation implements IRequestForAttestation {
    *
    * @param requestForAttestationInput - An object built from simple [[Claim]], [[Identity]] and legitimation objects.
    * @returns  A new [[RequestForAttestation]] `object`.
-   * @example ```javascript
-   * const serializedRequest =
-   *   '{ "claim": { "cType": "0x981...", "contents": { "name": "Alice", "age": 29 }, owner: "5Gf..." }, ... }, ... }';
-   * const parsedRequest = JSON.parse(serializedRequest);
-   * RequestForAttestation.fromRequest(parsedRequest);
-   * ```
    */
   public static fromRequest(
     requestForAttestationInput: IRequestForAttestation
@@ -84,9 +78,6 @@ export class RequestForAttestation implements IRequestForAttestation {
    * @param option.legitimations Array of [[Credential]] objects of the Attester which the Claimer requests to include into the attestation as legitimations.
    * @param option.delegationId The id of the DelegationNode of the Attester, which should be used in the attestation.
    * @returns A new [[RequestForAttestation]] object.
-   * @example ```javascript
-   * const input = RequestForAttestation.fromClaim(claim);
-   * ```
    */
   public static fromClaim(
     claim: IClaim,
@@ -142,10 +133,6 @@ export class RequestForAttestation implements IRequestForAttestation {
    * Builds a new [[RequestForAttestation]] instance.
    *
    * @param requestForAttestationInput - The base object from which to create the input.
-   * @example ```javascript
-   * // create a new request for attestation
-   * const reqForAtt = new RequestForAttestation(requestForAttestationInput);
-   * ```
    */
   public constructor(requestForAttestationInput: IRequestForAttestation) {
     RequestForAttestationUtils.errorCheck(requestForAttestationInput)
@@ -174,16 +161,6 @@ export class RequestForAttestation implements IRequestForAttestation {
    *
    * @param properties - Properties to remove from the [[Claim]] object.
    * @throws [[ERROR_CLAIM_HASHTREE_MISMATCH]] when a property which should be deleted wasn't found.
-   * @example ```javascript
-   * const rawClaim = {
-   *   name: 'Alice',
-   *   age: 29,
-   * };
-   * const claim = Claim.fromCTypeAndClaimContents(ctype, rawClaim, alice);
-   * const reqForAtt = RequestForAttestation.fromClaim(claim);
-   * reqForAtt.removeClaimProperties(['name']);
-   * // reqForAtt does not contain `name` in its claimHashTree and its claim contents anymore.
-   * ```
    */
   public removeClaimProperties(properties: string[]): void {
     properties.forEach((key) => {
@@ -201,10 +178,6 @@ export class RequestForAttestation implements IRequestForAttestation {
    * @returns Whether the data is valid.
    * @throws [[ERROR_CLAIM_NONCE_MAP_MALFORMED]] when any key of the claim contents could not be found in the claimHashTree.
    * @throws [[ERROR_ROOT_HASH_UNVERIFIABLE]] when the rootHash is not verifiable.
-   * @example ```javascript
-   * const reqForAtt = RequestForAttestation.fromClaim(claim);
-   * RequestForAttestation.verifyData(reqForAtt); // returns true if the data is correct
-   * ```
    */
   public static verifyData(input: IRequestForAttestation): boolean {
     // check claim hash
@@ -246,11 +219,6 @@ export class RequestForAttestation implements IRequestForAttestation {
    * @param verificationOpts.challenge - The expected value of the challenge. Verification will fail in case of a mismatch.
    * @throws [[ERROR_IDENTITY_MISMATCH]] if the DidDetails do not match the claim owner or if the light DID is used after it has been upgraded.
    * @returns Whether the signature is correct.
-   * @example ```javascript
-   * const reqForAtt = RequestForAttestation.fromClaim(claim);
-   * await reqForAtt.signWithDid(myKeystore, myDidDetails);
-   * RequestForAttestation.verifySignature(reqForAtt); // returns `true` if the signature is correct
-   * ```
    */
   public static async verifySignature(
     input: IRequestForAttestation,

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -73,19 +73,6 @@ export type LightDidCreationDetails = {
   /**
    * The set of service endpoints associated with this DID. Each service endpoint ID must be unique.
    * The service ID must not contain the DID prefix when used to create a new DID.
-   *
-   * @example ```typescript
-   * const authenticationKey = exampleKey;
-   * const services = [
-   *   {
-   *     id: 'test-service',
-   *     types: ['CredentialExposureService'],
-   *     urls: ['http://my_domain.example.org'],
-   *   },
-   * ];
-   * const lightDid = new LightDid({ authenticationKey, services });
-   * RequestForAttestation.fromRequest(parsedRequest);
-   * ```
    */
   serviceEndpoints?: DidServiceEndpoint[]
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1833
This removes all @example entries from the jsdoc comments.

## How to test:
- Open code editor
- Search for "@example"
- find nothing

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
