### PR TITLE
feat: conventional/semantic PR titles

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,7 +1,7 @@
 name: "Validate PR title"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,7 +1,7 @@
 name: "Validate PR title"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,17 @@
+name: "Validate PR title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -8,8 +8,7 @@ on:
       - synchronize
 
 jobs:
-  main:
-    name: Validate PR title
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2054

When squashing commits to merge the PR, the PR title becomes the commit message. We want our commits to be formatted as conventional/semantic commits, and this requirement propagates to the PR titles. This action should validate the PR title to follow the conventional commits guidelines.

## How to test:

Change the title of the PR to not match the conventional commits guidelines and see this action fail. This will not work on the current PR because of [specific configuration](https://github.com/amannn/action-semantic-pull-request#event-triggers), but failures and successes can be seen in the [action history](https://github.com/KILTprotocol/sdk-js/actions/workflows/semantic-pull-request.yml).

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
