### PR TITLE
docs: add docstrings to all public functions and methods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,22 @@ module.exports = {
     'jsdoc/no-types': 'warn',
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/require-jsdoc': ['warn', { publicOnly: true }],
+    'jsdoc/require-jsdoc': [
+      'warn',
+      {
+        publicOnly: true,
+        exemptEmptyConstructors: true,
+        contexts: ['MethodDefinition:has([accessibility="public"])'],
+        require: {
+          FunctionDeclaration: true, // require jsdoc on exported functions
+          FunctionExpression: true,
+          ArrowFunctionExpression: false, // do not require jsdoc on arrow functions
+          MethodDefinition: false, // bc we only want to enforce jsdoc on public methods, this must be false
+          ClassDeclaration: false, // do not require jsdoc on declarations of exported classes
+          ClassExpression: false,
+        },
+      },
+    ],
     'jsdoc/check-examples': [
       'warn',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,7 @@ module.exports = {
     'jsdoc/no-types': 'warn',
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/require-jsdoc': 'off',
+    'jsdoc/require-jsdoc': ['warn', { publicOnly: true }],
     'jsdoc/check-examples': [
       'warn',
       {
@@ -113,6 +113,7 @@ module.exports = {
         '@typescript-eslint/no-object-literal-type-assertion': 'off',
         'no-underscore-dangle': 'off',
         'global-require': 'off',
+        'jsdoc/require-jsdoc': 'off',
         'jsdoc/check-tag-names': [
           'warn',
           {
@@ -122,13 +123,14 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
-        '@typescript-eslint/ban-ts-comment': 'off'
+        '@typescript-eslint/ban-ts-comment': 'off',
       },
     },
     {
       files: ['**/__integrationtests__/*.ts'],
       rules: {
         'import/extensions': 'off',
+        'jsdoc/require-jsdoc': 'off',
       },
     },
   ],

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -61,6 +61,12 @@ function checkAddress(): void {
   }
 }
 
+/**
+ * Get the value set for a configuration.
+ *
+ * @param configOpt Key of the configuration.
+ * @returns Value for this key.
+ */
 export function get<K extends keyof configOpts>(configOpt: K): configOpts[K] {
   switch (configOpt) {
     case 'address':
@@ -79,6 +85,11 @@ function setLogLevel(logLevel: LogLevel | undefined): void {
   }
 }
 
+/**
+ * Set values for one or multiple configurations.
+ *
+ * @param opts Object of configurations as key-value pairs.
+ */
 export function set<K extends Partial<configOpts>>(opts: K): void {
   configuration = { ...configuration, ...opts }
   setLogLevel(configuration.logLevel)

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -79,6 +79,12 @@ function decode(
   return null
 }
 
+/**
+ * Query an attestation from the blockchain, returning the SCALE encoded value.
+ *
+ * @param claimHash The hash of the claim attested in the attestation.
+ * @returns An Option wrapping scale encoded attestation data.
+ */
 export async function queryRaw(
   claimHash: IRequestForAttestation['rootHash']
 ): Promise<Option<AttestationDetails>> {
@@ -166,6 +172,11 @@ async function queryDepositAmountEncoded(): Promise<U128> {
   return api.consts.attestation.deposit as U128
 }
 
+/**
+ * Gets the current deposit amount due for the creation of new attestations.
+ *
+ * @returns Deposit amount in Femto Kilt as a BigNumber.
+ */
 export async function queryDepositAmount(): Promise<BN> {
   const encodedDeposit = await queryDepositAmountEncoded()
   return encodedDeposit.toBn()

--- a/packages/core/src/attestation/Attestation.utils.ts
+++ b/packages/core/src/attestation/Attestation.utils.ts
@@ -47,7 +47,6 @@ export function errorCheck(input: IAttestation): void {
  *
  * @returns An ordered array of an [[Attestation]].
  */
-
 export function compress(attestation: IAttestation): CompressedAttestation {
   errorCheck(attestation)
   return [
@@ -67,7 +66,6 @@ export function compress(attestation: IAttestation): CompressedAttestation {
  *
  * @returns An object that has the same properties as an [[Attestation]].
  */
-
 export function decompress(attestation: CompressedAttestation): IAttestation {
   if (!Array.isArray(attestation) || attestation.length !== 5) {
     throw SDKErrors.ERROR_DECOMPRESSION_ARRAY('Attestation')

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -56,6 +56,13 @@ export function formatKiltBalance(
   return formatBalance(amount, options)
 }
 
+/**
+ * Converts balance from KILT denomination to base unit.
+ *
+ * @param balance Balance in KILT denomination.
+ * @param power Allows modifying conversion. Set to 0 for conversion to base unit, set to <0 for various larger denominations. -15 is KILT denomination.
+ * @returns Converted (redenominated) balance.
+ */
 export function convertToTxUnit(balance: BN, power: number): BN {
   return new BN(balance).mul(new BN(10).pow(new BN(15 + power)))
 }

--- a/packages/core/src/claim/Claim.utils.ts
+++ b/packages/core/src/claim/Claim.utils.ts
@@ -207,7 +207,7 @@ export function errorCheck(input: IClaim | PartialClaim): void {
 }
 
 /**
- *  Compresses the [[IClaim]] for storage and/or messaging.
+ *  Compresses an [[IClaim]] for storage and/or messaging.
  *
  * @param claim An [[IClaim]] object that will be sorted and stripped for messaging or storage.
  *
@@ -215,13 +215,20 @@ export function errorCheck(input: IClaim | PartialClaim): void {
  */
 export function compress(claim: IClaim): CompressedClaim
 /**
- *  Compresses the [[PartialClaim]] for storage and/or messaging.
+ *  Compresses a [[PartialClaim]] for storage and/or messaging.
  *
  * @param claim A [[PartialClaim]] object that will be sorted and stripped for messaging or storage.
  *
  * @returns An ordered array of a [[CompressedPartialClaim]].
  */
 export function compress(claim: PartialClaim): CompressedPartialClaim
+/**
+ *  Compresses a claim object for storage and/or messaging.
+ *
+ * @param claim A (partial) claim object that will be sorted and stripped for messaging or storage.
+ *
+ * @returns An ordered array of that represents the underlying data in a more compact form.
+ */
 export function compress(
   claim: IClaim | PartialClaim
 ): CompressedClaim | CompressedPartialClaim {
@@ -234,22 +241,28 @@ export function compress(
 }
 
 /**
- *  Decompresses the [[IClaim]] from storage and/or message.
+ *  Decompresses an [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedClaim]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when a [[CompressedClaim]] is not an Array or it's length is unequal 3.
- * @returns An [[IClaim]] object that has the same properties as the [[CompressedClaim]].
+ * @throws [[ERROR_DECOMPRESSION_ARRAY]] if `claim` is not an Array or it's length is unequal 3.
+ * @returns An [[IClaim]] object that has the same properties compressed representation.
  */
 export function decompress(claim: CompressedClaim): IClaim
 /**
- *  Decompresses the Partial [[IClaim]] from storage and/or message.
+ *  Decompresses a partial [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedPartialClaim]] array that is reverted back into an object.
- * @throws When a [[CompressedPartialClaim]] is not an Array or it's length is unequal 3.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]].
- * @returns A [[PartialClaim]] object that has the same properties as the [[CompressedPartialClaim]].
+ * @throws [[ERROR_DECOMPRESSION_ARRAY]] if `claim` is not an Array or it's length is unequal 3.
+ * @returns A [[PartialClaim]] object that has the same properties compressed representation.
  */
 export function decompress(claim: CompressedPartialClaim): PartialClaim
+/**
+ *  Decompresses compressed representation of a (partial) [[IClaim]] from storage and/or message.
+ *
+ * @param claim A [[CompressedClaim]] or [[CompressedPartialClaim]] array that is reverted back into an object.
+ * @throws [[ERROR_DECOMPRESSION_ARRAY]] if `claim` is not an Array or it's length is unequal 3.
+ * @returns An [[IClaim]] or [[PartialClaim]] object that has the same properties compressed representation.
+ */
 export function decompress(
   claim: CompressedClaim | CompressedPartialClaim
 ): IClaim | PartialClaim {

--- a/packages/core/src/credential/Credential.utils.ts
+++ b/packages/core/src/credential/Credential.utils.ts
@@ -46,7 +46,6 @@ export function errorCheck(input: ICredential): void {
  *
  * @returns An ordered array of a [[Credential]] that comprises of an [[Attestation]] and [[RequestForAttestation]] arrays.
  */
-
 export function compress(credential: ICredential): CompressedCredential {
   errorCheck(credential)
 
@@ -64,7 +63,6 @@ export function compress(credential: ICredential): CompressedCredential {
  *
  * @returns An object that has the same properties as a [[Credential]].
  */
-
 export function decompress(credential: CompressedCredential): ICredential {
   if (!Array.isArray(credential) || credential.length !== 2) {
     throw SDKErrors.ERROR_DECOMPRESSION_ARRAY('Credential')
@@ -83,7 +81,6 @@ export function decompress(credential: CompressedCredential): ICredential {
  *
  * @returns A boolean if the [[Claim]] structure in the [[Credential]] is valid.
  */
-
 export function verifyStructure(
   credential: ICredential,
   ctype: ICType

--- a/packages/core/src/ctype/CType.utils.ts
+++ b/packages/core/src/ctype/CType.utils.ts
@@ -18,6 +18,14 @@ import type { HexString } from '@polkadot/util/types'
 import { getOwner, isStored } from './CType.chain.js'
 import { CTypeModel, CTypeWrapperModel } from './CTypeSchema.js'
 
+/**
+ * Verifies data against CType schema or CType schema against metaschema.
+ *
+ * @param object Data to be verified against schema.
+ * @param schema Schema to verify against.
+ * @param messages Optional empty array. If passed, this receives all verification errors.
+ * @returns Whether or not verification was successful.
+ */
 export function verifySchemaWithErrors(
   object: Record<string, unknown>,
   schema: Record<string, unknown>,
@@ -36,6 +44,13 @@ export function verifySchemaWithErrors(
   return result.valid
 }
 
+/**
+ * Verifies data against CType schema or CType schema against metaschema.
+ *
+ * @param object Data to be verified against schema.
+ * @param schema Schema to verify against.
+ * @returns Whether or not verification was successful.
+ */
 export function verifySchema(
   object: Record<string, any>,
   schema: Record<string, any>
@@ -62,15 +77,33 @@ export function verifyClaimStructure(
   return verifySchema(claimContents, schema)
 }
 
+/**
+ * Checks on the KILT blockchain whether a CType is registered.
+ *
+ * @param ctype CType data.
+ * @returns Whether or not the CType is registered on-chain.
+ */
 export async function verifyStored(ctype: ICType): Promise<boolean> {
   return isStored(ctype.hash)
 }
 
+/**
+ * Checks on the KILT blockchain whether a CType is registered to the owner listed in the CType record.
+ *
+ * @param ctype CType data.
+ * @returns Whether or not the CType is registered on-chain to `ctype.owner`.
+ */
 export async function verifyOwner(ctype: ICType): Promise<boolean> {
   const owner = await getOwner(ctype.hash)
   return owner ? owner === ctype.owner : false
 }
 
+/**
+ * Utility for (re)creating ctype hashes. For this, the $id property needs to be stripped from the CType schema.
+ *
+ * @param ctypeSchema The CType schema (with or without $id).
+ * @returns CtypeSchema without the $id property.
+ */
 export function getSchemaPropertiesForHash(
   ctypeSchema: CTypeSchemaWithoutId | ICType['schema']
 ): Partial<ICType['schema']> {
@@ -86,6 +119,12 @@ export function getSchemaPropertiesForHash(
   return shallowCopy
 }
 
+/**
+ * Calculates the CType hash from a schema.
+ *
+ * @param schema The CType schema (with or without $id).
+ * @returns Hash as hex string.
+ */
 export function getHashForSchema(
   schema: CTypeSchemaWithoutId | ICType['schema']
 ): HexString {
@@ -93,12 +132,24 @@ export function getHashForSchema(
   return Crypto.hashObjectAsStr(preparedSchema)
 }
 
+/**
+ * Calculates the schema $id from a CType hash.
+ *
+ * @param hash CType hash as hex string.
+ * @returns Schema id uri.
+ */
 export function getIdForCTypeHash(
   hash: ICType['hash']
 ): ICType['schema']['$id'] {
   return `kilt:ctype:${hash}`
 }
 
+/**
+ * Calculates the schema $id for a CType schema by hashing it.
+ *
+ * @param schema CType schema for which to create schema id.
+ * @returns Schema id uri.
+ */
 export function getIdForSchema(
   schema: CTypeSchemaWithoutId | ICType['schema']
 ): string {
@@ -223,7 +274,7 @@ export function decompress(cType: CompressedCType): ICType {
  * @param cType - A [[CType]] that has nested [[CType]]s inside.
  * @param nestedCTypes - An array of [[CType]] schemas.
  * @param claimContents - The contents of a [[Claim]] to be validated.
- * @param messages
+ * @param messages Optional empty array. If passed, this receives all verification errors.
  *
  * @returns Whether the contents is valid.
  */

--- a/packages/core/src/ctype/CType.utils.ts
+++ b/packages/core/src/ctype/CType.utils.ts
@@ -141,7 +141,6 @@ export function errorCheck(input: ICType): void {
  *
  * @returns An ordered array of a [[CType]] schema.
  */
-
 export function compressSchema(
   cTypeSchema: ICType['schema']
 ): CompressedCTypeSchema {
@@ -172,7 +171,6 @@ export function compressSchema(
  *
  * @returns An object that has the same properties as a [[CType]] schema.
  */
-
 export function decompressSchema(
   cTypeSchema: CompressedCTypeSchema
 ): ICType['schema'] {
@@ -195,7 +193,6 @@ export function decompressSchema(
  *
  * @returns An ordered array of a [[CType]].
  */
-
 export function compress(cType: ICType): CompressedCType {
   errorCheck(cType)
   return [cType.hash, cType.owner, compressSchema(cType.schema)]
@@ -209,7 +206,6 @@ export function compress(cType: ICType): CompressedCType {
  *
  * @returns An object that has the same properties as a [[CType]].
  */
-
 export function decompress(cType: CompressedCType): ICType {
   if (!Array.isArray(cType) || cType.length !== 3) {
     throw SDKErrors.ERROR_DECOMPRESSION_ARRAY('CType')
@@ -231,7 +227,6 @@ export function decompress(cType: CompressedCType): ICType {
  *
  * @returns Whether the contents is valid.
  */
-
 export function validateNestedSchemas(
   cType: ICType['schema'],
   nestedCTypes: Array<ICType['schema']>,

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -12,6 +12,9 @@
  * The DelegationDecoder methods transform a Codec type into an object of a KILT type.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import type {
   Deposit,
   IDelegationNode,

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -210,6 +210,11 @@ async function queryDepositAmountEncoded(): Promise<U128> {
   return api.consts.delegation.deposit as U128
 }
 
+/**
+ * Gets the current deposit amount due for the creation of new delegation node.
+ *
+ * @returns Deposit amount in Femto Kilt as a BigNumber.
+ */
 export async function queryDepositAmount(): Promise<BN> {
   const encodedDeposit = await queryDepositAmountEncoded()
   return encodedDeposit.toBn()

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -35,6 +35,14 @@ export function permissionsAsBitset(delegation: IDelegationNode): Uint8Array {
   return uint8
 }
 
+/**
+ * Traverses a delegation tree and counts the number of delegation nodes between an attestation and an ancestral delegation node owned by `attester`.
+ *
+ * @param attester Identity to be located in the delegation tree.
+ * @param attestation Attestation whose delegation tree to search.
+ * @returns 0 if `attester` is the owner of `attestation`, the number of delegation nodes traversed otherwise.
+ * @throws [[SDKError]] If the `attester` is neither the owner nor in the delegation tree of `attestation`.
+ */
 export async function countNodeDepth(
   attester: IDidDetails['uri'],
   attestation: IAttestation
@@ -64,6 +72,12 @@ export async function countNodeDepth(
   return delegationTreeTraversalSteps
 }
 
+/**
+ * Checks for errors on delegation node data.
+ *
+ * @param delegationNodeInput Delegation node data.
+ * @throws [[SDKError]] in case of errors.
+ */
 export function errorCheck(delegationNodeInput: IDelegationNode): void {
   const { permissions, hierarchyId: rootId, parentId } = delegationNodeInput
 

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -29,6 +29,11 @@ export function connect(): Promise<Blockchain> {
   return BlockchainApiConnection.getConnectionOrConnect()
 }
 
+/**
+ * Allows setting global configuration such as the blockchain endpoint and log level.
+ *
+ * @param configs Config options object.
+ */
 export function config<K extends Partial<ConfigService.configOpts>>(
   configs: K
 ): void {

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -66,6 +66,8 @@ export function validateQuoteSchema(
  * Builds a [[Quote]] object, from a simple object with the same properties.
  *
  * @param deserializedQuote The object which is used to create the attester signed [[Quote]] object.
+ * @param options Optional settings.
+ * @param options.resolver DidResolver used in the process of verifying the attester signature.
  * @throws [[ERROR_QUOTE_MALFORMED]] when the derived basicQuote can not be validated with the QuoteSchema.
  *
  * @returns A [[Quote]] object signed by an Attester.
@@ -101,7 +103,9 @@ export async function fromAttesterSignedInput(
  *
  * @param quoteInput A [[Quote]] object.
  * @param attesterIdentity The DID used to sign the object.
- *
+ * @param signer Signer callback to interface with the key store managing signing keys.
+ * @param options Optional settings.
+ * @param options.keySelection Callback that receives all eligible public keys and returns the one to be used for signing.
  * @returns A signed [[Quote]] object.
  */
 export async function createAttesterSignature(
@@ -141,6 +145,9 @@ export async function createAttesterSignature(
  *
  * @param quoteInput A [[Quote]] object.
  * @param attesterIdentity The DID used to sign the object.
+ * @param signer Signer callback to interface with the key store managing signing keys.
+ * @param options Optional settings.
+ * @param options.keySelection Callback that receives all eligible public keys and returns the one to be used for signing.
  * @throws [[ERROR_QUOTE_MALFORMED]] when the derived quoteInput can not be validated with the QuoteSchema.
  *
  * @returns A [[Quote]] object ready to be signed via [[createAttesterSignature]].
@@ -166,10 +173,14 @@ export async function fromQuoteDataAndIdentity(
 /**
  * Creates a [[Quote]] signed by the Attester and the Claimer.
  *
- * @param claimerIdentity The DID of the Claimer in order to sign.
  * @param attesterSignedQuote A [[Quote]] object signed by an Attester.
  * @param requestRootHash A root hash of the entire object.
- *
+ * @param attesterIdentity The uri of the Attester DID.
+ * @param claimerIdentity The DID of the Claimer in order to sign.
+ * @param signer Signer callback to interface with the key store managing signing keys.
+ * @param options Optional settings.
+ * @param options.keySelection Callback that receives all eligible public keys and returns the one to be used for signing.
+ * @param options.resolver DidResolver used in the process of verifying the attester signature.
  * @returns A [[Quote]] agreement signed by both the Attester and Claimer.
  */
 export async function createQuoteAgreement(

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -44,7 +44,6 @@ import { QuoteSchema } from './QuoteSchema.js'
  *
  * @returns Whether the quote schema is valid.
  */
-
 export function validateQuoteSchema(
   schema: JsonSchema.Schema,
   validate: unknown,
@@ -71,7 +70,6 @@ export function validateQuoteSchema(
  *
  * @returns A [[Quote]] object signed by an Attester.
  */
-
 export async function fromAttesterSignedInput(
   deserializedQuote: IQuoteAttesterSigned,
   {
@@ -106,7 +104,6 @@ export async function fromAttesterSignedInput(
  *
  * @returns A signed [[Quote]] object.
  */
-
 export async function createAttesterSignature(
   quoteInput: IQuote,
   attesterIdentity: DidDetails,
@@ -148,7 +145,6 @@ export async function createAttesterSignature(
  *
  * @returns A [[Quote]] object ready to be signed via [[createAttesterSignature]].
  */
-
 export async function fromQuoteDataAndIdentity(
   quoteInput: IQuote,
   attesterIdentity: DidDetails,
@@ -176,7 +172,6 @@ export async function fromQuoteDataAndIdentity(
  *
  * @returns A [[Quote]] agreement signed by both the Attester and Claimer.
  */
-
 export async function createQuoteAgreement(
   attesterSignedQuote: IQuoteAttesterSigned,
   requestRootHash: IRequestForAttestation['rootHash'],

--- a/packages/core/src/quote/Quote.utils.ts
+++ b/packages/core/src/quote/Quote.utils.ts
@@ -27,7 +27,6 @@ import { SDKErrors } from '@kiltprotocol/utils'
  *
  * @returns An ordered array of a cost.
  */
-
 export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
   if (!cost.gross || !cost.net || !cost.tax) {
     throw SDKErrors.ERROR_COMPRESS_OBJECT(cost, 'Cost Breakdown')
@@ -43,7 +42,6 @@ export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
  *
  * @returns An object that has the same properties as a cost.
  */
-
 export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
   if (!Array.isArray(cost) || cost.length !== 3) {
     throw SDKErrors.ERROR_DECOMPRESSION_ARRAY('Cost Breakdown')
@@ -59,7 +57,6 @@ export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
  *
  * @returns An ordered array of an [[Quote]].
  */
-
 export function compressQuote(quote: IQuote): CompressedQuote {
   if (
     !quote.attesterDid ||
@@ -88,7 +85,6 @@ export function compressQuote(quote: IQuote): CompressedQuote {
  * @throws [[ERROR_DECOMPRESSION_ARRAY]] when quote is not an Array and it's length does not equal the defined length of 6.
  * @returns An object that has the same properties as an [[Quote]].
  */
-
 export function decompressQuote(quote: CompressedQuote): IQuote {
   if (!Array.isArray(quote) || quote.length !== 6) {
     throw SDKErrors.ERROR_DECOMPRESSION_ARRAY()
@@ -121,7 +117,6 @@ function decompressSignature(
  *
  * @returns An ordered array of an attester signed [[Quote]].
  */
-
 export function compressAttesterSignedQuote(
   attesterSignedQuote: IQuoteAttesterSigned
 ): CompressedQuoteAttesterSigned {
@@ -168,7 +163,6 @@ export function compressAttesterSignedQuote(
  *
  * @returns An object that has the same properties as an attester signed [[Quote]].
  */
-
 export function decompressAttesterSignedQuote(
   attesterSignedQuote: CompressedQuoteAttesterSigned
 ): IQuoteAttesterSigned {
@@ -194,7 +188,6 @@ export function decompressAttesterSignedQuote(
  *
  * @returns An ordered array of a [[Quote]] Agreement.
  */
-
 export function compressQuoteAgreement(
   quoteAgreement: IQuoteAgreement
 ): CompressedQuoteAgreed {
@@ -230,7 +223,6 @@ export function compressQuoteAgreement(
  *
  * @returns An object that has the same properties as a [[Quote]] Agreement.
  */
-
 export function decompressQuoteAgreement(
   quoteAgreement: CompressedQuoteAgreed
 ): IQuoteAgreement {

--- a/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.utils.ts
@@ -73,7 +73,6 @@ export function errorCheck(input: IRequestForAttestation): void {
  *
  * @returns An ordered array of [[Credential]]s.
  */
-
 export function compressLegitimation(
   leg: ICredential[]
 ): CompressedCredential[] {
@@ -99,7 +98,6 @@ function decompressLegitimation(leg: CompressedCredential[]): ICredential[] {
  *
  * @returns An ordered array of a [[RequestForAttestation]].
  */
-
 export function compress(
   reqForAtt: IRequestForAttestation
 ): CompressedRequestForAttestation {
@@ -123,7 +121,6 @@ export function compress(
  *
  * @returns An object that has the same properties as a [[RequestForAttestation]].
  */
-
 export function decompress(
   reqForAtt: CompressedRequestForAttestation
 ): IRequestForAttestation {
@@ -144,12 +141,11 @@ export function decompress(
 /**
  *  Checks the [[RequestForAttestation]] with a given [[CType]] to check if the claim meets the [[schema]] structure.
  *
- * @param RequestForAttestation A [[RequestForAttestation]] object for the attester.
+ * @param requestForAttestation A [[RequestForAttestation]] object for the attester.
  * @param ctype A [[CType]] to verify the [[Claim]] structure.
  *
  * @returns A boolean if the [[Claim]] structure in the [[RequestForAttestation]] is valid.
  */
-
 export function verifyStructure(
   requestForAttestation: IRequestForAttestation,
   ctype: ICType

--- a/packages/did/src/DemoKeystore/DemoKeystore.utils.ts
+++ b/packages/did/src/DemoKeystore/DemoKeystore.utils.ts
@@ -175,8 +175,6 @@ export async function createLocalDemoFullDidFromLightDid(
 
   const keys: PublicKeys = {
     [authKey.id]: authKey,
-    [authKey.id]: authKey,
-    [authKey.id]: authKey,
   }
   if (encKey) {
     keys[encKey.id] = encKey

--- a/packages/did/src/DemoKeystore/DemoKeystore.utils.ts
+++ b/packages/did/src/DemoKeystore/DemoKeystore.utils.ts
@@ -32,7 +32,13 @@ import {
   SigningAlgorithms,
 } from './DemoKeystore.js'
 
-// Given a seed, creates a light DID with an authentication and an encryption key.
+/**
+ * Given a seed, creates a light DID with an authentication and an encryption key.
+ *
+ * @param keystore Keystore instance.
+ * @param seed Seed from which to derive all keys.
+ * @returns LightDidDetails whose keys have been added to the keystore instance.
+ */
 export async function createMinimalLightDidFromSeed(
   keystore: DemoKeystore,
   seed?: string
@@ -153,6 +159,13 @@ export async function createLocalDemoFullDidFromSeed(
   })
 }
 
+/**
+ * Creates a FullDid from a LightDid where the verification keypair is enabled for all verification purposes (authentication, assertionMethod, capabilityDelegation).
+ * This is not recommended, use for demo purposes only!
+ *
+ * @param lightDid The LightDid whose keys will be used on the FullDid.
+ * @returns A FullDid instance that is not yet written to the blockchain.
+ */
 export async function createLocalDemoFullDidFromLightDid(
   lightDid: LightDidDetails
 ): Promise<FullDidDetails> {

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -20,7 +20,6 @@ import {
   NewDidKey,
   VerificationKeyRelationship,
   VerificationKeyType,
-  DidUri,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 
@@ -57,6 +56,15 @@ const LIGHT_KILT_DID_REGEX =
 export const defaultKeySelectionCallback = <T>(keys: T[]): Promise<T | null> =>
   Promise.resolve(keys[0] || null)
 
+/**
+ * Compiles a KILT DID uri for a full or light DID from a unique identifier and associated data.
+ *
+ * @param identifier A ss58 encoded address valid on the KILT network.
+ * @param didType 'full' to produce a [[FullDid]]'s uri, 'light' for a [[LightDid]].
+ * @param version KILT DID specification version number.
+ * @param encodedDetails When compiling a LightDid uri, encoded DidDetails can be appeneded to the end of the uri.
+ * @returns A DID uri as a string.
+ */
 export function getKiltDidFromIdentifier(
   identifier: DidIdentifier,
   didType: 'full' | 'light',
@@ -85,7 +93,13 @@ export type IDidParsingResult = {
   encodedDetails?: string
 }
 
-export function parseDidUri(didUri: DidUri): IDidParsingResult {
+/**
+ * Parses a KILT DID uri and returns the information contained within in a structured form.
+ *
+ * @param didUri A KILT DID uri as a string.
+ * @returns Object containing information extracted from the DID uri.
+ */
+export function parseDidUri(didUri: IDidDetails['uri']): IDidParsingResult {
   let matches = FULL_KILT_DID_REGEX.exec(didUri)?.groups
   if (matches && matches.identifier) {
     const version = matches.version
@@ -124,13 +138,25 @@ export function parseDidUri(didUri: DidUri): IDidParsingResult {
   throw SDKErrors.ERROR_INVALID_DID_FORMAT(didUri)
 }
 
+/**
+ * Parses a KILT DID uri and returns its unique identifier.
+ *
+ * @param didUri A KILT DID uri as a string.
+ * @returns The identifier contained within the DID uri.
+ */
 export function getIdentifierFromKiltDid(
-  did: IDidDetails['uri']
+  didUri: IDidDetails['uri']
 ): DidIdentifier {
-  return parseDidUri(did).identifier
+  return parseDidUri(didUri).identifier
 }
 
-// Returns true if both didA and didB refer to the same DID subject, i.e., whether they have the same identifier as specified in the method spec.
+/**
+ * Returns true if both didA and didB refer to the same DID subject, i.e., whether they have the same identifier as specified in the method spec.
+ *
+ * @param didA A KILT DID uri as a string.
+ * @param didB A second KILT DID uri as a string.
+ * @returns Whether didA and didB refer to the same DID subject.
+ */
 export function isSameSubject(
   didA: IDidDetails['uri'],
   didB: IDidDetails['uri']
@@ -154,16 +180,31 @@ const signatureAlgForKeyType: Record<VerificationKeyType, SigningAlgorithms> = {
   [VerificationKeyType.Sr25519]: SigningAlgorithms.Sr25519,
   [VerificationKeyType.Ecdsa]: SigningAlgorithms.EcdsaSecp256k1,
 }
+const keyTypeForSignatureAlg = Object.entries(signatureAlgForKeyType).reduce(
+  (obj, [key, value]) => {
+    return { ...obj, [value]: key }
+  },
+  {}
+) as Record<SigningAlgorithms, VerificationKeyType>
+
+/**
+ * Given the identifier of a key type, returns the identifier of the signature algorithm for which it is used.
+ *
+ * @param keyType Key type identifier.
+ * @returns Signing algorithm identifier.
+ */
 export function getSigningAlgorithmForVerificationKeyType(
   keyType: VerificationKeyType
 ): SigningAlgorithms {
   return signatureAlgForKeyType[keyType]
 }
-const keyTypeForSignatureAlg: Record<SigningAlgorithms, VerificationKeyType> = {
-  [SigningAlgorithms.Ed25519]: VerificationKeyType.Ed25519,
-  [SigningAlgorithms.Sr25519]: VerificationKeyType.Sr25519,
-  [SigningAlgorithms.EcdsaSecp256k1]: VerificationKeyType.Ecdsa,
-}
+
+/**
+ * Given the identifier of a signature algorithm, returns the identifier of the key type required for it.
+ *
+ * @param signatureAlg Signature algorithm identifier.
+ * @returns Key type identifier.
+ */
 export function getVerificationKeyTypeForSigningAlgorithm(
   signatureAlg: SigningAlgorithms
 ): VerificationKeyType {
@@ -174,6 +215,12 @@ const encryptionAlgForKeyType: Record<EncryptionKeyType, EncryptionAlgorithms> =
   {
     [EncryptionKeyType.X25519]: EncryptionAlgorithms.NaclBox,
   }
+/**
+ * Given the identifier of a key type, returns the identifier of the encryption algorithm for which it is used.
+ *
+ * @param keyType Key type identifier.
+ * @returns Encryption algorithm indentifier.
+ */
 export function getEncryptionAlgorithmForEncryptionKeyType(
   keyType: EncryptionKeyType
 ): EncryptionAlgorithms {
@@ -183,20 +230,46 @@ const keyTypeForEncryptionAlg: Record<EncryptionAlgorithms, EncryptionKeyType> =
   {
     [EncryptionAlgorithms.NaclBox]: EncryptionKeyType.X25519,
   }
+/**
+ * Given the identifier of an encryption algorithm, returns the identifier of the key type required for it.
+ *
+ * @param encryptionAlg Encryption algorithm identifier.
+ * @returns Key type identifier.
+ */
 export function getEncryptionKeyTypeForEncryptionAlgorithm(
   encryptionAlg: EncryptionAlgorithms
 ): EncryptionKeyType {
   return keyTypeForEncryptionAlg[encryptionAlg]
 }
 
+/**
+ * Checks whether a DidKey is a verification key.
+ *
+ * @param key Representation of a DID key.
+ * @returns True if the key is a verification key, false otherwise.
+ */
 export function isVerificationKey(key: NewDidKey | DidKey): boolean {
   return Object.values(VerificationKeyType).some((kt) => kt === key.type)
 }
 
+/**
+ * Checks whether a DidKey is an encryption key.
+ *
+ * @param key Representation of a DID key.
+ * @returns True if the key is a encryption key, false otherwise.
+ */
 export function isEncryptionKey(key: NewDidKey | DidKey): boolean {
   return Object.values(EncryptionKeyType).some((kt) => kt === key.type)
 }
 
+/**
+ * Type guard assuring that a string (or other input) is a valid KILT DID uri.
+ *
+ * @param input Arbitrary input.
+ * @param allowFragment Whether the uri is allowed to have a fragment (following '#').
+ * @returns True if validation has passed.
+ * @throws [[SDKError]] if validation fails.
+ */
 export function validateKiltDidUri(
   input: unknown,
   allowFragment = false
@@ -204,7 +277,9 @@ export function validateKiltDidUri(
   if (typeof input !== 'string') {
     throw TypeError(`DID string expected, got ${typeof input}`)
   }
-  const { identifier, type, fragment } = parseDidUri(input as DidUri)
+  const { identifier, type, fragment } = parseDidUri(
+    input as IDidDetails['uri']
+  )
   if (!allowFragment && fragment) {
     throw SDKErrors.ERROR_INVALID_DID_FORMAT(input)
   }
@@ -227,6 +302,14 @@ export function validateKiltDidUri(
   return true
 }
 
+/**
+ * Type guard assuring that a the input is a valid DidSignature object, consisting of a signature as hex and the uri of the signing key.
+ * Does not cryptographically verify the signature itself!
+ *
+ * @param input Arbitrary input.
+ * @returns True if validation of form has passed.
+ * @throws [[SDKError]] if validation fails.
+ */
 export function validateDidSignature(input: unknown): input is DidSignature {
   const signature = input as DidSignature
   try {
@@ -309,8 +392,17 @@ export type DidSignatureVerificationInput = {
   resolver?: IDidResolver
 }
 
-// Verify a DID signature given the key URI of the signature.
-// A signature verification returns false if a migrated and then deleted DID is used.
+/**
+ * Verify a DID signature given the key URI of the signature.
+ * A signature verification returns false if a migrated and then deleted DID is used.
+ *
+ * @param input Object wrapping all input.
+ * @param input.message The message that was signed.
+ * @param input.signature An object containing signature and signer key.
+ * @param input.expectedVerificationMethod Which relationship to the signer DID the key must have.
+ * @param input.resolver Allows specifying a custom DID resolver. Defaults to the built-in [[DidResolver]].
+ * @returns Object indicating verification result and optionally reason for failure.
+ */
 export async function verifyDidSignature({
   message,
   signature,

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -60,7 +60,7 @@ export const defaultKeySelectionCallback = <T>(keys: T[]): Promise<T | null> =>
  * Compiles a KILT DID uri for a full or light DID from a unique identifier and associated data.
  *
  * @param identifier A ss58 encoded address valid on the KILT network.
- * @param didType 'full' to produce a [[FullDid]]'s uri, 'light' for a [[LightDid]].
+ * @param didType 'full' to produce a FullDid's uri, 'light' for a LightDid.
  * @param version KILT DID specification version number.
  * @param encodedDetails When compiling a LightDid uri, encoded DidDetails can be appeneded to the end of the uri.
  * @returns A DID uri as a string.

--- a/packages/did/src/DidBatcher/DidBatchBuilder.utils.ts
+++ b/packages/did/src/DidBatcher/DidBatchBuilder.utils.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import type { Extrinsic } from '@polkadot/types/interfaces'
 
 import type { VerificationKeyRelationship } from '@kiltprotocol/types'

--- a/packages/did/src/DidBatcher/FullDidBuilder.utils.ts
+++ b/packages/did/src/DidBatcher/FullDidBuilder.utils.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import { ApiPromise } from '@polkadot/api'
 
 import type { DidKey, NewDidKey } from '@kiltprotocol/types'

--- a/packages/did/src/DidBatcher/TestUtils.ts
+++ b/packages/did/src/DidBatcher/TestUtils.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import { blake2AsHex } from '@polkadot/util-crypto'
 import type { DidKey } from '@kiltprotocol/types'
 

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -116,6 +116,12 @@ export abstract class DidDetails implements IDidDetails {
     return this.getVerificationKeys(KeyRelationship.capabilityDelegation)[0]
   }
 
+  /**
+   * Returns a key with a given id, if associated with this Did.
+   *
+   * @param id Key id (not the full key uri).
+   * @returns The respective public key data or undefined.
+   */
   public getKey(id: DidKey['id']): DidKey | undefined {
     const keyDetails = this.publicKeys.get(id)
     if (!keyDetails) {
@@ -127,6 +133,12 @@ export abstract class DidDetails implements IDidDetails {
     }
   }
 
+  /**
+   * Gets all verification public keys for this Did with a given verification relationship.
+   *
+   * @param relationship The verification relationship.
+   * @returns Array of keys matching this verification relationship.
+   */
   public getVerificationKeys(
     relationship: VerificationKeyRelationship
   ): DidVerificationKey[] {
@@ -134,6 +146,12 @@ export abstract class DidDetails implements IDidDetails {
     return [...keyIds].map((keyId) => this.getKey(keyId) as DidVerificationKey)
   }
 
+  /**
+   * Gets all key agreement public keys for this Did with a given relationship.
+   *
+   * @param relationship The public key's relationship to the DID.
+   * @returns Array of keys matching this relationship.
+   */
   public getEncryptionKeys(
     relationship: EncryptionKeyRelationship
   ): DidEncryptionKey[] {
@@ -141,11 +159,22 @@ export abstract class DidDetails implements IDidDetails {
     return [...keyIds].map((keyId) => this.getKey(keyId) as DidEncryptionKey)
   }
 
+  /**
+   * Gets all public keys associated with this Did.
+   *
+   * @returns Array of public keys.
+   */
   public getKeys(): DidKey[] {
     const keyIds = this.publicKeys.keys()
     return [...keyIds].map((keyId) => this.getKey(keyId) as DidKey)
   }
 
+  /**
+   * Returns a service endpoint with a given id, if associated with this Did.
+   *
+   * @param id Endpoint id (not the full endpoint uri).
+   * @returns The respective endpoint data or undefined.
+   */
   public getEndpoint(
     id: DidServiceEndpoint['id']
   ): DidServiceEndpoint | undefined {
@@ -159,6 +188,12 @@ export abstract class DidDetails implements IDidDetails {
     }
   }
 
+  /**
+   * Gets all service endpoints associated with this Did, optionally filtered by endpoint type.
+   *
+   * @param type Optionally pass type by which to filter endpoints.
+   * @returns Array of service endpoints.
+   */
   public getEndpoints(type?: string): DidServiceEndpoint[] {
     const serviceEndpointsEntries = type
       ? [...this.serviceEndpoints.entries()].filter(([, details]) => {

--- a/packages/did/src/DidDetails/DidDetails.utils.ts
+++ b/packages/did/src/DidDetails/DidDetails.utils.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import { SDKErrors } from '@kiltprotocol/utils'
 import { KeyRelationship } from '@kiltprotocol/types'
 

--- a/packages/did/src/DidDetails/FullDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.utils.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import type { Extrinsic } from '@polkadot/types/interfaces'
 import { BN } from '@polkadot/util'
 

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -67,6 +67,11 @@ export class LightDidDetails extends DidDetails {
     this.identifier = identifier
   }
 
+  /**
+   * Authentication key type of this LightDid.
+   *
+   * @returns Authentication key type.
+   */
   public get authKeyEncoding(): string {
     return getEncodingForVerificationKeyType(
       this.authenticationKey.type

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import { encode as cborEncode, decode as cborDecode } from 'cbor'
 
 import { base58Decode, base58Encode } from '@polkadot/util-crypto'

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -165,7 +165,7 @@ export async function queryDepositAmount(): Promise<BN> {
  * will link Account to FullDid and remove any pre-existing links of Account.
  * Account must hold balance to cover for submission fees and storage deposit.
  *
- * @returns An [[Extrinsic]] that must be did-authorized.
+ * @returns An extrinsic that must be did-authorized.
  */
 export async function getAssociateSenderExtrinsic(): Promise<Extrinsic> {
   const { api } = await BlockchainApiConnection.getConnectionOrConnect()
@@ -183,7 +183,7 @@ export async function getAssociateSenderExtrinsic(): Promise<Extrinsic> {
  * @param signatureValidUntilBlock The link request will be rejected if submitted later than this block number.
  * @param signature Account's signature over `(DidIdentifier, BlockNumber).toU8a()`.
  * @param sigType The type of key/substrate account which produced the `signature`.
- * @returns An [[Extrinsic]] that must be did-authorized.
+ * @returns An extrinsic that must be did-authorized.
  */
 export async function getAccountSignedAssociationExtrinsic(
   account: Address,
@@ -202,7 +202,7 @@ export async function getAccountSignedAssociationExtrinsic(
  * Must be signed and submitted by the deposit owner account.
  *
  * @param linkedAccount Account whose link should be released (not the deposit owner).
- * @returns The [[SubmittableExtrinsic]] for the `reclaimDeposit` call.
+ * @returns The a submittable extrinsic for the `reclaimDeposit` call.
  */
 export async function getReclaimDepositTx(
   linkedAccount: Address
@@ -256,7 +256,7 @@ function getMultiSignatureTypeFromKeypairType(
 /**
  * Return the default signer callback, which uses the address argument to crete a signing closure for the given payload.
  *
- * @param keyring The [[Keyring]] to retrieve the signing key.
+ * @param keyring The keyring to retrieve the signing key.
  * @returns The signature generating callback that uses the keyring to sign the input payload using the input address.
  */
 export function defaultSignerCallback(keyring: Keyring): LinkingSignerCallback {
@@ -268,14 +268,14 @@ export function defaultSignerCallback(keyring: Keyring): LinkingSignerCallback {
 
 /**
  * Builds an extrinsic to link `account` to a `did` where the fees and deposit are covered by some third account.
- * This extrinsic must be authorized using the [[FullDid]] whose `didIdentifier` was used here.
+ * This extrinsic must be authorized using the FullDid whose `didIdentifier` was used here.
  * Note that in addition to the signing account and did used here, the submitting account will also be able to dissolve the link via reclaiming its deposit!
  *
  * @param accountAddress Address of the account to be linked.
- * @param didIdentifier Method-specific identifier [[FullDid]] to be linked.
+ * @param didIdentifier Method-specific identifier FullDid to be linked.
  * @param signingCallback The signature generation callback that generates the account signature over the encoded (DidIdentifier, BlockNumber) tuple.
  * @param nBlocksValid How many blocks into the future should the account-signed proof be considered valid?
- * @returns An Extrinsic that must be did-authorized by the [[FullDid]] whose identifier was used.
+ * @returns An Extrinsic that must be did-authorized by the FullDid whose identifier was used.
  */
 export async function getAuthorizeLinkWithAccountExtrinsic(
   accountAddress: Address,

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -331,8 +331,7 @@ export class Message implements IMessage {
   public static verifyRequiredCTypeProperties(
     requiredProperties: string[],
     cType: ICType
-  ): boolean {
+  ): void {
     verifyRequiredCTypeProperties(requiredProperties, cType)
-    return true
   }
 }

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -312,10 +312,22 @@ export class Message implements IMessage {
     }
   }
 
+  /**
+   * Compresses a [[MessageBody]] depending on the message body type.
+   *
+   * @returns Returns the compressed message optimised for sending.
+   */
   public compress(): CompressedMessageBody {
     return compressMessage(this.body)
   }
 
+  /**
+   * Verifies required properties for a given [[CType]] before sending or receiving a message.
+   *
+   * @param requiredProperties The list of required properties that need to be verified against a [[CType]].
+   * @param cType A [[CType]] used to verify the properties.
+   * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] when the properties do not match the provide [[CType]].
+   */
   public static verifyRequiredCTypeProperties(
     requiredProperties: string[],
     cType: ICType

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -320,6 +320,7 @@ export class Message implements IMessage {
     requiredProperties: string[],
     cType: ICType
   ): boolean {
-    return verifyRequiredCTypeProperties(requiredProperties, cType)
+    verifyRequiredCTypeProperties(requiredProperties, cType)
+    return true
   }
 }

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -882,12 +882,12 @@ describe('Messaging Utilities', () => {
       )
     ).not.toThrowError(SDKErrors.ERROR_CTYPE_PROPERTIES_NOT_MATCHING())
 
-    expect(
+    expect(() =>
       MessageUtils.verifyRequiredCTypeProperties(
         ['id', 'name'],
         testCTypeWithMultipleProperties
       )
-    ).toEqual(true)
+    ).not.toThrowError()
   })
 
   beforeAll(async () => {

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -39,7 +39,7 @@ import { Message } from './Message.js'
  */
 export function errorCheckDelegationData(
   delegationData: IDelegationData
-): boolean | void {
+): void {
   const { permissions, id, parentId, isPCR, account } = delegationData
 
   if (!id) {
@@ -79,7 +79,7 @@ export function errorCheckDelegationData(
  * @param body The message body.
  * @throws [[SDKError]] if there are issues with form or content of the message body.
  */
-export function errorCheckMessageBody(body: MessageBody): boolean | void {
+export function errorCheckMessageBody(body: MessageBody): void {
   switch (body.type) {
     case Message.BodyType.REQUEST_TERMS: {
       ClaimUtils.errorCheck(body.content)
@@ -202,8 +202,6 @@ export function errorCheckMessageBody(body: MessageBody): boolean | void {
     default:
       throw SDKErrors.ERROR_MESSAGE_BODY_MALFORMED()
   }
-
-  return true
 }
 
 /**
@@ -212,7 +210,7 @@ export function errorCheckMessageBody(body: MessageBody): boolean | void {
  * @param message The message object.
  * @throws [[SDKError]] if there are issues with form or content of the message object.
  */
-export function errorCheckMessage(message: IMessage): boolean | void {
+export function errorCheckMessage(message: IMessage): void {
   const {
     body,
     messageId,
@@ -237,7 +235,6 @@ export function errorCheckMessage(message: IMessage): boolean | void {
     throw new TypeError('in reply to is expected to be a string')
   }
   errorCheckMessageBody(body)
-  return true
 }
 
 /**
@@ -246,13 +243,11 @@ export function errorCheckMessage(message: IMessage): boolean | void {
  * @param requiredProperties The list of required properties that need to be verified against a [[CType]].
  * @param cType A [[CType]] used to verify the properties.
  * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] when the properties do not match the provide [[CType]].
- *
- * @returns Returns the properties back.
  */
 export function verifyRequiredCTypeProperties(
   requiredProperties: string[],
   cType: ICType
-): boolean {
+): void {
   CTypeUtils.errorCheck(cType as ICType)
 
   const validProperties = requiredProperties.find(
@@ -261,8 +256,6 @@ export function verifyRequiredCTypeProperties(
   if (validProperties) {
     throw SDKErrors.ERROR_CTYPE_PROPERTIES_NOT_MATCHING()
   }
-
-  return true
 }
 
 /**

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -31,7 +31,12 @@ import { Utils as DidUtils } from '@kiltprotocol/did'
 
 import { Message } from './Message.js'
 
-// Had to add the check as differs from the delegation types
+/**
+ * Checks if delegation data is well formed.
+ *
+ * @param delegationData Delegation data to check.
+ * @throws [[SDKError]] if delegationData is not a valid instance of [[IDelegationData]].
+ */
 export function errorCheckDelegationData(
   delegationData: IDelegationData
 ): boolean | void {
@@ -68,6 +73,12 @@ export function errorCheckDelegationData(
   }
 }
 
+/**
+ * Checks if the message body is well formed.
+ *
+ * @param body The message body.
+ * @throws [[SDKError]] if there are issues with form or content of the message body.
+ */
 export function errorCheckMessageBody(body: MessageBody): boolean | void {
   switch (body.type) {
     case Message.BodyType.REQUEST_TERMS: {
@@ -195,6 +206,12 @@ export function errorCheckMessageBody(body: MessageBody): boolean | void {
   return true
 }
 
+/**
+ * Checks if the message object is well formed.
+ *
+ * @param message The message object.
+ * @throws [[SDKError]] if there are issues with form or content of the message object.
+ */
 export function errorCheckMessage(message: IMessage): boolean | void {
   const {
     body,

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -232,7 +232,6 @@ export function errorCheckMessage(message: IMessage): boolean | void {
  *
  * @returns Returns the properties back.
  */
-
 export function verifyRequiredCTypeProperties(
   requiredProperties: string[],
   cType: ICType
@@ -256,7 +255,6 @@ export function verifyRequiredCTypeProperties(
  *
  * @returns Returns the compressed message optimised for sending.
  */
-
 export function compressMessage(body: MessageBody): CompressedMessageBody {
   let compressedContents: CompressedMessageBody[1]
   switch (body.type) {
@@ -385,7 +383,6 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
  *
  * @returns Returns the compressed message back to its original form and more human readable.
  */
-
 export function decompressMessage(body: CompressedMessageBody): MessageBody {
   // body[0] is the [[MessageBodyType]] being sent.
   // body[1] is the content order of the [[compressMessage]] for each [[MessageBodyType]].

--- a/packages/testing/src/mocks/mockedApi.ts
+++ b/packages/testing/src/mocks/mockedApi.ts
@@ -8,6 +8,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
 
 /**
  * @ignore

--- a/packages/testing/src/mocks/typeRegistry.ts
+++ b/packages/testing/src/mocks/typeRegistry.ts
@@ -5,6 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+// This module is not part of the public-facing api.
+/* eslint-disable jsdoc/require-jsdoc */
+
 import type { HexString } from '@polkadot/util/types'
 
 import { ApiPromise, WsProvider } from '@polkadot/api'

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -104,6 +104,12 @@ export class SDKError extends Error {
   }
 }
 
+/**
+ * Type guard checking whether input can be read as an [[SDKError]].
+ *
+ * @param input Arbitrary input.
+ * @returns True if the input has the signature of an SDKError, false otherwise.
+ */
 export function isSDKError(input: unknown): input is SDKError {
   return (
     ((i: unknown): i is Error & Partial<SDKError> => i instanceof Error)(

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -98,6 +98,12 @@ export enum ErrorCode {
 export class SDKError extends Error {
   public errorCode: ErrorCode
 
+  /**
+   * Constructs an SDKError instance.
+   *
+   * @param errorCode Numerical error code identifying the error.
+   * @param message Error message for additional info.
+   */
   public constructor(errorCode: ErrorCode, message: string) {
     super(message)
     this.errorCode = errorCode

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -30,6 +30,12 @@ import type {
   VerifiableCredential,
 } from './types.js'
 
+/**
+ * Extracts the credential root hash from a KILT VC's id.
+ *
+ * @param credentialId The IRI that serves as the credential id on KILT VCs.
+ * @returns The credential root hash as a hex string.
+ */
 export function fromCredentialIRI(credentialId: string): HexString {
   const hexString = credentialId.startsWith(KILT_CREDENTIAL_IRI_PREFIX)
     ? credentialId.substring(KILT_CREDENTIAL_IRI_PREFIX.length)
@@ -41,6 +47,12 @@ export function fromCredentialIRI(credentialId: string): HexString {
   return hexString
 }
 
+/**
+ * Transforms the credential root hash to an IRI that functions as the VC's id.
+ *
+ * @param rootHash Credential root hash as a hex string.
+ * @returns An IRI composed by prefixing the root hash with the [[KILT_CREDENTIAL_IRI_PREFIX]].
+ */
 export function toCredentialIRI(rootHash: string): string {
   if (rootHash.startsWith(KILT_CREDENTIAL_IRI_PREFIX)) {
     return rootHash
@@ -50,6 +62,13 @@ export function toCredentialIRI(rootHash: string): string {
   return KILT_CREDENTIAL_IRI_PREFIX + rootHash
 }
 
+/**
+ * Transforms a regular KILT credential to its VC representation.
+ *
+ * @param input The credential to transform.
+ * @param ctype (optional) The full specification of the credential's CType. If specified, the CType will be included with the VC on its `credentialSchema` property.
+ * @returns The VC representation of the KILT credential and optionally its CType.
+ */
 export function fromCredential(
   input: ICredential,
   ctype?: ICType

--- a/packages/vc-export/src/vc-js/documentLoader.ts
+++ b/packages/vc-export/src/vc-js/documentLoader.ts
@@ -9,6 +9,13 @@ import type { RemoteDocument, Url } from 'jsonld/jsonld-spec'
 import vcjs from 'vc-js'
 import { validationContexts } from './context/index.js'
 
+/**
+ * Document loader that provides access to the JSON-LD contexts required for verifying Kilt VCs.
+ * Essentially wraps the vc-js defaultDocumentLoader, but additionally loads KILTs [[validationContexts]].
+ *
+ * @param url Document/context URL to resolve.
+ * @returns An object containing the resolution result.
+ */
 export async function documentLoader(url: Url): Promise<RemoteDocument> {
   const context = validationContexts[url]
   if (context)

--- a/packages/vc-export/src/vc-js/suites/KiltAbstractSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAbstractSuite.ts
@@ -71,6 +71,9 @@ export abstract class KiltAbstractSuite extends suites.LinkedDataProof {
     ) as Promise<VerifiableCredential>
   }
 
+  /**
+   * @inheritdoc
+   */
   public async matchProof(options: {
     proof: JsonLdObj
     document?: JsonLdObj
@@ -84,6 +87,9 @@ export abstract class KiltAbstractSuite extends suites.LinkedDataProof {
     return type instanceof Array ? type.includes(this.type) : type === this.type
   }
 
+  /**
+   * @inheritdoc
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async createProof(options: {
     document: JsonLdObj

--- a/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.ts
@@ -54,6 +54,9 @@ export class KiltAttestedSuite extends KiltAbstractSuite {
     BlockchainApiConnection.setConnection(Promise.resolve(this.provider))
   }
 
+  /**
+   * @inheritdoc
+   */
   public async verifyProof(options: {
     proof: Proof
     document: JsonLdObj

--- a/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.ts
@@ -27,6 +27,9 @@ export class KiltDisclosureSuite extends KiltAbstractSuite {
     })
   }
 
+  /**
+   * @inheritdoc
+   */
   public async verifyProof(options: {
     proof: JsonLdObj
     document?: JsonLdObj

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.ts
@@ -22,6 +22,9 @@ export class KiltSignatureSuite extends KiltAbstractSuite {
     super({ type: KILT_SELF_SIGNED_PROOF_TYPE, verificationMethod: '<none>' })
   }
 
+  /**
+   * @inheritdoc
+   */
   public async verifyProof(options: {
     proof: JsonLdObj
     document: JsonLdObj

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -298,6 +298,12 @@ export async function verifyCredentialDigestProof(
   }
 }
 
+/**
+ * Validates the claims in the VC's `credentialSubject` against a CType definition on the `credentialSchema` property.
+ *
+ * @param credential A verifiable credential where `credentialSchema.schema` is an [[ICTypeSchema]].
+ * @returns The [[VerificationResult]].
+ */
 export function validateSchema(
   credential: VerifiableCredential
 ): VerificationResult {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#450
Enables linter rule requiring jsdoc on all public functions and methods.
Adds docstrings wherever linter complained. 

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
