### PR TITLE
chore(tsconfig): only include packages of interest

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.build.json",
+  "include": ["packages/**/*", "jest-setup/*", "docs/*"],
   "compilerOptions": {
     "baseUrl": "./packages",
     "sourceMap": true,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1985
This PR changes the development tsconfig to only include relevant folders to prevent over-reporting of `yarn check`

## How to test:
- Run `yarn check`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
