### PR TITLE
fix: accept fragment as typeguard for some methods

### DIFF
--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -21,6 +21,7 @@ import {
   DidServiceEndpoint,
   EncryptionAlgorithms,
   SigningAlgorithms,
+  DidResourceUri,
 } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 
@@ -94,7 +95,9 @@ export type IDidParsingResult = {
  * @param didUri A KILT DID uri as a string.
  * @returns Object containing information extracted from the DID uri.
  */
-export function parseDidUri(didUri: IDidDetails['uri']): IDidParsingResult {
+export function parseDidUri(
+  didUri: IDidDetails['uri'] | DidResourceUri
+): IDidParsingResult {
   let matches = FULL_KILT_DID_REGEX.exec(didUri)?.groups
   if (matches && matches.identifier) {
     const version = matches.version
@@ -271,7 +274,7 @@ export function isEncryptionKey(key: NewDidKey | DidKey): boolean {
 export function validateKiltDidUri(
   input: unknown,
   allowFragment = false
-): input is IDidDetails['uri'] {
+): input is IDidDetails['uri'] | DidResourceUri {
   if (typeof input !== 'string') {
     throw TypeError(`DID string expected, got ${typeof input}`)
   }


### PR DESCRIPTION
This is causing https://github.com/KILTprotocol/docs/pull/117 to fail when verifying the signatures of credentials published behind a service endpoint.