### PR TITLE
feat: use jest.mocked()

### DIFF
--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -223,7 +223,7 @@ describe('RequestForAttestation', () => {
       keyCharlie.sign
     )
 
-    ;(query as jest.Mock).mockResolvedValue(credential.attestation)
+    jest.mocked(query).mockResolvedValue(credential.attestation)
 
     // check proof on complete data
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
@@ -252,7 +252,7 @@ describe('RequestForAttestation', () => {
       sign
     )
 
-    ;(query as jest.Mock).mockResolvedValue(credential.attestation)
+    jest.mocked(query).mockResolvedValue(credential.attestation)
 
     // check proof on complete data
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
@@ -298,7 +298,7 @@ describe('RequestForAttestation', () => {
       migratedAndDeleted.sign
     )
 
-    ;(query as jest.Mock).mockResolvedValue(credential.attestation)
+    jest.mocked(query).mockResolvedValue(credential.attestation)
 
     // check proof on complete data
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
@@ -502,7 +502,7 @@ describe('create presentation', () => {
   })
 
   it('should create presentation and exclude specific attributes using a full DID', async () => {
-    ;(query as jest.Mock).mockResolvedValue(attestation)
+    jest.mocked(query).mockResolvedValue(attestation)
 
     const cred = Credential.fromRequestAndAttestation(reqForAtt, attestation)
 
@@ -547,7 +547,7 @@ describe('create presentation', () => {
     )
 
     attestation = Attestation.fromRequestAndDid(reqForAtt, attester.uri)
-    ;(query as jest.Mock).mockResolvedValue(attestation)
+    jest.mocked(query).mockResolvedValue(attestation)
 
     const cred = Credential.fromRequestAndAttestation(reqForAtt, attestation)
 
@@ -593,7 +593,7 @@ describe('create presentation', () => {
     )
 
     attestation = Attestation.fromRequestAndDid(reqForAtt, attester.uri)
-    ;(query as jest.Mock).mockResolvedValue(attestation)
+    jest.mocked(query).mockResolvedValue(attestation)
 
     const cred = Credential.fromRequestAndAttestation(reqForAtt, attestation)
 
@@ -641,7 +641,7 @@ describe('create presentation', () => {
     )
 
     attestation = Attestation.fromRequestAndDid(reqForAtt, attester.uri)
-    ;(query as jest.Mock).mockResolvedValue(attestation)
+    jest.mocked(query).mockResolvedValue(attestation)
 
     const cred = Credential.fromRequestAndAttestation(reqForAtt, attestation)
 
@@ -688,7 +688,7 @@ describe('create presentation', () => {
     )
 
     attestation = Attestation.fromRequestAndDid(reqForAtt, attester.uri)
-    ;(query as jest.Mock).mockResolvedValue(attestation)
+    jest.mocked(query).mockResolvedValue(attestation)
 
     const cred = Credential.fromRequestAndAttestation(reqForAtt, attestation)
 

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -183,18 +183,18 @@ describe('CType', () => {
   })
 
   it('verifies whether a ctype is registered on chain ', async () => {
-    ;(isStored as jest.Mock).mockResolvedValue(false)
+    jest.mocked(isStored).mockResolvedValue(false)
     await expect(CType.verifyStored(claimCtype)).resolves.toBe(false)
-    ;(isStored as jest.Mock).mockResolvedValue(true)
+    jest.mocked(isStored).mockResolvedValue(true)
     await expect(CType.verifyStored(claimCtype)).resolves.toBe(true)
   })
 
   it('verifies ctype owner on chain', async () => {
-    ;(getOwner as jest.Mock).mockResolvedValue(didBob)
+    jest.mocked(getOwner).mockResolvedValue(didBob)
     await expect(CType.verifyOwner(claimCtype)).resolves.toBe(false)
-    ;(getOwner as jest.Mock).mockResolvedValue(claimCtype.owner)
+    jest.mocked(getOwner).mockResolvedValue(claimCtype.owner)
     await expect(CType.verifyOwner(claimCtype)).resolves.toBe(true)
-    ;(getOwner as jest.Mock).mockResolvedValue(null)
+    jest.mocked(getOwner).mockResolvedValue(null)
     await expect(CType.verifyOwner(claimCtype)).resolves.toBe(false)
   })
 })
@@ -322,8 +322,8 @@ describe('CType registration verification', () => {
 
   describe('when CType is not registered', () => {
     beforeAll(() => {
-      ;(getOwner as jest.Mock).mockReturnValue(null)
-      ;(isStored as jest.Mock).mockReturnValue(false)
+      jest.mocked(getOwner).mockResolvedValue(null)
+      jest.mocked(isStored).mockResolvedValue(false)
     })
 
     it('does not verify registration when not registered', async () => {
@@ -339,8 +339,8 @@ describe('CType registration verification', () => {
 
   describe('when CType is registered', () => {
     beforeAll(() => {
-      ;(getOwner as jest.Mock).mockReturnValue(didAlice)
-      ;(isStored as jest.Mock).mockReturnValue(true)
+      jest.mocked(getOwner).mockResolvedValue(didAlice)
+      jest.mocked(isStored).mockResolvedValue(true)
     })
 
     it('verifies registration when owner not set', async () => {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

jest.mocked() is a type-aware alternative to `value as jest.Mock`

## How to test:

Try passing a value of incorrect type to `mockResolvedValue()`

## Checklist:

- [ ] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
