### PR TITLE
fix: deposit amount test

### DIFF
--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -51,7 +51,9 @@ beforeAll(async () => {
 
 it('fetches the correct deposit amount', async () => {
   const depositAmount = await Attestation.queryDepositAmount()
-  expect(depositAmount.toString()).toMatchInlineSnapshot(`"120950000000000"`)
+  expect(['120950000000000', '120900000000000']).toContain(
+    depositAmount.toString()
+  )
 })
 
 describe('handling attestations that do not exist', () => {


### PR DESCRIPTION
Makes the deposit amount test accept the old and the new value while we’re in transition

## How to test:

yarn run test:integration packages/core/src/__integrationtests__/Attestation.spec.ts

## Checklist:

- [ ] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
