### PR TITLE
feat: remove unnecessary const types

### DIFF
--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable dot-notation */
 import { Keyring, ss58Format } from '@kiltprotocol/utils'
-import type { IIdentity, SubscriptionPromise } from '@kiltprotocol/types'
+import type { IIdentity } from '@kiltprotocol/types'
 import { ApiMocks } from '@kiltprotocol/testing'
 import { setConnection } from '../blockchainApiConnection/BlockchainApiConnection'
 import {
@@ -102,7 +102,7 @@ describe('Blockchain', () => {
 
   describe('parseSubscriptionOptions', () => {
     it('takes incomplete SubscriptionPromiseOptions and sets default values where needed', async () => {
-      const testFunction: SubscriptionPromise.ResultEvaluator = () => true
+      const testFunction = () => true
 
       expect(parseSubscriptionOptions()).toEqual({
         resolveOn: IS_FINALIZED,

--- a/packages/chain-helpers/src/errorhandling/ErrorHandler.ts
+++ b/packages/chain-helpers/src/errorhandling/ErrorHandler.ts
@@ -11,7 +11,7 @@
  * @packageDocumentation
  */
 
-import type { DispatchError, EventRecord } from '@polkadot/types/interfaces'
+import type { DispatchError } from '@polkadot/types/interfaces'
 import type { ISubmittableResult } from '@kiltprotocol/types'
 import type { RegistryError } from '@polkadot/types/types'
 
@@ -23,8 +23,8 @@ import type { RegistryError } from '@polkadot/types/types'
  * @returns Whether the extrinsic submission failed.
  */
 export function extrinsicFailed(extrinsicResult: ISubmittableResult): boolean {
-  const events: EventRecord[] = extrinsicResult.events || []
-  return events.some((eventRecord: EventRecord) => {
+  const events = extrinsicResult.events || []
+  return events.some((eventRecord) => {
     const { section, method } = eventRecord.event
     return section === 'system' && method === 'ExtrinsicFailed' // as done in https://github.com/polkadot-js/apps/blob/51835328db5f0eb90a9efcc7bf5510704a7ab279/packages/react-components/src/Status/Queue.tsx
   })
@@ -40,8 +40,8 @@ export function extrinsicFailed(extrinsicResult: ISubmittableResult): boolean {
 export function extrinsicSuccessful(
   extrinsicResult: ISubmittableResult
 ): boolean {
-  const events: EventRecord[] = extrinsicResult.events || []
-  return events.some((eventRecord: EventRecord) => {
+  const events = extrinsicResult.events || []
+  return events.some((eventRecord) => {
     const { section, method } = eventRecord.event
     return section === 'system' && method === 'ExtrinsicSuccess'
   })

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -9,7 +9,7 @@
  * @group integration/attestation
  */
 
-import type { IClaim, ICredential, KeyringPair } from '@kiltprotocol/types'
+import type { ICredential, KeyringPair } from '@kiltprotocol/types'
 import {
   createFullDidFromSeed,
   KeyTool,
@@ -116,7 +116,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   }, 60_000)
 
   it('should be possible to make a claim', async () => {
-    const content: IClaim['contents'] = { name: 'Ralph', age: 12 }
+    const content = { name: 'Ralph', age: 12 }
     const claim = Claim.fromCTypeAndClaimContents(
       driversLicenseCType,
       content,
@@ -137,7 +137,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   })
 
   it('should be possible to attest a claim and then claim the attestation deposit back', async () => {
-    const content: IClaim['contents'] = { name: 'Ralph', age: 12 }
+    const content = { name: 'Ralph', age: 12 }
 
     const claim = Claim.fromCTypeAndClaimContents(
       driversLicenseCType,
@@ -183,7 +183,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   }, 60_000)
 
   it('should not be possible to attest a claim without enough tokens', async () => {
-    const content: IClaim['contents'] = { name: 'Ralph', age: 12 }
+    const content = { name: 'Ralph', age: 12 }
 
     const claim = Claim.fromCTypeAndClaimContents(
       driversLicenseCType,
@@ -239,7 +239,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       type: 'object',
     })
 
-    const content: IClaim['contents'] = { name: 'Ralph', weight: 120 }
+    const content = { name: 'Ralph', weight: 120 }
     const claim = Claim.fromCTypeAndClaimContents(
       badCtype,
       content,
@@ -263,7 +263,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     let credential: ICredential
 
     beforeAll(async () => {
-      const content: IClaim['contents'] = { name: 'Rolfi', age: 18 }
+      const content = { name: 'Rolfi', age: 18 }
       const claim = Claim.fromCTypeAndClaimContents(
         driversLicenseCType,
         content,
@@ -319,12 +319,12 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         claimer,
         claimer.authenticationKey.id
       )
-      const fakecredential: ICredential = {
+      const fakeCredential: ICredential = {
         request,
         attestation: credential.attestation,
       }
 
-      expect(await Credential.verify(fakecredential)).toBeFalsy()
+      expect(await Credential.verify(fakeCredential)).toBeFalsy()
     }, 15_000)
 
     it('should not be possible for the claimer to revoke an attestation', async () => {

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -68,7 +68,7 @@ describe('when there is a dev chain with a faucet', () => {
   // Skipped because it is run in parallel with other tests and it fails because of the deposit taken
   // in the other test cases.
   it('should be able to faucet coins to a new address', async () => {
-    const address: string = addressFromRandom()
+    const address = addressFromRandom()
     const spy = jest.fn()
     listenToBalanceChanges(address, spy)
     const balanceBefore = await getBalances(faucet.address)

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -9,7 +9,6 @@
  * @group integration/blockchain
  */
 
-import type { SignerPayload } from '@polkadot/types/interfaces/extrinsics/types'
 import { BN } from '@polkadot/util'
 import type { KeyringPair } from '@kiltprotocol/types'
 import { ApiPromise } from '@polkadot/api'
@@ -54,7 +53,7 @@ describe('Chain returns specific errors, that we check for', () => {
 
     const nonce = await api.rpc.system.accountNextIndex(testIdentity.address)
 
-    const signer: SignerPayload = api.createType('SignerPayload', {
+    const signer = api.createType('SignerPayload', {
       method: tx.method.toHex(),
       nonce,
       genesisHash: api.genesisHash,
@@ -69,7 +68,7 @@ describe('Chain returns specific errors, that we check for', () => {
       .sign(testIdentity)
     tx.addSignature(testIdentity.address, signature, signer.toPayload())
 
-    const errorSigner: SignerPayload = api.createType('SignerPayload', {
+    const errorSigner = api.createType('SignerPayload', {
       method: errorTx.method.toHex(),
       nonce,
       genesisHash: api.genesisHash,
@@ -117,7 +116,7 @@ describe('Chain returns specific errors, that we check for', () => {
 
     const nonce = await api.rpc.system.accountNextIndex(testIdentity.address)
 
-    const signer: SignerPayload = api.createType('SignerPayload', {
+    const signer = api.createType('SignerPayload', {
       method: tx.method.toHex(),
       nonce,
       genesisHash: api.genesisHash,
@@ -132,7 +131,7 @@ describe('Chain returns specific errors, that we check for', () => {
       .sign(testIdentity)
     tx.addSignature(testIdentity.address, signature, signer.toPayload())
 
-    const errorSigner: SignerPayload = api.createType('SignerPayload', {
+    const errorSigner = api.createType('SignerPayload', {
       method: errorTx.method.toHex(),
       nonce,
       genesisHash: api.genesisHash,

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1236,13 +1236,11 @@ describe('Runtime constraints', () => {
     it('should not be possible to create a DID with too many service endpoints', async () => {
       // Maximum is 25
       const newServiceEndpoints = Array(25).map(
-        (_, index): DidServiceEndpoint => {
-          return {
-            id: `service-${index}`,
-            types: [`type-${index}`],
-            urls: [`x:url-${index}`],
-          }
-        }
+        (_, index): DidServiceEndpoint => ({
+          id: `service-${index}`,
+          types: [`type-${index}`],
+          urls: [`x:url-${index}`],
+        })
       )
       await expect(
         DidChain.generateCreateTxFromCreationDetails(

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -69,7 +69,7 @@ export async function initializeApi(): Promise<void> {
   })
 }
 
-const keyring: Keyring = new Keyring({ ss58Format, type: 'ed25519' })
+const keyring = new Keyring({ ss58Format, type: 'ed25519' })
 
 // Dev Faucet account seed phrase
 const faucetSeed =

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -80,7 +80,7 @@ describe('Attestation', () => {
       ])
     )
 
-    const attestation: IAttestation = Attestation.fromRequestAndDid(
+    const attestation = Attestation.fromRequestAndDid(
       requestForAttestation,
       identityAlice
     )
@@ -113,7 +113,7 @@ describe('Attestation', () => {
       ])
     )
 
-    const attestation: IAttestation = Attestation.fromRequestAndDid(
+    const attestation = Attestation.fromRequestAndDid(
       requestForAttestation,
       identityAlice
     )

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -130,7 +130,7 @@ describe('RequestForAttestation', () => {
   let migratedAndDeletedLightDid: DidDetails
   let migratedAndDeletedFullDid: DidDetails
 
-  const mockResolver: IDidResolver = (() => {
+  const mockResolver = (() => {
     const resolve = async (
       didUri: DidUri
     ): Promise<DidResolvedDetails | null> => {
@@ -387,7 +387,7 @@ describe('create presentation', () => {
   let reqForAtt: IRequestForAttestation
   let attestation: IAttestation
 
-  const mockResolver: IDidResolver = (() => {
+  const mockResolver = (() => {
     const resolve = async (
       didUri: DidUri
     ): Promise<DidResolvedDetails | null> => {

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -167,7 +167,7 @@ export async function verify(
  * @returns Boolean whether each element of the given Array of ICredentials is verifiable.
  */
 export function validateLegitimations(legitimations: ICredential[]): boolean {
-  legitimations.forEach((legitimation: ICredential) => {
+  legitimations.forEach((legitimation) => {
     if (!verifyDataIntegrity(legitimation)) {
       throw new SDKErrors.ERROR_LEGITIMATIONS_UNVERIFIABLE()
     }

--- a/packages/core/src/delegation/DelegationHierarchyDetails.chain.ts
+++ b/packages/core/src/delegation/DelegationHierarchyDetails.chain.ts
@@ -13,7 +13,6 @@ import type { Option } from '@polkadot/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import {
   decodeDelegationHierarchyDetails,
-  DelegationHierarchyDetailsRecord,
   IChainDelegationHierarchyDetails,
 } from './DelegationDecoder.js'
 
@@ -27,12 +26,11 @@ export async function query(
   rootId: IDelegationNode['id']
 ): Promise<IDelegationHierarchyDetails | null> {
   const api = await BlockchainApiConnection.getConnectionOrConnect()
-  const decoded: DelegationHierarchyDetailsRecord | null =
-    decodeDelegationHierarchyDetails(
-      await api.query.delegation.delegationHierarchies<
-        Option<IChainDelegationHierarchyDetails>
-      >(rootId)
-    )
+  const decoded = decodeDelegationHierarchyDetails(
+    await api.query.delegation.delegationHierarchies<
+      Option<IChainDelegationHierarchyDetails>
+    >(rootId)
+  )
   if (!decoded) {
     return null
   }

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -97,7 +97,7 @@ describe('DelegationNode', () => {
         permissions: [Permission.DELEGATE],
         revoked: false,
       })
-      const hash: string = node.generateHash()
+      const hash = node.generateHash()
       expect(hash).toBe(
         '0x3f3dc0df7527013f2373f18f55cf87847df3249526e9b1d5aa75df8eeb5b7d6e'
       )
@@ -113,8 +113,8 @@ describe('DelegationNode', () => {
         permissions: [Permission.DELEGATE],
         revoked: false,
       })
-      const permissions: Uint8Array = permissionsAsBitset(node)
-      const expected: Uint8Array = new Uint8Array(4)
+      const permissions = permissionsAsBitset(node)
+      const expected = new Uint8Array(4)
       expected[0] = 2
       expect(permissions.toString()).toBe(expected.toString())
     })
@@ -182,7 +182,7 @@ describe('DelegationNode', () => {
         }),
       }
 
-      const node: DelegationNode = new DelegationNode({
+      const node = new DelegationNode({
         id,
         hierarchyId,
         account: didAlice,
@@ -201,12 +201,12 @@ describe('DelegationNode', () => {
 
   describe('count subtree', () => {
     let topNode: DelegationNode
-    const a1: string = Crypto.hashStr('a1')
-    const b1: string = Crypto.hashStr('b1')
-    const b2: string = Crypto.hashStr('b2')
-    const c1: string = Crypto.hashStr('c1')
-    const c2: string = Crypto.hashStr('c2')
-    const d1: string = Crypto.hashStr('d1')
+    const a1 = Crypto.hashStr('a1')
+    const b1 = Crypto.hashStr('b1')
+    const b2 = Crypto.hashStr('b2')
+    const c1 = Crypto.hashStr('c1')
+    const c2 = Crypto.hashStr('c2')
+    const d1 = Crypto.hashStr('d1')
     beforeAll(() => {
       topNode = new DelegationNode({
         id: a1,

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -247,13 +247,11 @@ export class DelegationNode implements IDelegationNode {
    * @returns The hash representation of this delegation **as a hex string**.
    */
   public generateHash(): HexString {
-    const propsToHash: Array<Uint8Array | string> = [this.id, this.hierarchyId]
+    const propsToHash = [this.id, this.hierarchyId]
     if (this.parentId) {
       propsToHash.push(this.parentId)
     }
-    const uint8Props: Uint8Array[] = propsToHash.map((value) => {
-      return Crypto.coToUInt8(value)
-    })
+    const uint8Props = propsToHash.map((value) => Crypto.coToUInt8(value))
     uint8Props.push(DelegationNodeUtils.permissionsAsBitset(this))
     const generated = Crypto.u8aToHex(
       Crypto.hash(Crypto.u8aConcat(...uint8Props), 256)

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -27,10 +27,10 @@ import { DelegationNode } from './DelegationNode.js'
  * @returns The bitset as single value uint8 array.
  */
 export function permissionsAsBitset(delegation: IDelegationNode): Uint8Array {
-  const permissionsBitsetData: number = delegation.permissions.reduce(
+  const permissionsBitsetData = delegation.permissions.reduce(
     (accumulator, currentValue) => accumulator + currentValue
   )
-  const uint8: Uint8Array = new Uint8Array(4)
+  const uint8 = new Uint8Array(4)
   uint8[0] = permissionsBitsetData
   return uint8
 }

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -61,7 +61,7 @@ describe('Quote', () => {
   let invalidPropertiesQuote: IQuote
   let invalidCostQuote: IQuote
 
-  const mockResolver: IDidResolver = (() => {
+  const mockResolver = (() => {
     const resolve = async (
       didUri: string
     ): Promise<DidResolvedDetails | null> => {
@@ -232,7 +232,7 @@ describe('Quote compression', () => {
   let compressedResultAttesterSignedQuote: CompressedQuoteAttesterSigned
   let compressedResultQuoteAgreement: CompressedQuoteAgreed
 
-  const mockResolver: IDidResolver = (() => {
+  const mockResolver = (() => {
     const resolve = async (
       didUri: string
     ): Promise<DidResolvedDetails | null> => {

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -53,10 +53,7 @@ function getHashLeaves(
   legitimations: ICredential[],
   delegationId: IDelegationNode['id'] | null
 ): Uint8Array[] {
-  const result: Uint8Array[] = []
-  claimHashes.forEach((item) => {
-    result.push(Crypto.coToUInt8(item))
-  })
+  const result = claimHashes.map((item) => Crypto.coToUInt8(item))
   if (legitimations) {
     legitimations.forEach((legitimation) => {
       result.push(Crypto.coToUInt8(legitimation.attestation.claimHash))
@@ -78,12 +75,12 @@ function getHashLeaves(
 export function calculateRootHash(
   request: Partial<IRequestForAttestation>
 ): Hash {
-  const hashes: Uint8Array[] = getHashLeaves(
+  const hashes = getHashLeaves(
     request.claimHashes || [],
     request.legitimations || [],
     request.delegationId || null
   )
-  const root: Uint8Array = getHashRoot(hashes)
+  const root = getHashRoot(hashes)
   return Crypto.u8aToHex(root)
 }
 

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -215,7 +215,7 @@ function decodeDidPublicKeyDetails(
 function decodeDidChainRecord(
   didDetail: IDidChainRecordCodec
 ): IDidChainRecordJSON {
-  const publicKeys: DidKey[] = [...didDetail.publicKeys.entries()].map(
+  const publicKeys = [...didDetail.publicKeys.entries()].map(
     ([keyId, keyDetails]) => decodeDidPublicKeyDetails(keyId, keyDetails)
   )
   const authenticationKeyId = didDetail.authenticationKey.toHex()
@@ -470,9 +470,8 @@ export async function generateCreateTxFromCreationDetails(
     )
   }
 
-  const newKeyAgreementKeys: PublicKeyEnum[] = keyAgreementKeys.map(
-    ({ publicKey }) =>
-      formatPublicKey({ type: EncryptionKeyType.X25519, publicKey })
+  const newKeyAgreementKeys = keyAgreementKeys.map(({ publicKey }) =>
+    formatPublicKey({ type: EncryptionKeyType.X25519, publicKey })
   )
 
   const newAssertionKey = assertionKey

--- a/packages/did/src/DidBatcher/DidBatchBuilder.ts
+++ b/packages/did/src/DidBatcher/DidBatchBuilder.ts
@@ -73,8 +73,7 @@ export class DidBatchBuilder {
     ext: Extrinsic,
     keyRelationship: VerificationKeyRelationship
   ): void {
-    const lastBatch: BatchInfo | undefined =
-      this.batches[this.batches.length - 1]
+    const lastBatch = this.batches[this.batches.length - 1]
 
     // If there was not previous batch, or the new extrinsic requires a different key, create and add a new batch.
     if (!lastBatch || lastBatch.keyRelationship !== keyRelationship) {
@@ -118,6 +117,7 @@ export class DidBatchBuilder {
    * @param extrinsics The list of Extrinsic to add to the batch.
    * @returns The builder containing the new extrinsics.
    */
+
   /* istanbul ignore next */
   public addMultipleExtrinsics(extrinsics: Extrinsic[]): this {
     extrinsics.forEach((ext) => {
@@ -167,7 +167,7 @@ export class DidBatchBuilder {
       )
     }
 
-    const signedBatches: SubmittableExtrinsic[] = await Promise.all(
+    const signedBatches = await Promise.all(
       this.batches.map(async (batch, index) => {
         // Don't create a new batch if the batch contains only one extrinsic
         const processedBatch =

--- a/packages/did/src/DidDetails/DidDetails.utils.ts
+++ b/packages/did/src/DidDetails/DidDetails.utils.ts
@@ -25,7 +25,7 @@ export function checkDidCreationDetails({
       `One and only one ${KeyRelationship.authentication} key is required on any instance of DidDetails`
     )
   }
-  const allowedKeyRelationships: Set<string> = new Set([
+  const allowedKeyRelationships = new Set([
     ...Object.values(KeyRelationship),
     'none',
   ])

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -119,10 +119,9 @@ jest.mock('../Did.chain.ts', () => ({
 
 describe('When creating an instance from the chain', () => {
   it('correctly assign the right keys and the right service endpoints', async () => {
-    const fullDidDetails: FullDidDetails | null =
-      await FullDidDetails.fromChainInfo(
-        getKiltDidFromIdentifier(existingIdentifier, 'full')
-      )
+    const fullDidDetails = await FullDidDetails.fromChainInfo(
+      getKiltDidFromIdentifier(existingIdentifier, 'full')
+    )
 
     expect(fullDidDetails).not.toBeNull()
 
@@ -251,10 +250,9 @@ describe('When creating an instance from the chain', () => {
   })
 
   it('returns null if the identifier does not exist', async () => {
-    const fullDidDetails: FullDidDetails | null =
-      await FullDidDetails.fromChainInfo(
-        getKiltDidFromIdentifier(nonExistingIdentifier, 'full')
-      )
+    const fullDidDetails = await FullDidDetails.fromChainInfo(
+      getKiltDidFromIdentifier(nonExistingIdentifier, 'full')
+    )
     expect(fullDidDetails).toBeNull()
   })
 })

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -9,9 +9,9 @@ import type { Extrinsic } from '@polkadot/types/interfaces'
 import { BN } from '@polkadot/util'
 
 import type {
+  DidIdentifier,
   DidVerificationKey,
   IDidDetails,
-  DidIdentifier,
   IIdentity,
   SignCallback,
   SubmittableExtrinsic,
@@ -23,8 +23,6 @@ import type {
   DidConstructorDetails,
   DidKeySelectionCallback,
   MapKeysToRelationship,
-  PublicKeys,
-  ServiceEndpoints,
 } from '../types.js'
 import {
   generateDidAuthenticatedTx,
@@ -104,7 +102,7 @@ export class FullDidDetails extends DidDetails {
       keyAgreementKeys,
     } = didRec
 
-    const keys: PublicKeys = publicKeys.reduce((res, key) => {
+    const keys = publicKeys.reduce((res, key) => {
       res[key.id] = key
       return res
     }, {})
@@ -120,12 +118,13 @@ export class FullDidDetails extends DidDetails {
       keyRelationships.capabilityDelegation = new Set([capabilityDelegationKey])
     }
 
-    const serviceEndpoints: ServiceEndpoints = (
-      await queryServiceEndpoints(identifier)
-    ).reduce((res, service) => {
-      res[service.id] = service
-      return res
-    }, {})
+    const serviceEndpoints = (await queryServiceEndpoints(identifier)).reduce(
+      (res, service) => {
+        res[service.id] = service
+        return res
+      },
+      {}
+    )
 
     return new FullDidDetails({
       identifier,

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -72,12 +72,11 @@ describe('When creating an instance from the details', () => {
       },
       serviceEndpoints: endpoints,
     }
-    const lightDidDetails: LightDidDetails =
-      LightDidDetails.fromDetails(validOptions)
+    const lightDidDetails = LightDidDetails.fromDetails(validOptions)
 
     expect(lightDidDetails?.identifier).toStrictEqual(authKey.address)
 
-    const encodedDetails: string = serializeAndEncodeAdditionalLightDidDetails({
+    const encodedDetails = serializeAndEncodeAdditionalLightDidDetails({
       encryptionKey: {
         publicKey: encKey.publicKey,
         type: EncryptionKeyType.X25519,
@@ -184,12 +183,11 @@ describe('When creating an instance from the details', () => {
         type: EncryptionKeyType.X25519,
       },
     }
-    const lightDidDetails: LightDidDetails =
-      LightDidDetails.fromDetails(validOptions)
+    const lightDidDetails = LightDidDetails.fromDetails(validOptions)
 
     expect(lightDidDetails?.identifier).toStrictEqual(authKey.address)
 
-    const encodedDetails: string = serializeAndEncodeAdditionalLightDidDetails({
+    const encodedDetails = serializeAndEncodeAdditionalLightDidDetails({
       encryptionKey: {
         publicKey: encKey.publicKey,
         type: EncryptionKeyType.X25519,
@@ -321,8 +319,7 @@ describe('When creating an instance from a URI', () => {
       serviceEndpoints: endpoints,
     }
     // We are sure this is correct because of the describe case above
-    const expectedLightDidDetails: LightDidDetails =
-      LightDidDetails.fromDetails(creationOptions)
+    const expectedLightDidDetails = LightDidDetails.fromDetails(creationOptions)
 
     const builtLightDidDetails = LightDidDetails.fromUri(
       expectedLightDidDetails.uri
@@ -374,8 +371,7 @@ describe('When creating an instance from a URI', () => {
       serviceEndpoints: endpoints,
     }
     // We are sure this is correct because of the describe case above
-    const expectedLightDidDetails: LightDidDetails =
-      LightDidDetails.fromDetails(creationOptions)
+    const expectedLightDidDetails = LightDidDetails.fromDetails(creationOptions)
 
     const uriWithFragment: DidUri = `${expectedLightDidDetails.uri}#authentication`
 
@@ -387,7 +383,7 @@ describe('When creating an instance from a URI', () => {
     const validKiltAddress = new Keyring({ ss58Format }).addFromMnemonic(
       'random'
     )
-    const incorrectURIs: DidUri[] = [
+    const incorrectURIs = [
       'did:kilt:light:sdasdsadas',
       // @ts-ignore not a valid did uri
       'random-uri',
@@ -401,7 +397,7 @@ describe('When creating an instance from a URI', () => {
       `did:kilt:light:00${validKiltAddress}:randomdetails`,
     ]
     incorrectURIs.forEach((uri) => {
-      expect(() => LightDidDetails.fromUri(uri)).toThrow()
+      expect(() => LightDidDetails.fromUri(uri as DidUri)).toThrow()
     })
   })
 })
@@ -421,14 +417,12 @@ describe('When creating an instance from an identifier', () => {
     }
 
     // We are sure this is correct because of the describe case above
-    const expectedLightDidDetails: LightDidDetails =
-      LightDidDetails.fromDetails(creationOptions)
+    const expectedLightDidDetails = LightDidDetails.fromDetails(creationOptions)
     // We are sure this is correct because of the describe case above
-    const builtLightDidDetails: LightDidDetails =
-      LightDidDetails.fromIdentifier(
-        authKey.address,
-        VerificationKeyType.Sr25519
-      )
+    const builtLightDidDetails = LightDidDetails.fromIdentifier(
+      authKey.address,
+      VerificationKeyType.Sr25519
+    )
 
     expect(builtLightDidDetails).toStrictEqual<LightDidDetails>(
       expectedLightDidDetails
@@ -459,14 +453,12 @@ describe('When creating an instance from an identifier', () => {
     }
 
     // We are sure this is correct because of the describe case above
-    const expectedLightDidDetails: LightDidDetails =
-      LightDidDetails.fromDetails(creationOptions)
+    const expectedLightDidDetails = LightDidDetails.fromDetails(creationOptions)
     // We are sure this is correct because of the describe case above
-    const builtLightDidDetails: LightDidDetails =
-      LightDidDetails.fromIdentifier(
-        authKey.address,
-        VerificationKeyType.Ed25519
-      )
+    const builtLightDidDetails = LightDidDetails.fromIdentifier(
+      authKey.address,
+      VerificationKeyType.Ed25519
+    )
 
     expect(builtLightDidDetails).toStrictEqual<LightDidDetails>(
       expectedLightDidDetails

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -8,11 +8,11 @@
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
 
 import type {
-  IDidDetails,
   DidIdentifier,
+  DidUri,
+  IDidDetails,
   IIdentity,
   SignCallback,
-  DidUri,
 } from '@kiltprotocol/types'
 import { VerificationKeyType } from '@kiltprotocol/types'
 
@@ -23,11 +23,10 @@ import { FullDidCreationBuilder } from '../DidBatcher/FullDidCreationBuilder.js'
 
 import type {
   DidConstructorDetails,
-  MapKeysToRelationship,
-  PublicKeys,
-  ServiceEndpoints,
   LightDidSupportedVerificationKeyType,
+  MapKeysToRelationship,
   NewLightDidAuthenticationKey,
+  PublicKeys,
 } from '../types.js'
 import {
   getKiltDidFromIdentifier,
@@ -132,13 +131,10 @@ export class LightDidDetails extends DidDetails {
       keyRelationships.keyAgreement = new Set([encryptionKeyId])
     }
 
-    const endpoints: ServiceEndpoints = serviceEndpoints.reduce(
-      (res, service) => {
-        res[service.id] = service
-        return res
-      },
-      {}
-    )
+    const endpoints = serviceEndpoints.reduce((res, service) => {
+      res[service.id] = service
+      return res
+    }, {})
 
     return new LightDidDetails(id.substring(2), {
       uri,

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -272,8 +272,8 @@ describe('When exporting a DID Document from a full DID', () => {
 
 describe('When exporting a DID Document from a light DID', () => {
   const authKey = generateAuthenticationKeyDetails() as NewDidVerificationKey
-  const encKey: DidKey = generateEncryptionKeyDetails()
-  const serviceEndpoints: DidServiceEndpoint[] = [
+  const encKey = generateEncryptionKeyDetails()
+  const serviceEndpoints = [
     generateServiceEndpointDetails('id-1'),
     generateServiceEndpointDetails('id-2'),
   ]

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -18,7 +18,6 @@ import { encodeAddress, signatureVerify } from '@polkadot/util-crypto'
 import type { Option, Struct, u128 } from '@polkadot/types'
 import type {
   AccountId,
-  BlockNumber,
   Extrinsic,
   MultiSignature,
 } from '@polkadot/types/interfaces'
@@ -285,7 +284,7 @@ export async function getAuthorizeLinkWithAccountExtrinsic(
   nBlocksValid = 10
 ): Promise<Extrinsic> {
   const api = await BlockchainApiConnection.getConnectionOrConnect()
-  const blockNo: BlockNumber = await api.query.system.number()
+  const blockNo = await api.query.system.number()
   const validTill = blockNo.addn(nBlocksValid)
   // Gets the current definition of BlockNumber (second tx argument) from the metadata.
   const blockNumberType =

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -130,16 +130,14 @@ export async function resolveKey(
       if (!key) {
         return null
       }
-      const result: ResolvedDidKey = {
+      const { includedAt } = key
+      return {
         controller: did,
         uri: didUri,
         publicKey: key.publicKey,
         type: key.type,
+        ...(includedAt && { includedAt }),
       }
-      if (key.includedAt) {
-        result.includedAt = key.includedAt
-      }
-      return result
     }
     case 'light': {
       const resolvedDetails = await resolveDoc(didUri)

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -10,20 +10,19 @@ import { decodeAddress } from '@polkadot/util-crypto'
 import Keyring from '@polkadot/keyring'
 
 import {
+  DidIdentifier,
   DidKey,
+  DidPublicKey,
   DidResolutionDocumentMetadata,
   DidResolvedDetails,
+  DidResourceUri,
   DidServiceEndpoint,
+  DidUri,
+  EncryptionKeyType,
   IDidDetails,
-  DidIdentifier,
-  KeyringPair,
   ResolvedDidKey,
   ResolvedDidServiceEndpoint,
   VerificationKeyType,
-  EncryptionKeyType,
-  DidUri,
-  DidPublicKey,
-  DidResourceUri,
 } from '@kiltprotocol/types'
 import { ss58Format } from '@kiltprotocol/utils'
 
@@ -198,7 +197,7 @@ describe('When resolving a key', () => {
       identifierWithAuthenticationKey,
       'full'
     )
-    const keyIdUri: DidPublicKey['uri'] = `${fullDid}#auth`
+    const keyIdUri: DidResourceUri = `${fullDid}#auth`
 
     await expect(
       DidResolver.resolveKey(keyIdUri)
@@ -276,7 +275,7 @@ describe('When resolving a service endpoint', () => {
   })
 
   it('throws for invalid URIs', async () => {
-    const uriWithoutFragment: DidUri = getKiltDidFromIdentifier(
+    const uriWithoutFragment = getKiltDidFromIdentifier(
       deletedIdentifier,
       'full'
     )
@@ -428,9 +427,9 @@ describe('When resolving a full DID', () => {
 })
 
 describe('When resolving a light DID', () => {
-  const keyring: Keyring = new Keyring({ ss58Format })
-  const authKey: KeyringPair = keyring.addFromMnemonic('auth')
-  const encryptionKey: KeyringPair = keyring.addFromMnemonic('enc')
+  const keyring = new Keyring({ ss58Format })
+  const authKey = keyring.addFromMnemonic('auth')
+  const encryptionKey = keyring.addFromMnemonic('enc')
 
   it('correctly resolves the details with an authentication key', async () => {
     const lightDidWithAuthenticationKey = LightDidDetails.fromDetails({

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -180,7 +180,7 @@ describe('Messaging', () => {
       JSON.stringify(decryptedMessage.body)
     )
 
-    const encryptedMessageWrongContent: IEncryptedMessage = JSON.parse(
+    const encryptedMessageWrongContent = JSON.parse(
       JSON.stringify(encryptedMessage)
     ) as IEncryptedMessage
     const messedUpContent = Crypto.coToUInt8(
@@ -232,7 +232,7 @@ describe('Messaging', () => {
       owner: aliceFullDid.uri,
       contents: {},
     })
-    const date: string = new Date(2019, 11, 10).toISOString()
+    const date = new Date(2019, 11, 10).toISOString()
 
     const quoteData: IQuote = {
       attesterDid: bobFullDid.uri,
@@ -369,7 +369,7 @@ describe('Messaging', () => {
       contents: {},
     })
 
-    const date: string = new Date(2019, 11, 10).toISOString()
+    const date = new Date(2019, 11, 10).toISOString()
     const quoteData: IQuote = {
       attesterDid: bobLightDid.uri,
       cTypeHash: `${Crypto.hashStr('0x12345678')}`,

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -17,7 +17,6 @@ import {
   IEncryptedMessage,
   IEncryptedMessageContents,
   IMessage,
-  ISubmitCredential,
   MessageBody,
   MessageBodyType,
 } from '@kiltprotocol/types'
@@ -81,7 +80,7 @@ export class Message implements IMessage {
         break
       case Message.BodyType.SUBMIT_CREDENTIAL:
         {
-          const submitClaimsForCtype: ISubmitCredential = body
+          const submitClaimsForCtype = body
           submitClaimsForCtype.content.forEach((claim) => {
             if (!DidUtils.isSameSubject(claim.request.claim.owner, sender)) {
               throw new SDKErrors.ERROR_IDENTITY_MISMATCH('Claims', 'Sender')

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -112,7 +112,7 @@ async function buildCredential(
     type: 'object',
   }
 
-  const testCType: ICType = CType.fromSchema(rawCType)
+  const testCType = CType.fromSchema(rawCType)
 
   const claim = Claim.fromCTypeAndClaimContents(testCType, contents, claimerDid)
   // build request for attestation with legitimations

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -85,7 +85,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
     }
     case Message.BodyType.SUBMIT_TERMS: {
       Claim.verifyDataStructure(body.content.claim)
-      body.content.legitimations.map((credential: ICredential) =>
+      body.content.legitimations.map((credential) =>
         Credential.verifyDataStructure(credential)
       )
       if (body.content.delegationId) {

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -310,7 +310,7 @@ export async function createLocalDemoFullDidFromLightDid(
     keys[encKey.id] = encKey
   }
 
-  const fullDidCreationDetails: DidConstructorDetails = {
+  return new FullDidDetails({
     uri: DidUtils.getKiltDidFromIdentifier(identifier, 'full'),
     keyRelationships: {
       authentication: new Set([authKey.id]),
@@ -320,10 +320,6 @@ export async function createLocalDemoFullDidFromLightDid(
     },
     keys,
     serviceEndpoints: {},
-  }
-
-  return new FullDidDetails({
-    ...fullDidCreationDetails,
     identifier,
   })
 }

--- a/packages/testing/src/mocks/mockedApi.ts
+++ b/packages/testing/src/mocks/mockedApi.ts
@@ -186,7 +186,7 @@ export function getMockedApi(): MockApiPromise {
   )
 
   function getMockSubmittableExtrinsic(): SubmittableExtrinsic {
-    const result: ISubmittableResult = TxResultsQueue.shift() || defaultTxResult
+    const result = TxResultsQueue.shift() || defaultTxResult
     return new MockSubmittableExtrinsic(result) as any as SubmittableExtrinsic
   }
 

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -216,8 +216,8 @@ export function encryptAsymmetricAsStr(
   secretKeyB: CryptoInput
 ): EncryptedAsymmetricString {
   const encrypted = encryptAsymmetric(message, publicKeyA, secretKeyB)
-  const box: string = u8aToHex(encrypted.box)
-  const nonce: string = u8aToHex(encrypted.nonce)
+  const box = u8aToHex(encrypted.box)
+  const nonce = u8aToHex(encrypted.nonce)
   return { box, nonce }
 }
 

--- a/packages/utils/src/Decode.spec.ts
+++ b/packages/utils/src/Decode.spec.ts
@@ -18,13 +18,13 @@ const cases = ['Option<Text>', 'Option<AccountId>', 'Vec<Option<Text>>']
 
 describe('positive tests', () => {
   it('checks codec types', () => {
-    cases.forEach((T: any) => {
+    cases.forEach((T) => {
       expect(codecIsType(registry.createType(T), [T])).toBe(true)
     })
   })
 
   it('asserts codec types', () => {
-    cases.forEach((T: any) => {
+    cases.forEach((T) => {
       expect(() => assertCodecIsType(registry.createType(T), [T])).not.toThrow()
     })
   })

--- a/packages/utils/src/UUID.spec.ts
+++ b/packages/utils/src/UUID.spec.ts
@@ -13,7 +13,7 @@ import * as UUID from './UUID'
 
 describe('UUID', () => {
   it('generate', () => {
-    const uuid: string = UUID.generate()
+    const uuid = UUID.generate()
     expect(uuid.substring(0, 2)).toEqual('0x')
     expect(uuid.substring(2)).toHaveLength(64)
   })

--- a/packages/utils/src/json-schema/dereference.ts
+++ b/packages/utils/src/json-schema/dereference.ts
@@ -79,7 +79,7 @@ export function dereference(
   basePointer = ''
 ) {
   if (schema && typeof schema === 'object' && !Array.isArray(schema)) {
-    const id: string = schema.$id || schema.id
+    const id = schema.$id || schema.id
     if (id) {
       const url = new URL(id, baseURI)
       if (url.hash.length > 1) {

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -11,7 +11,6 @@
 
 import {
   DidDocumentPublicKeyType,
-  DidPublicKey,
   DidUri,
   ICredential,
   ICType,
@@ -27,10 +26,10 @@ import * as verificationUtils from './verificationUtils'
 import * as presentationUtils from './presentationUtils'
 import type { IPublicKeyRecord, VerifiableCredential } from './types'
 import {
-  KILT_VERIFIABLECREDENTIAL_TYPE,
   DEFAULT_VERIFIABLECREDENTIAL_CONTEXT,
   DEFAULT_VERIFIABLECREDENTIAL_TYPE,
   KILT_CREDENTIAL_CONTEXT_URL,
+  KILT_VERIFIABLECREDENTIAL_TYPE,
 } from './constants'
 
 const ctype: ICType = {
@@ -208,7 +207,7 @@ describe('proofs', () => {
   let documentLoader: DocumentLoader
   beforeAll(() => {
     VC = toVC.fromCredential(credential)
-    const keyId: DidPublicKey['uri'] = VC.proof[0].verificationMethod
+    const keyId = VC.proof[0].verificationMethod
     const verificationMethod: IPublicKeyRecord = {
       uri: keyId,
       type: DidDocumentPublicKeyType.Ed25519VerificationKey,

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -240,7 +240,7 @@ export async function verifyCredentialDigestProof(
 
     // 1: check credential digest against credential contents & claim property hashes in proof
     // collect hashes from hash array, legitimations & delegationId
-    const hashes: string[] = proof.claimHashes.concat(
+    const hashes = proof.claimHashes.concat(
       credential.legitimationIds,
       credential.delegationId || []
     )


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

The TypeScript compiler is quite good at inferring types of values. There’s no need to over specify the types of constants. It even has a downside of introducing more noise in the code. I have removed the types where they are not needed.

## How to test:

yarn check

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
