### PR TITLE
feat: attestation module flexibly handles old delegation pallet

### DIFF
--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -44,7 +44,7 @@ const containerPromise = new GenericContainer(
 )
   .withCmd(['--dev', '--ws-port', '9944', '--ws-external'])
   .withExposedPorts(9944)
-  .withWaitStrategy(Wait.forLogMessage('Listening for new connections'))
+  .withWaitStrategy(Wait.forLogMessage('Idle'))
   .start()
 export async function initializeApi(): Promise<void> {
   const started = await containerPromise

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -58,15 +58,15 @@ export async function getStoreTx(
           : undefined
       )
     default:
-      throw new SDKErrors.SDKError(
+      throw new SDKErrors.ERROR_CODEC_MISMATCH(
         'Failed to encode call: unknown authorization type'
       )
   }
 }
 
 export interface AuthorizationId extends Enum {
-  isDelegation: boolean
-  asDelegation: H256
+  readonly isDelegation: boolean
+  readonly asDelegation: H256
 }
 
 interface AttestationDetailsV1 extends Struct {
@@ -77,12 +77,9 @@ interface AttestationDetailsV1 extends Struct {
   readonly deposit: Deposit
 }
 
-interface AttestationDetailsV2 extends Struct {
-  readonly ctypeHash: Hash
-  readonly attester: AccountId
+interface AttestationDetailsV2
+  extends Omit<AttestationDetailsV1, 'delegationId'> {
   readonly authorizationId: Option<AuthorizationId>
-  readonly revoked: boolean
-  readonly deposit: Deposit
 }
 
 export type AttestationDetails = AttestationDetailsV2
@@ -104,7 +101,7 @@ function decode(
     } else if ('delegationId' in chainAttestation) {
       delegationId = chainAttestation.delegationId.unwrapOr(undefined)?.toHex()
     } else {
-      throw new SDKErrors.SDKError(
+      throw new SDKErrors.ERROR_CODEC_MISMATCH(
         'Failed to decode Attestation: unknown Codec type'
       )
     }
@@ -182,7 +179,7 @@ export async function getRevokeTx(
           : undefined
       )
     default:
-      throw new SDKErrors.SDKError(
+      throw new SDKErrors.ERROR_CODEC_MISMATCH(
         'Failed to encode call: unknown authorization type'
       )
   }
@@ -216,7 +213,7 @@ export async function getRemoveTx(
           : undefined
       )
     default:
-      throw new SDKErrors.SDKError(
+      throw new SDKErrors.ERROR_CODEC_MISMATCH(
         'Failed to encode call: unknown authorization type'
       )
   }

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -40,19 +40,28 @@ export async function getStoreTx(
 
   const authorizationArgName =
     blockchain.api.tx.attestation.add.meta.args[2].name.toString()
-
-  const authorization =
-    authorizationArgName === 'delegationId' // true -> uses old attestation authorization
-      ? delegationId
-      : delegationId
-      ? { delegation: { subjectNodeId: delegationId } } // maxChecks parameter is unused on the chain side and therefore omitted
-      : undefined
-  const tx = blockchain.api.tx.attestation.add(
-    claimHash,
-    cTypeHash,
-    authorization
-  )
-  return tx
+  switch (authorizationArgName) {
+    case 'delegationId':
+      // uses old attestation authorization
+      return blockchain.api.tx.attestation.add(
+        claimHash,
+        cTypeHash,
+        delegationId
+      )
+    case 'authorization':
+      // uses generalized attestation authorization
+      return blockchain.api.tx.attestation.add(
+        claimHash,
+        cTypeHash,
+        delegationId
+          ? { delegation: { subjectNodeId: delegationId } } // maxChecks parameter is unused on the chain side and therefore omitted
+          : undefined
+      )
+    default:
+      throw new SDKErrors.SDKError(
+        'Failed to encode call: unknown authorization type'
+      )
+  }
 }
 
 export interface AuthorizationId extends Enum {
@@ -158,19 +167,25 @@ export async function getRevokeTx(
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   log.debug(() => `Revoking attestations with claim hash ${claimHash}`)
-  const argName =
+  const authorizationArgName =
     blockchain.api.tx.attestation.revoke.meta.args[1].name.toString()
-  const authorization =
-    argName === 'maxParentChecks' // true -> uses old attestation authorization
-      ? maxParentChecks
-      : maxParentChecks
-      ? { delegation: { maxChecks: maxParentChecks } } // subjectNodeId parameter is unused on the chain side and therefore omitted
-      : undefined
-  const tx: SubmittableExtrinsic = blockchain.api.tx.attestation.revoke(
-    claimHash,
-    authorization
-  )
-  return tx
+  switch (authorizationArgName) {
+    case 'maxParentChecks':
+      // uses old attestation authorization
+      return blockchain.api.tx.attestation.revoke(claimHash, maxParentChecks)
+    case 'authorization':
+      // uses generalized attestation authorization
+      return blockchain.api.tx.attestation.revoke(
+        claimHash,
+        maxParentChecks
+          ? { delegation: { maxChecks: maxParentChecks } } // subjectNodeId parameter is unused on the chain side and therefore omitted
+          : undefined
+      )
+    default:
+      throw new SDKErrors.SDKError(
+        'Failed to encode call: unknown authorization type'
+      )
+  }
 }
 
 /**
@@ -186,19 +201,25 @@ export async function getRemoveTx(
 ): Promise<SubmittableExtrinsic> {
   const blockchain = await BlockchainApiConnection.getConnectionOrConnect()
   log.debug(() => `Removing attestation with claim hash ${claimHash}`)
-  const argName =
+  const authorizationArgName =
     blockchain.api.tx.attestation.remove.meta.args[1].name.toString()
-  const authorization =
-    argName === 'maxParentChecks' // true -> uses old attestation authorization
-      ? maxParentChecks
-      : maxParentChecks
-      ? { delegation: { maxChecks: maxParentChecks } } // subjectNodeId parameter is unused on the chain side and therefore omitted
-      : undefined
-  const tx: SubmittableExtrinsic = blockchain.api.tx.attestation.remove(
-    claimHash,
-    authorization
-  )
-  return tx
+  switch (authorizationArgName) {
+    case 'maxParentChecks':
+      // uses old attestation authorization
+      return blockchain.api.tx.attestation.remove(claimHash, maxParentChecks)
+    case 'authorization':
+      // uses generalized attestation authorization
+      return blockchain.api.tx.attestation.remove(
+        claimHash,
+        maxParentChecks
+          ? { delegation: { maxChecks: maxParentChecks } } // subjectNodeId parameter is unused on the chain side and therefore omitted
+          : undefined
+      )
+    default:
+      throw new SDKErrors.SDKError(
+        'Failed to encode call: unknown authorization type'
+      )
+  }
 }
 
 /**

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -215,7 +215,7 @@ export async function getAttestationHashes(
     DecoderUtils.assertCodecIsType(claimHashes, ['Option<Vec<H256>>'])
     return claimHashes.unwrapOrDefault().map((hash) => hash.toHex())
   }
-  throw new SDKErrors.SDKError(
+  throw new SDKErrors.ERROR_CODEC_MISMATCH(
     'Failed to query delegated attestations: Unknown pallet storage'
   )
 }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -13,7 +13,7 @@
 
 /* eslint-disable max-classes-per-file */
 
-export class SDKError extends Error {
+export abstract class SDKError extends Error {
   constructor(...args: ConstructorParameters<ErrorConstructor>) {
     super(...args)
     this.name = this.constructor.name
@@ -349,3 +349,5 @@ export class ERROR_NO_PROOF_FOR_STATEMENT extends SDKError {
     super(`No matching proof found for statement\n${statement}`)
   }
 }
+
+export class ERROR_CODEC_MISMATCH extends SDKError {}

--- a/tests/bundle.spec.ts
+++ b/tests/bundle.spec.ts
@@ -19,7 +19,7 @@ test.beforeAll(async () => {
   )
     .withCmd(['--dev', '--ws-port', '9944', '--ws-external'])
     .withExposedPorts({ container: 9944, host: 9944 })
-    .withWaitStrategy(Wait.forLogMessage('Listening for new connections'))
+    .withWaitStrategy(Wait.forLogMessage('Idle'))
     .start()
 })
 


### PR DESCRIPTION
## follow-up for https://github.com/KILTprotocol/sdk-js/pull/544

Because the current spiritnet does not have the new delegation / authorisation logic on the Attestation pallet deployed, with this PR the sdk handles both old and new.

## How to test:

Integration tests now work for latest-develop and latest tags (with the exception of a snapshot test).

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
