### PR TITLE
fix: trigger docs tests only on releases

### DIFF
--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -49,11 +49,3 @@ jobs:
           git add .
           git commit -m "[CI Skip] ci: publish prerelease" -n
           git push
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          repository: KILTProtocol/docs
-          event-type: sdk-update
-          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'
-

--- a/.github/workflows/npmpublish-rc.yml
+++ b/.github/workflows/npmpublish-rc.yml
@@ -32,3 +32,13 @@ jobs:
         run: yarn run publish --tag rc
         env:
           YARN_NPM_AUTH_TOKEN: ${{secrets.npm_token}}
+      - name: Get current package version
+        id: package_version
+        run: echo "::set-output name=package_version::$(node -pe "require('./package.json').version")"          
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: KILTProtocol/docs
+          event-type: sdk-update
+          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'             

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -32,3 +32,13 @@ jobs:
         run: yarn run publish --tag latest
         env:
           YARN_NPM_AUTH_TOKEN: ${{secrets.npm_token}}
+      - name: Get current package version
+        id: package_version
+        run: echo "::set-output name=package_version::$(node -pe "require('./package.json').version")"          
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: KILTProtocol/docs
+          event-type: sdk-update
+          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'          


### PR DESCRIPTION
Fixes the changes introduced in https://github.com/KILTprotocol/sdk-js/pull/539 by triggering docs test and update only on NPM releases. I think adding the action to dev publishing was only meant to be used for testing. We forgot to change it back, so this PR does that.