### PR TITLE
feat: remove unnecessary use of .resolves

### DIFF
--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
@@ -38,7 +38,7 @@ it('resolves the promise', async () => {
     rejectOn: REJECT_ON,
   })
   subscription(RESOLVE)
-  await expect(promise).resolves.toEqual(RESOLVE)
+  expect(await promise).toEqual(RESOLVE)
 })
 
 it('rejects the promise', async () => {

--- a/packages/core/src/__integrationtests__/AccountLinking.spec.ts
+++ b/packages/core/src/__integrationtests__/AccountLinking.spec.ts
@@ -59,15 +59,18 @@ describe('When there is an on-chain DID', () => {
     }, 40_000)
     it('should be possible to associate the tx sender', async () => {
       // Check that no links exist
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-      ).resolves.toBeNull()
-      await expect(
-        AccountLinks.queryConnectedAccountsForDid(did.identifier)
-      ).resolves.toStrictEqual([])
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-      ).resolves.toBeFalsy()
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+      ).toBeNull()
+      expect(
+        await AccountLinks.queryConnectedAccountsForDid(did.identifier)
+      ).toStrictEqual([])
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          paymentAccount.address
+        )
+      ).toBeFalsy()
 
       const associateSenderTx = await AccountLinks.getAssociateSenderExtrinsic()
       const signedTx = await did.authorizeExtrinsic(
@@ -76,8 +79,8 @@ describe('When there is an on-chain DID', () => {
         paymentAccount.address
       )
       const balanceBefore = await Balance.getBalances(paymentAccount.address)
-      const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-      await expect(submissionPromise).resolves.not.toThrow()
+      await submitExtrinsic(signedTx, paymentAccount)
+
       // Check that the deposit has been taken from the sender's balance.
       const balanceAfter = await Balance.getBalances(paymentAccount.address)
       // Lookup reserve - deposit == 0
@@ -88,15 +91,21 @@ describe('When there is an on-chain DID', () => {
           .toString()
       ).toMatchInlineSnapshot('"0"')
       // Check that the link has been created correctly
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-      ).resolves.toStrictEqual(did.identifier)
-      await expect(
-        AccountLinks.queryConnectedAccountsForDid(did.identifier, ss58Format)
-      ).resolves.toStrictEqual([paymentAccount.address])
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-      ).resolves.toBeTruthy()
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+      ).toStrictEqual(did.identifier)
+      expect(
+        await AccountLinks.queryConnectedAccountsForDid(
+          did.identifier,
+          ss58Format
+        )
+      ).toStrictEqual([paymentAccount.address])
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          paymentAccount.address
+        )
+      ).toBeTruthy()
     }, 30_000)
     it('should be possible to associate the tx sender to a new DID', async () => {
       const associateSenderTx = await AccountLinks.getAssociateSenderExtrinsic()
@@ -106,51 +115,63 @@ describe('When there is an on-chain DID', () => {
         paymentAccount.address
       )
       const balanceBefore = await Balance.getBalances(paymentAccount.address)
-      const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-      await expect(submissionPromise).resolves.not.toThrow()
+      await submitExtrinsic(signedTx, paymentAccount)
+
       // Reserve should not change when replacing the link
       const balanceAfter = await Balance.getBalances(paymentAccount.address)
       expect(
         balanceAfter.reserved.sub(balanceBefore.reserved).toString()
       ).toMatchInlineSnapshot('"0"')
       // Check that account is linked to new DID
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-      ).resolves.toStrictEqual(newDid.identifier)
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+      ).toStrictEqual(newDid.identifier)
       // Check that old DID has no accounts linked
-      await expect(
-        AccountLinks.queryConnectedAccountsForDid(did.identifier)
-      ).resolves.toStrictEqual([])
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-      ).resolves.toBeFalsy()
+      expect(
+        await AccountLinks.queryConnectedAccountsForDid(did.identifier)
+      ).toStrictEqual([])
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          paymentAccount.address
+        )
+      ).toBeFalsy()
       // Check that new DID has the account linked
-      await expect(
-        AccountLinks.queryConnectedAccountsForDid(newDid.identifier, ss58Format)
-      ).resolves.toStrictEqual([paymentAccount.address])
-      await expect(
-        AccountLinks.queryIsConnected(newDid.identifier, paymentAccount.address)
-      ).resolves.toBeTruthy()
+      expect(
+        await AccountLinks.queryConnectedAccountsForDid(
+          newDid.identifier,
+          ss58Format
+        )
+      ).toStrictEqual([paymentAccount.address])
+      expect(
+        await AccountLinks.queryIsConnected(
+          newDid.identifier,
+          paymentAccount.address
+        )
+      ).toBeTruthy()
     }, 30_000)
     it('should be possible for the sender to remove the link', async () => {
       const removeSenderTx = await AccountLinks.getLinkRemovalByAccountTx()
       const balanceBefore = await Balance.getBalances(paymentAccount.address)
-      const submissionPromise = submitExtrinsic(removeSenderTx, paymentAccount)
-      await expect(submissionPromise).resolves.not.toThrow()
+      await submitExtrinsic(removeSenderTx, paymentAccount)
+
       // Check that the deposit has been returned to the sender's balance.
       const balanceAfter = await Balance.getBalances(paymentAccount.address)
       expect(
         balanceBefore.reserved.sub(balanceAfter.reserved).toString()
       ).toStrictEqual(linkDeposit.toString())
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-      ).resolves.toBeNull()
-      await expect(
-        AccountLinks.queryConnectedAccountsForDid(did.identifier)
-      ).resolves.toStrictEqual([])
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-      ).resolves.toBeFalsy()
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+      ).toBeNull()
+      expect(
+        await AccountLinks.queryConnectedAccountsForDid(did.identifier)
+      ).toStrictEqual([])
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          paymentAccount.address
+        )
+      ).toBeFalsy()
     })
   })
 
@@ -183,8 +204,8 @@ describe('When there is an on-chain DID', () => {
           paymentAccount.address
         )
         const balanceBefore = await Balance.getBalances(paymentAccount.address)
-        const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-        await expect(submissionPromise).resolves.not.toThrow()
+        await submitExtrinsic(signedTx, paymentAccount)
+
         // Check that the deposit has been taken from the sender's balance.
         const balanceAfter = await Balance.getBalances(paymentAccount.address)
         // Lookup reserve - deposit == 0
@@ -194,21 +215,27 @@ describe('When there is an on-chain DID', () => {
             .sub(linkDeposit)
             .toString()
         ).toMatchInlineSnapshot('"0"')
-        await expect(
-          AccountLinks.queryConnectedDidForAccount(keypair.address)
-        ).resolves.toStrictEqual(did.identifier)
-        await expect(
-          AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-        ).resolves.toBeNull()
-        await expect(
-          AccountLinks.queryConnectedAccountsForDid(did.identifier, ss58Format)
-        ).resolves.toStrictEqual([keypair.address])
-        await expect(
-          AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-        ).resolves.toBeFalsy()
-        await expect(
-          AccountLinks.queryIsConnected(did.identifier, keypair.address)
-        ).resolves.toBeTruthy()
+        expect(
+          await AccountLinks.queryConnectedDidForAccount(keypair.address)
+        ).toStrictEqual(did.identifier)
+        expect(
+          await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+        ).toBeNull()
+        expect(
+          await AccountLinks.queryConnectedAccountsForDid(
+            did.identifier,
+            ss58Format
+          )
+        ).toStrictEqual([keypair.address])
+        expect(
+          await AccountLinks.queryIsConnected(
+            did.identifier,
+            paymentAccount.address
+          )
+        ).toBeFalsy()
+        expect(
+          await AccountLinks.queryIsConnected(did.identifier, keypair.address)
+        ).toBeTruthy()
       })
       it('should be possible to associate the account to a new DID while the sender pays the deposit', async () => {
         const linkAuthorisation =
@@ -223,44 +250,50 @@ describe('When there is an on-chain DID', () => {
           paymentAccount.address
         )
         const balanceBefore = await Balance.getBalances(paymentAccount.address)
-        const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-        await expect(submissionPromise).resolves.not.toThrow()
+        await submitExtrinsic(signedTx, paymentAccount)
+
         // Reserve should not change when replacing the link
         const balanceAfter = await Balance.getBalances(paymentAccount.address)
         expect(
           balanceAfter.reserved.sub(balanceBefore.reserved).toString()
         ).toMatchInlineSnapshot('"0"')
-        await expect(
-          AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-        ).resolves.toBeNull()
-        await expect(
-          AccountLinks.queryConnectedDidForAccount(keypair.address)
-        ).resolves.toStrictEqual(newDid.identifier)
-        await expect(
-          AccountLinks.queryConnectedAccountsForDid(did.identifier)
-        ).resolves.toStrictEqual([])
-        await expect(
-          AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-        ).resolves.toBeFalsy()
-        await expect(
-          AccountLinks.queryIsConnected(did.identifier, keypair.address)
-        ).resolves.toBeFalsy()
+        expect(
+          await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+        ).toBeNull()
+        expect(
+          await AccountLinks.queryConnectedDidForAccount(keypair.address)
+        ).toStrictEqual(newDid.identifier)
+        expect(
+          await AccountLinks.queryConnectedAccountsForDid(did.identifier)
+        ).toStrictEqual([])
+        expect(
+          await AccountLinks.queryIsConnected(
+            did.identifier,
+            paymentAccount.address
+          )
+        ).toBeFalsy()
+        expect(
+          await AccountLinks.queryIsConnected(did.identifier, keypair.address)
+        ).toBeFalsy()
         // Check that new DID has the account linked
-        await expect(
-          AccountLinks.queryConnectedAccountsForDid(
+        expect(
+          await AccountLinks.queryConnectedAccountsForDid(
             newDid.identifier,
             ss58Format
           )
-        ).resolves.toStrictEqual([keypair.address])
-        await expect(
-          AccountLinks.queryIsConnected(
+        ).toStrictEqual([keypair.address])
+        expect(
+          await AccountLinks.queryIsConnected(
             newDid.identifier,
             paymentAccount.address
           )
-        ).resolves.toBeFalsy()
-        await expect(
-          AccountLinks.queryIsConnected(newDid.identifier, keypair.address)
-        ).resolves.toBeTruthy()
+        ).toBeFalsy()
+        expect(
+          await AccountLinks.queryIsConnected(
+            newDid.identifier,
+            keypair.address
+          )
+        ).toBeTruthy()
       })
       it('should be possible for the DID to remove the link', async () => {
         const removeLinkTx = await AccountLinks.getLinkRemovalByDidExtrinsic(
@@ -272,29 +305,32 @@ describe('When there is an on-chain DID', () => {
           paymentAccount.address
         )
         const balanceBefore = await Balance.getBalances(paymentAccount.address)
-        const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-        await expect(submissionPromise).resolves.not.toThrow()
+        await submitExtrinsic(signedTx, paymentAccount)
+
         // Check that the deposit has been returned to the sender's balance.
         const balanceAfter = await Balance.getBalances(paymentAccount.address)
         expect(
           balanceBefore.reserved.sub(balanceAfter.reserved).toString()
         ).toStrictEqual(linkDeposit.toString())
         // Check that the link has been removed completely
-        await expect(
-          AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-        ).resolves.toBeNull()
-        await expect(
-          AccountLinks.queryConnectedDidForAccount(keypair.address)
-        ).resolves.toBeNull()
-        await expect(
-          AccountLinks.queryConnectedAccountsForDid(newDid.identifier)
-        ).resolves.toStrictEqual([])
-        await expect(
-          AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-        ).resolves.toBeFalsy()
-        await expect(
-          AccountLinks.queryIsConnected(did.identifier, keypair.address)
-        ).resolves.toBeFalsy()
+        expect(
+          await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+        ).toBeNull()
+        expect(
+          await AccountLinks.queryConnectedDidForAccount(keypair.address)
+        ).toBeNull()
+        expect(
+          await AccountLinks.queryConnectedAccountsForDid(newDid.identifier)
+        ).toStrictEqual([])
+        expect(
+          await AccountLinks.queryIsConnected(
+            did.identifier,
+            paymentAccount.address
+          )
+        ).toBeFalsy()
+        expect(
+          await AccountLinks.queryIsConnected(did.identifier, keypair.address)
+        ).toBeFalsy()
       })
     }
   )
@@ -333,8 +369,8 @@ describe('When there is an on-chain DID', () => {
         paymentAccount.address
       )
       const balanceBefore = await Balance.getBalances(paymentAccount.address)
-      const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-      await expect(submissionPromise).resolves.not.toThrow()
+      await submitExtrinsic(signedTx, paymentAccount)
+
       // Check that the deposit has been taken from the sender's balance.
       const balanceAfter = await Balance.getBalances(paymentAccount.address)
       // Lookup reserve - deposit == 0
@@ -344,22 +380,28 @@ describe('When there is an on-chain DID', () => {
           .sub(linkDeposit)
           .toString()
       ).toMatchInlineSnapshot('"0"')
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(genericAccount.address)
-      ).resolves.toStrictEqual(did.identifier)
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-      ).resolves.toBeNull()
-      await expect(
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(genericAccount.address)
+      ).toStrictEqual(did.identifier)
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+      ).toBeNull()
+      expect(
         // Wildcard substrate encoding. Account should match the generated one.
-        AccountLinks.queryConnectedAccountsForDid(did.identifier, 42)
-      ).resolves.toStrictEqual([genericAccount.address])
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-      ).resolves.toBeFalsy()
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, genericAccount.address)
-      ).resolves.toBeTruthy()
+        await AccountLinks.queryConnectedAccountsForDid(did.identifier, 42)
+      ).toStrictEqual([genericAccount.address])
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          paymentAccount.address
+        )
+      ).toBeFalsy()
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          genericAccount.address
+        )
+      ).toBeTruthy()
     })
 
     it('should be possible to add a Web3 name for the linked DID and retrieve it starting from the linked account', async () => {
@@ -369,48 +411,51 @@ describe('When there is an on-chain DID', () => {
         didKey.sign,
         paymentAccount.address
       )
-      const submissionPromise = submitExtrinsic(signedTx, paymentAccount)
-      await expect(submissionPromise).resolves.not.toThrow()
+      await submitExtrinsic(signedTx, paymentAccount)
+
       // Check that the Web3 name has been linked to the DID
-      await expect(
-        Web3Names.queryDidIdentifierForWeb3Name('test-name')
-      ).resolves.toStrictEqual(did.identifier)
+      expect(
+        await Web3Names.queryDidIdentifierForWeb3Name('test-name')
+      ).toStrictEqual(did.identifier)
       // Check that it is possible to retrieve the web3 name from the account linked to the DID
-      await expect(
-        AccountLinks.queryWeb3Name(genericAccount.address)
-      ).resolves.toStrictEqual('test-name')
+      expect(
+        await AccountLinks.queryWeb3Name(genericAccount.address)
+      ).toStrictEqual('test-name')
     })
 
     it('should be possible for the sender to remove the link', async () => {
       // No need for DID-authorizing this.
       const reclaimDepositTx = await AccountLinks.getLinkRemovalByAccountTx()
       const balanceBefore = await Balance.getBalances(paymentAccount.address)
-      const submissionPromise = submitExtrinsic(
-        reclaimDepositTx,
-        genericAccount
-      )
-      await expect(submissionPromise).resolves.not.toThrow()
+      await submitExtrinsic(reclaimDepositTx, genericAccount)
+
       // Check that the deposit has been returned to the sender's balance.
       const balanceAfter = await Balance.getBalances(paymentAccount.address)
       expect(
         balanceBefore.reserved.sub(balanceAfter.reserved).toString()
       ).toStrictEqual(linkDeposit.toString())
       // Check that the link has been removed completely
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
-      ).resolves.toBeNull()
-      await expect(
-        AccountLinks.queryConnectedDidForAccount(genericAccount.address)
-      ).resolves.toBeNull()
-      await expect(
-        AccountLinks.queryConnectedAccountsForDid(newDid.identifier)
-      ).resolves.toStrictEqual([])
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, paymentAccount.address)
-      ).resolves.toBeFalsy()
-      await expect(
-        AccountLinks.queryIsConnected(did.identifier, genericAccount.address)
-      ).resolves.toBeFalsy()
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(paymentAccount.address)
+      ).toBeNull()
+      expect(
+        await AccountLinks.queryConnectedDidForAccount(genericAccount.address)
+      ).toBeNull()
+      expect(
+        await AccountLinks.queryConnectedAccountsForDid(newDid.identifier)
+      ).toStrictEqual([])
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          paymentAccount.address
+        )
+      ).toBeFalsy()
+      expect(
+        await AccountLinks.queryIsConnected(
+          did.identifier,
+          genericAccount.address
+        )
+      ).toBeFalsy()
     })
   })
 })

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -466,6 +466,6 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   })
 })
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -130,9 +130,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       claimer.authenticationKey.id
     )
     expect(RequestForAttestation.verifyDataIntegrity(request)).toBe(true)
-    await expect(RequestForAttestation.verifySignature(request)).resolves.toBe(
-      true
-    )
+    expect(await RequestForAttestation.verifySignature(request)).toBe(true)
     expect(request.claim.contents).toMatchObject(content)
   })
 

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -174,6 +174,6 @@ describe('When there are haves and have-nots', () => {
   }, 50_000)
 })
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -164,6 +164,6 @@ describe('Chain returns specific errors, that we check for', () => {
   }, 40000)
 })
 
-afterAll(() => {
-  if (typeof api !== 'undefined') disconnect()
+afterAll(async () => {
+  if (typeof api !== 'undefined') await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -140,7 +140,7 @@ describe('Chain returns specific errors, that we check for', () => {
       version: api.extrinsicVersion,
       tip: '0x00000000000000000000000000005678',
     })
-    expect(
+    await expect(
       Blockchain.dispatchTx(
         tx,
         Blockchain.parseSubscriptionOptions({

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -141,6 +141,6 @@ describe('When there is an CtypeCreator and a verifier', () => {
   })
 })
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -144,10 +144,8 @@ it('should be possible to delegate attestation rights', async () => {
     rootKey.sign,
     attesterKey.sign
   )
-  await Promise.all([
-    expect(rootNode.verify()).resolves.toBeTruthy(),
-    expect(delegatedNode.verify()).resolves.toBeTruthy(),
-  ])
+  expect(await rootNode.verify()).toBeTruthy()
+  expect(await delegatedNode.verify()).toBeTruthy()
 }, 60_000)
 
 describe('and attestation rights have been delegated', () => {
@@ -169,10 +167,8 @@ describe('and attestation rights have been delegated', () => {
       attesterKey.sign
     )
 
-    await Promise.all([
-      expect(rootNode.verify()).resolves.toBeTruthy(),
-      expect(delegatedNode.verify()).resolves.toBeTruthy(),
-    ])
+    expect(await rootNode.verify()).toBeTruthy()
+    expect(await delegatedNode.verify()).toBeTruthy()
   }, 75_000)
 
   it("should be possible to attest a claim in the root's name and revoke it by the root", async () => {
@@ -195,9 +191,7 @@ describe('and attestation rights have been delegated', () => {
       claimer.authenticationKey.id
     )
     expect(RequestForAttestation.verifyDataIntegrity(request)).toBeTruthy()
-    await expect(
-      RequestForAttestation.verifySignature(request)
-    ).resolves.toBeTruthy()
+    expect(await RequestForAttestation.verifySignature(request)).toBeTruthy()
 
     const attestation = Attestation.fromRequestAndDid(request, attester.uri)
     const storeTx = await Attestation.getStoreTx(attestation)
@@ -213,7 +207,7 @@ describe('and attestation rights have been delegated', () => {
       attestation
     )
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
-    await expect(Credential.verify(credential)).resolves.toBeTruthy()
+    expect(await Credential.verify(credential)).toBeTruthy()
 
     // revoke attestation through root
     const revokeTx = await Attestation.getRevokeTx(
@@ -289,8 +283,8 @@ describe('revocation', () => {
     })
 
     // Check that delegation fails to verify but that it is still on the blockchain (i.e., not removed)
-    await expect(delegationA.verify()).resolves.toBeFalsy()
-    await expect(DelegationNode.query(delegationA.id)).resolves.not.toBeNull()
+    expect(await delegationA.verify()).toBeFalsy()
+    expect(await DelegationNode.query(delegationA.id)).not.toBeNull()
   }, 60_000)
 
   it('delegee cannot revoke root but can revoke own delegation', async () => {
@@ -393,10 +387,8 @@ describe('Deposit claiming', () => {
       rootKey.sign
     )
 
-    await expect(DelegationNode.query(delegatedNode.id)).resolves.not.toBeNull()
-    await expect(
-      DelegationNode.query(subDelegatedNode.id)
-    ).resolves.not.toBeNull()
+    expect(await DelegationNode.query(delegatedNode.id)).not.toBeNull()
+    expect(await DelegationNode.query(subDelegatedNode.id)).not.toBeNull()
 
     const depositClaimTx = await delegatedNode.getReclaimDepositTx()
 
@@ -417,11 +409,13 @@ describe('Deposit claiming', () => {
 })
 
 describe('handling queries to data not on chain', () => {
-  it('DelegationNode query on empty', async () =>
-    expect(DelegationNode.query(randomAsHex(32))).resolves.toBeNull())
+  it('DelegationNode query on empty', async () => {
+    expect(await DelegationNode.query(randomAsHex(32))).toBeNull()
+  })
 
-  it('getAttestationHashes on empty', async () =>
-    expect(getAttestationHashes(randomAsHex(32))).resolves.toEqual([]))
+  it('getAttestationHashes on empty', async () => {
+    expect(await getAttestationHashes(randomAsHex(32))).toEqual([])
+  })
 })
 
 describe('hierarchyDetails', () => {

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -441,6 +441,6 @@ describe('hierarchyDetails', () => {
   }, 60_000)
 })
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Deposit.spec.ts
+++ b/packages/core/src/__integrationtests__/Deposit.spec.ts
@@ -448,6 +448,6 @@ describe('Different deposits scenarios', () => {
   }, 120_000)
 })
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Deposit.spec.ts
+++ b/packages/core/src/__integrationtests__/Deposit.spec.ts
@@ -374,79 +374,77 @@ describe('Different deposits scenarios', () => {
   }, 240_000)
 
   it('Check if deleting full DID returns deposit', async () => {
-    await expect(
-      checkDeleteFullDid(keys[0].keypair, testFullDidOne, keys[0].sign)
-    ).resolves.toBe(true)
+    expect(
+      await checkDeleteFullDid(keys[0].keypair, testFullDidOne, keys[0].sign)
+    ).toBe(true)
   }, 45_000)
   it('Check if reclaiming full DID returns deposit', async () => {
-    await expect(
-      checkReclaimFullDid(keys[1].keypair, testFullDidTwo)
-    ).resolves.toBe(true)
+    expect(await checkReclaimFullDid(keys[1].keypair, testFullDidTwo)).toBe(
+      true
+    )
   }, 45_000)
   it('Check if removing an attestation from a full DID returns deposit', async () => {
-    await expect(
-      checkRemoveFullDidAttestation(
+    expect(
+      await checkRemoveFullDidAttestation(
         keys[2].keypair,
         testFullDidThree,
         keys[2].sign,
         requestForAttestation
       )
-    ).resolves.toBe(true)
+    ).toBe(true)
   }, 90_000)
   it('Check if reclaiming an attestation from a full DID returns the deposit', async () => {
-    await expect(
-      checkReclaimFullDidAttestation(
+    expect(
+      await checkReclaimFullDidAttestation(
         keys[3].keypair,
         testFullDidFour,
         keys[3].sign,
         requestForAttestation
       )
-    ).resolves.toBe(true)
+    ).toBe(true)
   }, 90_000)
   it('Check if deleting from a migrated light DID to a full DID returns deposit', async () => {
-    await expect(
-      checkDeleteFullDid(keys[4].keypair, testFullDidFive, keys[4].sign)
-    ).resolves.toBe(true)
+    expect(
+      await checkDeleteFullDid(keys[4].keypair, testFullDidFive, keys[4].sign)
+    ).toBe(true)
   }, 90_000)
   it('Check if reclaiming from a migrated light DID to a full DID returns deposit', async () => {
-    await expect(
-      checkReclaimFullDid(keys[5].keypair, testFullDidSix)
-    ).resolves.toBe(true)
+    expect(await checkReclaimFullDid(keys[5].keypair, testFullDidSix)).toBe(
+      true
+    )
   }, 90_000)
   it('Check if removing an attestation from a migrated light DID to a full DID returns the deposit', async () => {
-    await expect(
-      checkRemoveFullDidAttestation(
+    expect(
+      await checkRemoveFullDidAttestation(
         keys[6].keypair,
         testFullDidSeven,
         keys[6].sign,
         requestForAttestation
       )
-    ).resolves.toBe(true)
+    ).toBe(true)
   }, 90_000)
   it('Check if reclaiming an attestation from a migrated light DID to a full DID returns the deposit', async () => {
-    await expect(
-      checkReclaimFullDidAttestation(
+    expect(
+      await checkReclaimFullDidAttestation(
         keys[7].keypair,
         testFullDidEight,
         keys[7].sign,
         requestForAttestation
       )
-    ).resolves.toBe(true)
+    ).toBe(true)
   }, 90_000)
   it('Check if deleting a full DID and reclaiming an attestation returns the deposit', async () => {
-    await expect(
-      checkDeletedDidReclaimAttestation(
-        keys[8].keypair,
-        testFullDidNine,
-        keys[8].sign,
-        requestForAttestation
-      )
-    ).resolves.not.toThrow()
+    await checkDeletedDidReclaimAttestation(
+      keys[8].keypair,
+      testFullDidNine,
+      keys[8].sign,
+      requestForAttestation
+    )
   }, 120_000)
   it('Check if claiming and releasing a web3 name correctly handles deposits', async () => {
-    await expect(
-      checkWeb3Deposit(keys[9].keypair, testFullDidTen, keys[9].sign)
-    ).resolves.toBeTruthy()
+    expect(
+      await checkWeb3Deposit(keys[9].keypair, testFullDidTen, keys[9].sign)
+    ).toBeTruthy()
   }, 120_000)
 })
 

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1538,4 +1538,6 @@ describe('Runtime constraints', () => {
   })
 })
 
-afterAll(async () => disconnect())
+afterAll(async () => {
+  await disconnect()
+})

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -124,7 +124,7 @@ describe('write and didDeleteTx', () => {
       key.sign
     )
 
-    await expect(submitExtrinsic(tx, paymentAccount)).resolves.not.toThrow()
+    await submitExtrinsic(tx, paymentAccount)
 
     details = (await FullDidDetails.fromChainInfo(
       DidUtils.getKiltDidFromIdentifier(newDetails.identifier, 'full')
@@ -161,16 +161,15 @@ describe('write and didDeleteTx', () => {
     const emptyAccount = addressFromRandom()
 
     // Should be defined and have 0 elements
-    await expect(
-      DidChain.queryServiceEndpoints(emptyAccount)
-    ).resolves.toBeDefined()
-    await expect(
-      DidChain.queryServiceEndpoints(emptyAccount)
-    ).resolves.toHaveLength(0)
+    expect(await DidChain.queryServiceEndpoints(emptyAccount)).toBeDefined()
+    expect(await DidChain.queryServiceEndpoints(emptyAccount)).toHaveLength(0)
     // Should return null
-    await expect(
-      DidChain.queryServiceEndpoint(emptyAccount, 'non-existing-service-id')
-    ).resolves.toBeNull()
+    expect(
+      await DidChain.queryServiceEndpoint(
+        emptyAccount,
+        'non-existing-service-id'
+      )
+    ).toBeNull()
     // Should return 0
     const endpointsCount = await DidChain.queryEndpointsCounts(emptyAccount)
     expect(endpointsCount.toString()).toStrictEqual(new BN(0).toString())
@@ -213,9 +212,7 @@ describe('write and didDeleteTx', () => {
 
   it('deletes DID from previous step', async () => {
     // We verify that the DID to delete is on chain.
-    await expect(
-      DidChain.queryDetails(details.identifier)
-    ).resolves.not.toBeNull()
+    expect(await DidChain.queryDetails(details.identifier)).not.toBeNull()
 
     const storedEndpointsCount = await DidChain.queryEndpointsCounts(
       details.identifier
@@ -229,26 +226,24 @@ describe('write and didDeleteTx', () => {
     )
 
     // Check that DID is not blacklisted.
-    await expect(DidChain.queryDeletedDidIdentifiers()).resolves.not.toContain(
+    expect(await DidChain.queryDeletedDidIdentifiers()).not.toContain(
       details.identifier
     )
-    await expect(
-      DidChain.queryDidDeletionStatus(details.identifier)
-    ).resolves.toBeFalsy()
+    expect(
+      await DidChain.queryDidDeletionStatus(details.identifier)
+    ).toBeFalsy()
 
-    await expect(
-      submitExtrinsic(submittable, paymentAccount)
-    ).resolves.not.toThrow()
+    await submitExtrinsic(submittable, paymentAccount)
 
-    await expect(DidChain.queryDetails(details.identifier)).resolves.toBeNull()
+    expect(await DidChain.queryDetails(details.identifier)).toBeNull()
 
     // Check that DID is now blacklisted.
-    await expect(DidChain.queryDeletedDidIdentifiers()).resolves.toContain(
+    expect(await DidChain.queryDeletedDidIdentifiers()).toContain(
       details.identifier
     )
-    await expect(
-      DidChain.queryDidDeletionStatus(details.identifier)
-    ).resolves.toBeTruthy()
+    expect(
+      await DidChain.queryDidDeletionStatus(details.identifier)
+    ).toBeTruthy()
   }, 60_000)
 })
 
@@ -262,7 +257,7 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
     sign
   )
 
-  await expect(submitExtrinsic(tx, paymentAccount)).resolves.not.toThrow()
+  await submitExtrinsic(tx, paymentAccount)
 
   // This will better be handled once we have the UpdateBuilder class, which encapsulates all the logic.
   let fullDetails = (await FullDidDetails.fromChainInfo(
@@ -280,7 +275,7 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
     sign,
     paymentAccount.address
   )
-  await expect(submitExtrinsic(tx2, paymentAccount)).resolves.not.toThrow()
+  await submitExtrinsic(tx2, paymentAccount)
 
   // Authentication key changed, so details must be updated.
   // Also this will better be handled once we have the UpdateBuilder class, which encapsulates all the logic.
@@ -301,10 +296,10 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
     newKey.sign,
     paymentAccount.address
   )
-  await expect(submitExtrinsic(tx3, paymentAccount)).resolves.not.toThrow()
-  await expect(
-    DidChain.queryServiceEndpoint(fullDetails.identifier, newEndpoint.id)
-  ).resolves.toStrictEqual(newEndpoint)
+  await submitExtrinsic(tx3, paymentAccount)
+  expect(
+    await DidChain.queryServiceEndpoint(fullDetails.identifier, newEndpoint.id)
+  ).toStrictEqual(newEndpoint)
 
   // Delete the added service endpoint
   const removeEndpointCall = await DidChain.getRemoveEndpointExtrinsic(
@@ -315,12 +310,12 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
     newKey.sign,
     paymentAccount.address
   )
-  await expect(submitExtrinsic(tx4, paymentAccount)).resolves.not.toThrow()
+  await submitExtrinsic(tx4, paymentAccount)
 
   // There should not be any endpoint with the given ID now.
-  await expect(
-    DidChain.queryServiceEndpoint(fullDetails.identifier, newEndpoint.id)
-  ).resolves.toBeNull()
+  expect(
+    await DidChain.queryServiceEndpoint(fullDetails.identifier, newEndpoint.id)
+  ).toBeNull()
 
   // Claim the deposit back
   const storedEndpointsCount = await DidChain.queryEndpointsCounts(
@@ -330,16 +325,12 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
     fullDetails.identifier,
     storedEndpointsCount
   )
-  await expect(
-    submitExtrinsic(reclaimDepositTx, paymentAccount)
-  ).resolves.not.toThrow()
+  await submitExtrinsic(reclaimDepositTx, paymentAccount)
   // Verify that the DID has been deleted
-  await expect(
-    DidChain.queryDetails(fullDetails.identifier)
-  ).resolves.toBeNull()
-  await expect(
-    DidChain.queryServiceEndpoints(fullDetails.identifier)
-  ).resolves.toHaveLength(0)
+  expect(await DidChain.queryDetails(fullDetails.identifier)).toBeNull()
+  expect(
+    await DidChain.queryServiceEndpoints(fullDetails.identifier)
+  ).toHaveLength(0)
   const newEndpointsCount = await DidChain.queryEndpointsCounts(
     fullDetails.identifier
   )
@@ -382,9 +373,9 @@ describe('DID migration', () => {
     // The main identifier should be left untouched
     expect(migratedFullDid.identifier).toStrictEqual(lightDidDetails.identifier)
 
-    await expect(
-      DidChain.queryDetails(migratedFullDid.identifier)
-    ).resolves.not.toBeNull()
+    expect(
+      await DidChain.queryDetails(migratedFullDid.identifier)
+    ).not.toBeNull()
 
     const { metadata } = (await resolveDoc(
       lightDidDetails.uri
@@ -424,9 +415,9 @@ describe('DID migration', () => {
     // The main identifier should be left untouched
     expect(migratedFullDid.identifier).toStrictEqual(lightDidDetails.identifier)
 
-    await expect(
-      DidChain.queryDetails(migratedFullDid.identifier)
-    ).resolves.not.toBeNull()
+    expect(
+      await DidChain.queryDetails(migratedFullDid.identifier)
+    ).not.toBeNull()
 
     const { metadata } = (await resolveDoc(
       lightDidDetails.uri
@@ -480,9 +471,9 @@ describe('DID migration', () => {
     // The main identifier should be left untouched
     expect(migratedFullDid.identifier).toStrictEqual(lightDidDetails.identifier)
 
-    await expect(
-      DidChain.queryDetails(migratedFullDid.identifier)
-    ).resolves.not.toBeNull()
+    expect(
+      await DidChain.queryDetails(migratedFullDid.identifier)
+    ).not.toBeNull()
 
     const { metadata } = (await resolveDoc(
       lightDidDetails.uri
@@ -499,19 +490,15 @@ describe('DID migration', () => {
       migratedFullDid.identifier,
       storedEndpointsCount
     )
-    await expect(
-      submitExtrinsic(reclaimDepositTx, paymentAccount)
-    ).resolves.not.toThrow()
+    await submitExtrinsic(reclaimDepositTx, paymentAccount)
 
-    await expect(
-      DidChain.queryDetails(migratedFullDid.identifier)
-    ).resolves.toBeNull()
-    await expect(
-      DidChain.queryServiceEndpoints(migratedFullDid.identifier)
-    ).resolves.toStrictEqual([])
-    await expect(
-      DidChain.queryDidDeletionStatus(migratedFullDid.identifier)
-    ).resolves.toBeTruthy()
+    expect(await DidChain.queryDetails(migratedFullDid.identifier)).toBeNull()
+    expect(
+      await DidChain.queryServiceEndpoints(migratedFullDid.identifier)
+    ).toStrictEqual([])
+    expect(
+      await DidChain.queryDidDeletionStatus(migratedFullDid.identifier)
+    ).toBeTruthy()
   }, 60_000)
 })
 
@@ -550,9 +537,9 @@ describe('DID authorization', () => {
       sign,
       paymentAccount.address
     )
-    await expect(submitExtrinsic(tx, paymentAccount)).resolves.not.toThrow()
+    await submitExtrinsic(tx, paymentAccount)
 
-    await expect(CType.verifyStored(ctype)).resolves.toEqual(true)
+    expect(await CType.verifyStored(ctype)).toEqual(true)
   }, 60_000)
 
   it('no longer authorizes ctype creation after DID deletion', async () => {
@@ -567,7 +554,7 @@ describe('DID authorization', () => {
       sign,
       paymentAccount.address
     )
-    await expect(submitExtrinsic(tx, paymentAccount)).resolves.not.toThrow()
+    await submitExtrinsic(tx, paymentAccount)
 
     const ctype = CType.fromSchema({
       title: UUID.generate(),
@@ -586,7 +573,7 @@ describe('DID authorization', () => {
       name: 'DidNotPresent',
     })
 
-    await expect(CType.verifyStored(ctype)).resolves.toEqual(false)
+    expect(await CType.verifyStored(ctype)).toEqual(false)
   }, 60_000)
 })
 
@@ -916,20 +903,16 @@ describe('DID management batching', () => {
         sign,
         paymentAccount.address
       )
-      await expect(
-        submitExtrinsic(authorisedTx, paymentAccount)
-      ).resolves.not.toThrow()
+      await submitExtrinsic(authorisedTx, paymentAccount)
 
       // Now, consuming the builder will result in the second operation to fail but the batch to succeed, so we can test the atomic flag.
-      await expect(
-        updateBuilder.buildAndSubmit(
-          sign,
-          paymentAccount.address,
-          async (tx) => submitExtrinsic(tx, paymentAccount),
-          // Not atomic
-          false
-        )
-      ).resolves.not.toThrow()
+      await updateBuilder.buildAndSubmit(
+        sign,
+        paymentAccount.address,
+        async (tx) => submitExtrinsic(tx, paymentAccount),
+        // Not atomic
+        false
+      )
 
       const updatedFullDid = await FullDidDetails.fromChainInfo(fullDid.uri)
       // .setAttestationKey() extrinsic went through in the batch
@@ -985,9 +968,7 @@ describe('DID management batching', () => {
         sign,
         paymentAccount.address
       )
-      await expect(
-        submitExtrinsic(authorisedTx, paymentAccount)
-      ).resolves.not.toThrow()
+      await submitExtrinsic(authorisedTx, paymentAccount)
 
       // Now, consuming the builder will result in the second operation to fail AND the batch to fail, so we can test the atomic flag.
       await expect(
@@ -1052,10 +1033,10 @@ describe('DID extrinsics batching', () => {
       .build(key.sign, paymentAccount.address, { atomic: false })
 
     // The entire submission promise is resolves and does not throw
-    await expect(submitExtrinsic(tx, paymentAccount)).resolves.not.toThrow()
+    await submitExtrinsic(tx, paymentAccount)
 
     // The ctype has been created, even though the delegation operations failed.
-    await expect(CType.verifyStored(ctype)).resolves.toBeTruthy()
+    expect(await CType.verifyStored(ctype)).toBeTruthy()
   })
 
   it('atomic batch fails if any extrinsics fail', async () => {
@@ -1089,7 +1070,7 @@ describe('DID extrinsics batching', () => {
     })
 
     // The ctype has not been created, since atomicity ensures the whole batch is reverted in case of failure.
-    await expect(CType.verifyStored(ctype)).resolves.toBeFalsy()
+    expect(await CType.verifyStored(ctype)).toBeFalsy()
   })
 
   it('can batch extrinsics for the same required key type', async () => {
@@ -1106,16 +1087,14 @@ describe('DID extrinsics batching', () => {
     const tx = await new DidBatchBuilder(api, fullDid)
       .addMultipleExtrinsics([web3Name1ReleaseExt, web3Name2ClaimExt])
       .build(key.sign, paymentAccount.address)
-    await expect(submitExtrinsic(tx, paymentAccount)).resolves.not.toThrow()
+    await submitExtrinsic(tx, paymentAccount)
 
     // Test for correct creation and deletion
-    await expect(
-      Web3Names.queryDidIdentifierForWeb3Name('test-1')
-    ).resolves.toBeNull()
+    expect(await Web3Names.queryDidIdentifierForWeb3Name('test-1')).toBeNull()
     // Test for correct creation of second web3 name
-    await expect(
-      Web3Names.queryDidIdentifierForWeb3Name('test-2')
-    ).resolves.toStrictEqual(fullDid.identifier)
+    expect(
+      await Web3Names.queryDidIdentifierForWeb3Name('test-2')
+    ).toStrictEqual(fullDid.identifier)
   }, 30_000)
 
   it('can batch extrinsics for different required key types', async () => {
@@ -1163,19 +1142,17 @@ describe('DID extrinsics batching', () => {
       paymentAccount.address
     )
 
-    await expect(
-      submitExtrinsic(batchedExtrinsics, paymentAccount)
-    ).resolves.not.toThrow()
+    await submitExtrinsic(batchedExtrinsics, paymentAccount)
 
     // Test correct use of authentication keys
-    await expect(Web3Names.queryDidForWeb3Name('test')).resolves.toBeNull()
-    await expect(
-      Web3Names.queryDidIdentifierForWeb3Name('test-2')
-    ).resolves.toStrictEqual(fullDid.identifier)
+    expect(await Web3Names.queryDidForWeb3Name('test')).toBeNull()
+    expect(
+      await Web3Names.queryDidIdentifierForWeb3Name('test-2')
+    ).toStrictEqual(fullDid.identifier)
 
     // Test correct use of attestation keys
-    await expect(CType.verifyStored(ctype1)).resolves.toBeTruthy()
-    await expect(CType.verifyStored(ctype2)).resolves.toBeTruthy()
+    expect(await CType.verifyStored(ctype1)).toBeTruthy()
+    expect(await CType.verifyStored(ctype2)).toBeTruthy()
 
     // Test correct use of delegation keys
     const node = await DelegationNode.query(rootNode.id)
@@ -1202,17 +1179,15 @@ describe('Runtime constraints', () => {
           type: EncryptionKeyType.X25519,
         })
       )
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            keyAgreementKeys: newKeyAgreementKeys,
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          keyAgreementKeys: newKeyAgreementKeys,
+        },
+        paymentAccount.address,
+        sign
+      )
       // One more than the maximum
       newKeyAgreementKeys.push({
         publicKey: Uint8Array.from(new Array(32).fill(100)),
@@ -1242,17 +1217,15 @@ describe('Runtime constraints', () => {
           urls: [`x:url-${index}`],
         })
       )
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            serviceEndpoints: newServiceEndpoints,
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          serviceEndpoints: newServiceEndpoints,
+        },
+        paymentAccount.address,
+        sign
+      )
       // One more than the maximum
       newServiceEndpoints.push({
         id: 'service-100',
@@ -1275,24 +1248,22 @@ describe('Runtime constraints', () => {
     }, 30_000)
 
     it('should not be possible to create a DID with a service endpoint that is too long', async () => {
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            serviceEndpoints: [
-              {
-                // Maximum is 50
-                id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-                types: ['type-a'],
-                urls: ['x:url-a'],
-              },
-            ],
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          serviceEndpoints: [
+            {
+              // Maximum is 50
+              id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              types: ['type-a'],
+              urls: ['x:url-a'],
+            },
+          ],
+        },
+        paymentAccount.address,
+        sign
+      )
       await expect(
         DidChain.generateCreateTxFromCreationDetails(
           {
@@ -1323,17 +1294,15 @@ describe('Runtime constraints', () => {
         types: Array(1).map((_, index): string => `type-${index}`),
         urls: ['x:url-1'],
       }
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            serviceEndpoints: [newEndpoint],
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          serviceEndpoints: [newEndpoint],
+        },
+        paymentAccount.address,
+        sign
+      )
       // One more than the maximum
       newEndpoint.types.push('new-type')
       await expect(
@@ -1359,17 +1328,15 @@ describe('Runtime constraints', () => {
         types: ['type-1'],
         urls: Array(1).map((_, index): string => `x:url-${index}`),
       }
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            serviceEndpoints: [newEndpoint],
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          serviceEndpoints: [newEndpoint],
+        },
+        paymentAccount.address,
+        sign
+      )
       // One more than the maximum
       newEndpoint.urls.push('x:new-url')
       await expect(
@@ -1389,24 +1356,22 @@ describe('Runtime constraints', () => {
     }, 30_000)
 
     it('should not be possible to create a DID with a service endpoint that has a type that is too long', async () => {
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            serviceEndpoints: [
-              {
-                id: 'id-1',
-                // Maximum is 50
-                types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-                urls: ['x:url-1'],
-              },
-            ],
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          serviceEndpoints: [
+            {
+              id: 'id-1',
+              // Maximum is 50
+              types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+              urls: ['x:url-1'],
+            },
+          ],
+        },
+        paymentAccount.address,
+        sign
+      )
       await expect(
         DidChain.generateCreateTxFromCreationDetails(
           {
@@ -1431,26 +1396,24 @@ describe('Runtime constraints', () => {
     }, 30_000)
 
     it('should not be possible to create a DID with a service endpoint that has a URL that is too long', async () => {
-      await expect(
-        DidChain.generateCreateTxFromCreationDetails(
-          {
-            authenticationKey: testAuthKey,
-            identifier: encodeAddress(testAuthKey.publicKey),
-            serviceEndpoints: [
-              {
-                id: 'id-1',
-                types: ['type-1'],
-                // Maximum is 200
-                urls: [
-                  'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-                ],
-              },
-            ],
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).resolves.not.toThrow()
+      await DidChain.generateCreateTxFromCreationDetails(
+        {
+          authenticationKey: testAuthKey,
+          identifier: encodeAddress(testAuthKey.publicKey),
+          serviceEndpoints: [
+            {
+              id: 'id-1',
+              types: ['type-1'],
+              // Maximum is 200
+              urls: [
+                'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              ],
+            },
+          ],
+        },
+        paymentAccount.address,
+        sign
+      )
       await expect(
         DidChain.generateCreateTxFromCreationDetails(
           {
@@ -1479,14 +1442,12 @@ describe('Runtime constraints', () => {
 
   describe('Service endpoint addition', () => {
     it('should not be possible to add a service endpoint that is too long', async () => {
-      await expect(
-        DidChain.getAddEndpointExtrinsic({
-          // Maximum is 50
-          id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          types: ['type-a'],
-          urls: ['x:url-a'],
-        })
-      ).resolves.not.toThrow()
+      await DidChain.getAddEndpointExtrinsic({
+        // Maximum is 50
+        id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        types: ['type-a'],
+        urls: ['x:url-a'],
+      })
       await expect(
         DidChain.getAddEndpointExtrinsic({
           // One more than maximum
@@ -1506,9 +1467,7 @@ describe('Runtime constraints', () => {
         types: Array(1).map((_, index): string => `type-${index}`),
         urls: ['x:url-1'],
       }
-      await expect(
-        DidChain.getAddEndpointExtrinsic(newEndpoint)
-      ).resolves.not.toThrow()
+      await DidChain.getAddEndpointExtrinsic(newEndpoint)
       // One more than the maximum
       newEndpoint.types.push('new-type')
       await expect(
@@ -1525,9 +1484,7 @@ describe('Runtime constraints', () => {
         types: ['type-1'],
         urls: Array(1).map((_, index): string => `x:url-${index}`),
       }
-      await expect(
-        DidChain.getAddEndpointExtrinsic(newEndpoint)
-      ).resolves.not.toThrow()
+      await DidChain.getAddEndpointExtrinsic(newEndpoint)
       // One more than the maximum
       newEndpoint.urls.push('x:new-url')
       await expect(
@@ -1538,14 +1495,12 @@ describe('Runtime constraints', () => {
     }, 30_000)
 
     it('should not be possible to add a service endpoint that has a type that is too long', async () => {
-      await expect(
-        DidChain.getAddEndpointExtrinsic({
-          id: 'id-1',
-          // Maximum is 50
-          types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-          urls: ['x:url-1'],
-        })
-      ).resolves.not.toThrow()
+      await DidChain.getAddEndpointExtrinsic({
+        id: 'id-1',
+        // Maximum is 50
+        types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        urls: ['x:url-1'],
+      })
       await expect(
         DidChain.getAddEndpointExtrinsic({
           id: 'id-1',
@@ -1559,16 +1514,14 @@ describe('Runtime constraints', () => {
     }, 30_000)
 
     it('should not be possible to add a service endpoint that has a URL that is too long', async () => {
-      await expect(
-        DidChain.getAddEndpointExtrinsic({
-          id: 'id-1',
-          types: ['type-1'],
-          // Maximum is 200
-          urls: [
-            'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          ],
-        })
-      ).resolves.not.toThrow()
+      await DidChain.getAddEndpointExtrinsic({
+        id: 'id-1',
+        types: ['type-1'],
+        // Maximum is 200
+        urls: [
+          'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ],
+      })
       await expect(
         DidChain.getAddEndpointExtrinsic({
           id: 'id-1',

--- a/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
@@ -70,6 +70,6 @@ it('records an extrinsic error when ctype does not exist', async () => {
   })
 }, 30_000)
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -87,13 +87,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       paymentAccount.address
     )
 
-    const p = submitExtrinsic(
-      authorizedTx,
-      paymentAccount,
-      Blockchain.IS_IN_BLOCK
-    )
-
-    await expect(p).resolves.not.toThrow()
+    await submitExtrinsic(authorizedTx, paymentAccount, Blockchain.IS_IN_BLOCK)
   }, 30_000)
 
   it('should be possible to lookup the DID identifier with the given nick', async () => {
@@ -169,9 +163,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should be possible to remove a w3n by the payment account', async () => {
     const tx = await Web3Names.getReclaimDepositTx(nick)
-    const p = submitExtrinsic(tx, paymentAccount, Blockchain.IS_IN_BLOCK)
-
-    await expect(p).resolves.not.toThrow()
+    await submitExtrinsic(tx, paymentAccount, Blockchain.IS_IN_BLOCK)
   }, 30_000)
 
   it('should be possible to remove a w3n by the owner did', async () => {
@@ -194,20 +186,14 @@ describe('When there is an Web3NameCreator and a payer', () => {
       w3nCreatorKey.sign,
       paymentAccount.address
     )
-    const p = submitExtrinsic(
-      authorizedTx,
-      paymentAccount,
-      Blockchain.IS_IN_BLOCK
-    )
-
-    await expect(p).resolves.not.toThrow()
+    await submitExtrinsic(authorizedTx, paymentAccount, Blockchain.IS_IN_BLOCK)
   }, 40_000)
 })
 
 describe('Runtime constraints', () => {
   it('should not be possible to create a web3 name that is too short', async () => {
     // Minimum is 3
-    await expect(Web3Names.getClaimTx('aaa')).resolves.not.toThrow()
+    await Web3Names.getClaimTx('aaa')
     // One less than the minimum
     await expect(
       Web3Names.getClaimTx('aa')
@@ -218,11 +204,9 @@ describe('Runtime constraints', () => {
 
   it('should not be possible to create a web3 name that is too long', async () => {
     // Maximum is 32
-    await expect(
-      Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-    ).resolves.not.toThrow()
+    await Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     // One more than the maximum
-    await expect(async () =>
+    await expect(
       Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32."'
@@ -231,7 +215,7 @@ describe('Runtime constraints', () => {
 
   it('should not be possible to claim deposit for a web3 name that is too short', async () => {
     // Minimum is 3
-    await expect(Web3Names.getReclaimDepositTx('aaa')).resolves.not.toThrow()
+    await Web3Names.getReclaimDepositTx('aaa')
     // One less than the minimum
     await expect(
       Web3Names.getReclaimDepositTx('aa')
@@ -242,11 +226,9 @@ describe('Runtime constraints', () => {
 
   it('should not be possible to claim deposit for a web3 name that is too long', async () => {
     // Maximum is 32
-    await expect(
-      Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-    ).resolves.not.toThrow()
+    await Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     // One more than the maximum
-    await expect(async () =>
+    await expect(
       Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32."'

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -236,6 +236,6 @@ describe('Runtime constraints', () => {
   }, 30_000)
 })
 
-afterAll(() => {
-  disconnect()
+afterAll(async () => {
+  await disconnect()
 })

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -227,11 +227,11 @@ describe('RequestForAttestation', () => {
 
     // check proof on complete data
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
-    await expect(
-      Credential.verify(credential, {
+    expect(
+      await Credential.verify(credential, {
         resolver: mockResolver,
       })
-    ).resolves.toBe(true)
+    ).toBe(true)
   })
   it('verify credentials signed by a light DID', async () => {
     const { keypair, sign } = makeSigningKeyTool(SigningAlgorithms.Ed25519)
@@ -256,11 +256,11 @@ describe('RequestForAttestation', () => {
 
     // check proof on complete data
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
-    await expect(
-      Credential.verify(credential, {
+    expect(
+      await Credential.verify(credential, {
         resolver: mockResolver,
       })
-    ).resolves.toBe(true)
+    ).toBe(true)
   })
 
   it('fail to verify credentials signed by a light DID after it has been migrated and deleted', async () => {
@@ -302,11 +302,11 @@ describe('RequestForAttestation', () => {
 
     // check proof on complete data
     expect(Credential.verifyDataIntegrity(credential)).toBeTruthy()
-    await expect(
-      Credential.verify(credential, {
+    expect(
+      await Credential.verify(credential, {
         resolver: mockResolver,
       })
-    ).resolves.toBeFalsy()
+    ).toBeFalsy()
   })
 
   it('compresses and decompresses the credentials object', () => {
@@ -515,11 +515,11 @@ describe('create presentation', () => {
       challenge,
     })
     expect(Credential.getAttributes(att)).toEqual(new Set(['name']))
-    await expect(
-      Credential.verify(att, {
+    expect(
+      await Credential.verify(att, {
         resolver: mockResolver,
       })
-    ).resolves.toBe(true)
+    ).toBe(true)
     expect(att.request.claimerSignature?.challenge).toEqual(challenge)
   })
   it('should create presentation and exclude specific attributes using a light DID', async () => {
@@ -560,11 +560,11 @@ describe('create presentation', () => {
       challenge,
     })
     expect(Credential.getAttributes(att)).toEqual(new Set(['name']))
-    await expect(
-      Credential.verify(att, {
+    expect(
+      await Credential.verify(att, {
         resolver: mockResolver,
       })
-    ).resolves.toBe(true)
+    ).toBe(true)
     expect(att.request.claimerSignature?.challenge).toEqual(challenge)
   })
   it('should create presentation and exclude specific attributes using a migrated DID', async () => {
@@ -607,11 +607,11 @@ describe('create presentation', () => {
       challenge,
     })
     expect(Credential.getAttributes(att)).toEqual(new Set(['name']))
-    await expect(
-      Credential.verify(att, {
+    expect(
+      await Credential.verify(att, {
         resolver: mockResolver,
       })
-    ).resolves.toBe(true)
+    ).toBe(true)
     expect(att.request.claimerSignature?.challenge).toEqual(challenge)
   })
 
@@ -655,11 +655,11 @@ describe('create presentation', () => {
       challenge,
     })
     expect(Credential.getAttributes(att)).toEqual(new Set(['name']))
-    await expect(
-      Credential.verify(att, {
+    expect(
+      await Credential.verify(att, {
         resolver: mockResolver,
       })
-    ).resolves.toBeFalsy()
+    ).toBeFalsy()
   })
 
   it('should fail to create a valid presentation using a light DID after it has been migrated and deleted', async () => {
@@ -702,11 +702,11 @@ describe('create presentation', () => {
       challenge,
     })
     expect(Credential.getAttributes(att)).toEqual(new Set(['name']))
-    await expect(
-      Credential.verify(att, {
+    expect(
+      await Credential.verify(att, {
         resolver: mockResolver,
       })
-    ).resolves.toBeFalsy()
+    ).toBeFalsy()
   })
 
   it('should get attribute keys', async () => {

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -184,18 +184,18 @@ describe('CType', () => {
 
   it('verifies whether a ctype is registered on chain ', async () => {
     jest.mocked(isStored).mockResolvedValue(false)
-    await expect(CType.verifyStored(claimCtype)).resolves.toBe(false)
+    expect(await CType.verifyStored(claimCtype)).toBe(false)
     jest.mocked(isStored).mockResolvedValue(true)
-    await expect(CType.verifyStored(claimCtype)).resolves.toBe(true)
+    expect(await CType.verifyStored(claimCtype)).toBe(true)
   })
 
   it('verifies ctype owner on chain', async () => {
     jest.mocked(getOwner).mockResolvedValue(didBob)
-    await expect(CType.verifyOwner(claimCtype)).resolves.toBe(false)
+    expect(await CType.verifyOwner(claimCtype)).toBe(false)
     jest.mocked(getOwner).mockResolvedValue(claimCtype.owner)
-    await expect(CType.verifyOwner(claimCtype)).resolves.toBe(true)
+    expect(await CType.verifyOwner(claimCtype)).toBe(true)
     jest.mocked(getOwner).mockResolvedValue(null)
-    await expect(CType.verifyOwner(claimCtype)).resolves.toBe(false)
+    expect(await CType.verifyOwner(claimCtype)).toBe(false)
   })
 })
 
@@ -328,12 +328,12 @@ describe('CType registration verification', () => {
 
     it('does not verify registration when not registered', async () => {
       const ctype = CType.fromSchema(rawCType, didAlice)
-      await expect(CType.verifyStored(ctype)).resolves.toBeFalsy()
+      expect(await CType.verifyStored(ctype)).toBeFalsy()
     })
 
     it('does not verify owner when not registered', async () => {
       const ctype = CType.fromSchema(rawCType, didAlice)
-      await expect(CType.verifyOwner(ctype)).resolves.toBeFalsy()
+      expect(await CType.verifyOwner(ctype)).toBeFalsy()
     })
   })
 
@@ -345,27 +345,27 @@ describe('CType registration verification', () => {
 
     it('verifies registration when owner not set', async () => {
       const ctype = CType.fromSchema(rawCType)
-      await expect(CType.verifyStored(ctype)).resolves.toBeTruthy()
+      expect(await CType.verifyStored(ctype)).toBeTruthy()
     })
 
     it('verifies registration when owner matches', async () => {
       const ctype = CType.fromSchema(rawCType, didAlice)
-      await expect(CType.verifyStored(ctype)).resolves.toBeTruthy()
+      expect(await CType.verifyStored(ctype)).toBeTruthy()
     })
 
     it('verifies registration when owner does not match', async () => {
       const ctype = CType.fromSchema(rawCType, didBob)
-      await expect(CType.verifyStored(ctype)).resolves.toBeTruthy()
+      expect(await CType.verifyStored(ctype)).toBeTruthy()
     })
 
     it('verifies owner when owner matches', async () => {
       const ctype = CType.fromSchema(rawCType, didAlice)
-      await expect(CType.verifyOwner(ctype)).resolves.toBeTruthy()
+      expect(await CType.verifyOwner(ctype)).toBeTruthy()
     })
 
     it('does not verify owner when owner does not match', async () => {
       const ctype = CType.fromSchema(rawCType, didBob)
-      await expect(CType.verifyOwner(ctype)).resolves.toBeFalsy()
+      expect(await CType.verifyOwner(ctype)).toBeFalsy()
     })
   })
 })

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -137,8 +137,8 @@ describe('DelegationNode', () => {
         } as DelegationNode,
       }
 
-      await expect(
-        new DelegationNode({
+      expect(
+        await new DelegationNode({
           id: successId,
           hierarchyId,
           account: didAlice,
@@ -147,10 +147,10 @@ describe('DelegationNode', () => {
           parentId: undefined,
           revoked: false,
         }).verify()
-      ).resolves.toBe(true)
+      ).toBe(true)
 
-      await expect(
-        new DelegationNode({
+      expect(
+        await new DelegationNode({
           id: failureId,
           hierarchyId,
           account: didAlice,
@@ -159,7 +159,7 @@ describe('DelegationNode', () => {
           parentId: undefined,
           revoked: false,
         }).verify()
-      ).resolves.toBe(false)
+      ).toBe(false)
     })
 
     it('get delegation root', async () => {
@@ -277,15 +277,15 @@ describe('DelegationNode', () => {
     })
 
     it('counts all subnodes', async () => {
-      await expect(topNode.subtreeNodeCount()).resolves.toStrictEqual(5)
+      expect(await topNode.subtreeNodeCount()).toStrictEqual(5)
     })
 
     it('counts smaller subtrees', async () => {
-      await expect(nodes[b2].subtreeNodeCount()).resolves.toStrictEqual(0)
-      await expect(nodes[b1].subtreeNodeCount()).resolves.toStrictEqual(3)
-      await expect(nodes[c1].subtreeNodeCount()).resolves.toStrictEqual(1)
-      await expect(nodes[c2].subtreeNodeCount()).resolves.toStrictEqual(0)
-      await expect(nodes[d1].subtreeNodeCount()).resolves.toStrictEqual(0)
+      expect(await nodes[b2].subtreeNodeCount()).toStrictEqual(0)
+      expect(await nodes[b1].subtreeNodeCount()).toStrictEqual(3)
+      expect(await nodes[c1].subtreeNodeCount()).toStrictEqual(1)
+      expect(await nodes[c2].subtreeNodeCount()).toStrictEqual(0)
+      expect(await nodes[d1].subtreeNodeCount()).toStrictEqual(0)
     })
 
     it('counts all subnodes in deeply nested structure (100)', async () => {
@@ -305,9 +305,7 @@ describe('DelegationNode', () => {
         }),
         {}
       )
-      await expect(
-        nodes[hashList[0]].subtreeNodeCount()
-      ).resolves.toStrictEqual(100)
+      expect(await nodes[hashList[0]].subtreeNodeCount()).toStrictEqual(100)
     })
 
     it('counts all subnodes in deeply nested structure (1000)', async () => {
@@ -327,9 +325,7 @@ describe('DelegationNode', () => {
         }),
         {}
       )
-      await expect(
-        nodes[hashList[0]].subtreeNodeCount()
-      ).resolves.toStrictEqual(1000)
+      expect(await nodes[hashList[0]].subtreeNodeCount()).toStrictEqual(1000)
     })
 
     it('counts all subnodes in deeply nested structure (10000)', async () => {
@@ -349,9 +345,7 @@ describe('DelegationNode', () => {
         }),
         {}
       )
-      await expect(
-        nodes[hashList[0]].subtreeNodeCount()
-      ).resolves.toStrictEqual(10000)
+      expect(await nodes[hashList[0]].subtreeNodeCount()).toStrictEqual(10000)
     })
   })
 
@@ -384,10 +378,12 @@ describe('DelegationNode', () => {
 
     it('counts steps from last child till select parent', async () => {
       await Promise.all(
-        [0, 1, 5, 10, 75, 100, 300, 500, 999].map((i) =>
+        [0, 1, 5, 10, 75, 100, 300, 500, 999].map(async (i) =>
           expect(
-            nodes[hashList[0]].findAncestorOwnedBy(nodes[hashList[i]].account)
-          ).resolves.toMatchObject({
+            await nodes[hashList[0]].findAncestorOwnedBy(
+              nodes[hashList[i]].account
+            )
+          ).toMatchObject({
             steps: i,
             node: nodes[hashList[i]],
           })
@@ -396,46 +392,54 @@ describe('DelegationNode', () => {
     })
 
     it('counts various distances within the hierarchy', async () => {
-      await Promise.all([
-        expect(
-          nodes[hashList[1]].findAncestorOwnedBy(nodes[hashList[2]].account)
-        ).resolves.toMatchObject({
-          steps: 1,
-          node: nodes[hashList[2]],
-        }),
-        expect(
-          nodes[hashList[250]].findAncestorOwnedBy(nodes[hashList[450]].account)
-        ).resolves.toMatchObject({ steps: 200, node: nodes[hashList[450]] }),
-        expect(
-          nodes[hashList[800]].findAncestorOwnedBy(nodes[hashList[850]].account)
-        ).resolves.toMatchObject({
-          steps: 50,
-          node: nodes[hashList[850]],
-        }),
-        expect(
-          nodes[hashList[5]].findAncestorOwnedBy(nodes[hashList[955]].account)
-        ).resolves.toMatchObject({
-          steps: 950,
-          node: nodes[hashList[955]],
-        }),
-      ])
+      expect(
+        await nodes[hashList[1]].findAncestorOwnedBy(nodes[hashList[2]].account)
+      ).toMatchObject({
+        steps: 1,
+        node: nodes[hashList[2]],
+      })
+      expect(
+        await nodes[hashList[250]].findAncestorOwnedBy(
+          nodes[hashList[450]].account
+        )
+      ).toMatchObject({ steps: 200, node: nodes[hashList[450]] })
+      expect(
+        await nodes[hashList[800]].findAncestorOwnedBy(
+          nodes[hashList[850]].account
+        )
+      ).toMatchObject({
+        steps: 50,
+        node: nodes[hashList[850]],
+      })
+      expect(
+        await nodes[hashList[5]].findAncestorOwnedBy(
+          nodes[hashList[955]].account
+        )
+      ).toMatchObject({
+        steps: 950,
+        node: nodes[hashList[955]],
+      })
     })
 
     it('returns null if trying to count backwards', async () => {
-      await Promise.all([
-        expect(
-          nodes[hashList[10]].findAncestorOwnedBy(nodes[hashList[5]].account)
-        ).resolves.toMatchObject({
-          steps: 989,
-          node: null,
-        }),
-        expect(
-          nodes[hashList[99]].findAncestorOwnedBy(nodes[hashList[95]].account)
-        ).resolves.toMatchObject({ steps: 900, node: null }),
-        expect(
-          nodes[hashList[900]].findAncestorOwnedBy(nodes[hashList[500]].account)
-        ).resolves.toMatchObject({ steps: 99, node: null }),
-      ])
+      expect(
+        await nodes[hashList[10]].findAncestorOwnedBy(
+          nodes[hashList[5]].account
+        )
+      ).toMatchObject({
+        steps: 989,
+        node: null,
+      })
+      expect(
+        await nodes[hashList[99]].findAncestorOwnedBy(
+          nodes[hashList[95]].account
+        )
+      ).toMatchObject({ steps: 900, node: null })
+      expect(
+        await nodes[hashList[900]].findAncestorOwnedBy(
+          nodes[hashList[500]].account
+        )
+      ).toMatchObject({ steps: 99, node: null })
     })
 
     it('returns null if looking for non-existent account', async () => {
@@ -443,26 +447,24 @@ describe('DelegationNode', () => {
         Crypto.hash('-1', 256),
         ss58Format
       )}`
-      await Promise.all([
-        expect(
-          nodes[hashList[10]].findAncestorOwnedBy(noOnesAddress)
-        ).resolves.toMatchObject({
-          steps: 989,
-          node: null,
-        }),
-        expect(
-          nodes[hashList[99]].findAncestorOwnedBy(noOnesAddress)
-        ).resolves.toMatchObject({
-          steps: 900,
-          node: null,
-        }),
-        expect(
-          nodes[hashList[900]].findAncestorOwnedBy(noOnesAddress)
-        ).resolves.toMatchObject({
-          steps: 99,
-          node: null,
-        }),
-      ])
+      expect(
+        await nodes[hashList[10]].findAncestorOwnedBy(noOnesAddress)
+      ).toMatchObject({
+        steps: 989,
+        node: null,
+      })
+      expect(
+        await nodes[hashList[99]].findAncestorOwnedBy(noOnesAddress)
+      ).toMatchObject({
+        steps: 900,
+        node: null,
+      })
+      expect(
+        await nodes[hashList[900]].findAncestorOwnedBy(noOnesAddress)
+      ).toMatchObject({
+        steps: 99,
+        node: null,
+      })
     })
 
     it('error check should throw errors on faulty delegation nodes', async () => {
@@ -588,7 +590,7 @@ describe('DelegationHierarchy', () => {
     expect(queriedDelegation).not.toBe(undefined)
     if (queriedDelegation) {
       expect(queriedDelegation.account).toBe(didAlice)
-      await expect(queriedDelegation.getCTypeHash()).resolves.toBe(ctypeHash)
+      expect(await queriedDelegation.getCTypeHash()).toBe(ctypeHash)
       expect(queriedDelegation.id).toBe(ROOT_IDENTIFIER)
     }
   })

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -168,13 +168,13 @@ describe('Quote', () => {
 
   it('tests created quote data against given data', async () => {
     expect(validQuoteData.attesterDid).toEqual(attesterIdentity.uri)
-    await expect(
-      claimerIdentity.signPayload(
+    expect(
+      await claimerIdentity.signPayload(
         Crypto.hashObjectAsStr(validAttesterSignedQuote),
         claimer.sign,
         claimerIdentity.authenticationKey.id
       )
-    ).resolves.toEqual(quoteBothAgreed.claimerSignature)
+    ).toEqual(quoteBothAgreed.claimerSignature)
 
     const { fragment: attesterKeyId } = DidUtils.parseDidUri(
       validAttesterSignedQuote.attesterSignature.keyUri
@@ -196,11 +196,9 @@ describe('Quote', () => {
         )
       )
     ).toBeTruthy()
-    await expect(() =>
-      Quote.verifyAttesterSignedQuote(validAttesterSignedQuote, {
-        resolver: mockResolver,
-      })
-    ).not.toThrow()
+    await Quote.verifyAttesterSignedQuote(validAttesterSignedQuote, {
+      resolver: mockResolver,
+    })
     expect(
       await Quote.createAttesterSignedQuote(
         validQuoteData,

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -172,7 +172,7 @@ export async function signWithDidKey(
     sign,
     keyId
   )
-  addSignature(req4Att, signature, signatureKeyId, { challenge })
+  await addSignature(req4Att, signature, signatureKeyId, { challenge })
 }
 
 /**

--- a/packages/did/src/Did.chain.spec.ts
+++ b/packages/did/src/Did.chain.spec.ts
@@ -56,26 +56,26 @@ describe('services validation', () => {
   it.each([...validTestURIs, ...unencodedTestUris.map(encodeURI)])(
     'allows adding services with valid URI "%s"',
     async (uri) => {
-      await expect(
-        getAddEndpointExtrinsic({
+      expect(
+        await getAddEndpointExtrinsic({
           id: 'service_1',
           types: [],
           urls: [uri],
         })
-      ).resolves.toBeDefined()
+      ).toBeDefined()
     }
   )
 
   it.each([...validTestIds, ...invalidTestIds.map(encodeURIComponent)])(
     'allows adding services with valid id "%s"',
     async (id) => {
-      await expect(
-        getAddEndpointExtrinsic({
+      expect(
+        await getAddEndpointExtrinsic({
           id,
           types: [],
           urls: [],
         })
-      ).resolves.toBeDefined()
+      ).toBeDefined()
     }
   )
 

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -71,13 +71,13 @@ describe('light DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: true,
       didDetails: details,
       key: details.authenticationKey,
@@ -91,13 +91,13 @@ describe('light DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: true,
       didDetails: details,
       key: details.authenticationKey,
@@ -111,13 +111,13 @@ describe('light DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.assertionMethod,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/verification method/i),
     })
@@ -131,13 +131,13 @@ describe('light DID', () => {
       details.authenticationKey.id
     )
     signature.keyUri += '1a'
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/no key with id/i),
     })
@@ -150,13 +150,13 @@ describe('light DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING.substring(1),
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/invalid signature/i),
     })
@@ -171,13 +171,13 @@ describe('light DID', () => {
     )
     // @ts-expect-error
     signature.keyUri = signature.keyUri.replace('#', '?')
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/signature key id .+ invalid/i),
     })
@@ -197,13 +197,13 @@ describe('light DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/migrated/i),
     })
@@ -263,13 +263,13 @@ describe('full DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: true,
       didDetails: details,
       key: details.authenticationKey,
@@ -283,13 +283,13 @@ describe('full DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: true,
       didDetails: details,
       key: details.authenticationKey,
@@ -309,13 +309,13 @@ describe('full DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/deactivated/i),
     })
@@ -329,13 +329,13 @@ describe('full DID', () => {
       sign,
       details.authenticationKey.id
     )
-    await expect(
-      verifyDidSignature({
+    expect(
+      await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: KeyRelationship.authentication,
       })
-    ).resolves.toMatchObject<VerificationResult>({
+    ).toMatchObject<VerificationResult>({
       verified: false,
       reason: expect.stringMatching(/no result/i),
     })

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -223,8 +223,8 @@ export async function resolve(
 
   if (fragment) {
     return (
-      resolveKey(didUri as DidResourceUri) ||
-      resolveServiceEndpoint(didUri as DidResourceUri) ||
+      (await resolveKey(didUri as DidResourceUri)) ||
+      (await resolveServiceEndpoint(didUri as DidResourceUri)) ||
       null
     )
   }

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -199,9 +199,9 @@ describe('When resolving a key', () => {
     )
     const keyIdUri: DidResourceUri = `${fullDid}#auth`
 
-    await expect(
-      DidResolver.resolveKey(keyIdUri)
-    ).resolves.toStrictEqual<ResolvedDidKey>({
+    expect(
+      await DidResolver.resolveKey(keyIdUri)
+    ).toStrictEqual<ResolvedDidKey>({
       controller: fullDid,
       publicKey: new Uint8Array(32).fill(0),
       uri: keyIdUri,
@@ -213,7 +213,7 @@ describe('When resolving a key', () => {
     const deletedFullDid = getKiltDidFromIdentifier(deletedIdentifier, 'full')
     let keyIdUri: DidPublicKey['uri'] = `${deletedFullDid}#enc`
 
-    await expect(DidResolver.resolveKey(keyIdUri)).resolves.toBeNull()
+    expect(await DidResolver.resolveKey(keyIdUri)).toBeNull()
 
     const didWithNoEncryptionKey = getKiltDidFromIdentifier(
       identifierWithAuthenticationKey,
@@ -221,19 +221,17 @@ describe('When resolving a key', () => {
     )
     keyIdUri = `${didWithNoEncryptionKey}#enc`
 
-    await expect(DidResolver.resolveKey(keyIdUri)).resolves.toBeNull()
+    expect(await DidResolver.resolveKey(keyIdUri)).toBeNull()
   })
 
   it('throws for invalid URIs', async () => {
     const uriWithoutFragment = getKiltDidFromIdentifier(
       deletedIdentifier,
       'full'
-    )
-    // @ts-ignore
+    ) as DidResourceUri
     await expect(DidResolver.resolveKey(uriWithoutFragment)).rejects.toThrow()
 
-    const invalidUri = 'invalid-uri'
-    // @ts-ignore
+    const invalidUri = 'invalid-uri' as DidResourceUri
     await expect(DidResolver.resolveKey(invalidUri)).rejects.toThrow()
   })
 })
@@ -246,9 +244,9 @@ describe('When resolving a service endpoint', () => {
     )
     const serviceIdUri: DidResourceUri = `${fullDid}#service-1`
 
-    await expect(
-      DidResolver.resolveServiceEndpoint(serviceIdUri)
-    ).resolves.toStrictEqual<ResolvedDidServiceEndpoint>({
+    expect(
+      await DidResolver.resolveServiceEndpoint(serviceIdUri)
+    ).toStrictEqual<ResolvedDidServiceEndpoint>({
       uri: serviceIdUri,
       type: [`type-service-1`],
       serviceEndpoint: [`x:url-service-1`],
@@ -259,9 +257,7 @@ describe('When resolving a service endpoint', () => {
     const deletedFullDid = getKiltDidFromIdentifier(deletedIdentifier, 'full')
     let serviceIdUri: DidResourceUri = `${deletedFullDid}#service-1`
 
-    await expect(
-      DidResolver.resolveServiceEndpoint(serviceIdUri)
-    ).resolves.toBeNull()
+    expect(await DidResolver.resolveServiceEndpoint(serviceIdUri)).toBeNull()
 
     const didWithNoServiceEndpoints = getKiltDidFromIdentifier(
       identifierWithAuthenticationKey,
@@ -269,24 +265,20 @@ describe('When resolving a service endpoint', () => {
     )
     serviceIdUri = `${didWithNoServiceEndpoints}#service-1`
 
-    await expect(
-      DidResolver.resolveServiceEndpoint(serviceIdUri)
-    ).resolves.toBeNull()
+    expect(await DidResolver.resolveServiceEndpoint(serviceIdUri)).toBeNull()
   })
 
   it('throws for invalid URIs', async () => {
     const uriWithoutFragment = getKiltDidFromIdentifier(
       deletedIdentifier,
       'full'
-    )
+    ) as DidResourceUri
     await expect(
-      // @ts-ignore
       DidResolver.resolveServiceEndpoint(uriWithoutFragment)
     ).rejects.toThrow()
 
-    const invalidUri = 'invalid-uri'
+    const invalidUri = 'invalid-uri' as DidResourceUri
     await expect(
-      // @ts-ignore
       DidResolver.resolveServiceEndpoint(invalidUri)
     ).rejects.toThrow()
   })
@@ -392,7 +384,7 @@ describe('When resolving a full DID', () => {
     ).address
     const randomDid = getKiltDidFromIdentifier(randomIdentifier, 'full')
 
-    await expect(DidResolver.resolveDoc(randomDid)).resolves.toBeNull()
+    expect(await DidResolver.resolveDoc(randomDid)).toBeNull()
   })
 
   it('correctly resolves a deleted DID', async () => {

--- a/packages/testing/scripts/fetchMetadata.js
+++ b/packages/testing/scripts/fetchMetadata.js
@@ -54,7 +54,7 @@ const api = new ApiPromise({ provider })
 let exitCode
 
 async function fetch() {
-  api.connect()
+  await api.connect()
   await api.isReady
   let metadata
   switch (argv.format) {

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -229,9 +229,13 @@ describe('proofs', () => {
 
   it('it verifies self-signed proof', async () => {
     // verify
-    await expect(
-      verificationUtils.verifySelfSignedProof(VC, VC.proof[0], documentLoader)
-    ).resolves.toMatchObject({
+    expect(
+      await verificationUtils.verifySelfSignedProof(
+        VC,
+        VC.proof[0],
+        documentLoader
+      )
+    ).toMatchObject({
       verified: true,
     })
   })
@@ -316,19 +320,23 @@ describe('proofs', () => {
     })
 
     it('errors on proof mismatch', async () => {
-      await expect(
-        verificationUtils.verifySelfSignedProof(VC, VC.proof[1], documentLoader)
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifySelfSignedProof(
+          VC,
+          VC.proof[1],
+          documentLoader
+        )
+      ).toMatchObject({
         verified: false,
       })
-      await expect(
-        verificationUtils.verifyCredentialDigestProof(VC, VC.proof[0])
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifyCredentialDigestProof(VC, VC.proof[0])
+      ).toMatchObject({
         verified: false,
       })
-      await expect(
-        verificationUtils.verifyAttestedProof(VC, VC.proof[2])
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifyAttestedProof(VC, VC.proof[2])
+      ).toMatchObject({
         verified: false,
       })
     })
@@ -352,14 +360,18 @@ describe('proofs', () => {
 
     it('it detects tampering with credential digest', async () => {
       VC.id = `${VC.id.slice(0, 10)}1${VC.id.slice(11)}`
-      await expect(
-        verificationUtils.verifySelfSignedProof(VC, VC.proof[0], documentLoader)
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifySelfSignedProof(
+          VC,
+          VC.proof[0],
+          documentLoader
+        )
+      ).toMatchObject({
         verified: false,
       })
-      await expect(
-        verificationUtils.verifyCredentialDigestProof(VC, VC.proof[2])
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifyCredentialDigestProof(VC, VC.proof[2])
+      ).toMatchObject({
         verified: false,
       })
     })
@@ -368,24 +380,24 @@ describe('proofs', () => {
       jest.spyOn(Attestation, 'query').mockResolvedValue(credential.attestation)
 
       VC.delegationId = '0x123'
-      await expect(
-        verificationUtils.verifyCredentialDigestProof(VC, VC.proof[2])
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifyCredentialDigestProof(VC, VC.proof[2])
+      ).toMatchObject({
         verified: false,
       })
-      await expect(
-        verificationUtils.verifyAttestedProof(VC, VC.proof[1])
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifyAttestedProof(VC, VC.proof[1])
+      ).toMatchObject({
         verified: false,
         status: verificationUtils.AttestationStatus.invalid,
       })
     })
 
-    it('it detects tampering on claimed properties', () => {
+    it('it detects tampering on claimed properties', async () => {
       VC.credentialSubject.name = 'Kort'
-      return expect(
-        verificationUtils.verifyCredentialDigestProof(VC, VC.proof[2])
-      ).resolves.toMatchObject({
+      expect(
+        await verificationUtils.verifyCredentialDigestProof(VC, VC.proof[2])
+      ).toMatchObject({
         verified: false,
       })
     })

--- a/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.spec.ts
@@ -60,25 +60,26 @@ describe('jsigs', () => {
         'https://w3id.org/security/v2',
         { documentLoader, compactToRelative: false }
       )
-      await expect(purpose.match(compactedProof, {})).resolves.toBe(true)
-      await expect(
-        purpose.match(compactedProof, { document: credential, documentLoader })
-      ).resolves.toBe(true)
+      expect(await purpose.match(compactedProof, {})).toBe(true)
+      expect(
+        await purpose.match(compactedProof, {
+          document: credential,
+          documentLoader,
+        })
+      ).toBe(true)
     })
 
     it('suite matches proof', async () => {
       const proofWithContext = { ...proof, '@context': credential['@context'] }
-      await expect(suite.matchProof({ proof: proofWithContext })).resolves.toBe(
-        true
-      )
-      await expect(
-        suite.matchProof({
+      expect(await suite.matchProof({ proof: proofWithContext })).toBe(true)
+      expect(
+        await suite.matchProof({
           proof: proofWithContext,
           document: credential,
           purpose,
           documentLoader,
         })
-      ).resolves.toBe(true)
+      ).toBe(true)
     })
   })
 
@@ -88,9 +89,9 @@ describe('jsigs', () => {
     })
 
     it('verifies Kilt Attestation Proof', async () => {
-      await expect(
-        jsigs.verify(credential, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: true })
+      expect(
+        await jsigs.verify(credential, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: true })
     })
   })
 
@@ -103,9 +104,9 @@ describe('jsigs', () => {
     })
 
     it('fails to verify Kilt Attestation Proof', async () => {
-      await expect(
-        jsigs.verify(credential, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await jsigs.verify(credential, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: false })
     })
   })
 
@@ -115,9 +116,9 @@ describe('jsigs', () => {
     })
 
     it('fails to verify Kilt Attestation Proof', async () => {
-      await expect(
-        jsigs.verify(credential, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await jsigs.verify(credential, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: false })
     })
   })
 })
@@ -129,9 +130,14 @@ describe('vc-js', () => {
     })
 
     it('verifies Kilt Attestation Proof', async () => {
-      await expect(
-        vcjs.verifyCredential({ credential, suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: true })
+      expect(
+        await vcjs.verifyCredential({
+          credential,
+          suite,
+          purpose,
+          documentLoader,
+        })
+      ).toMatchObject({ verified: true })
     })
   })
 
@@ -144,9 +150,14 @@ describe('vc-js', () => {
     })
 
     it('fails to verify Kilt Attestation Proof', async () => {
-      await expect(
-        vcjs.verifyCredential({ credential, suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await vcjs.verifyCredential({
+          credential,
+          suite,
+          purpose,
+          documentLoader,
+        })
+      ).toMatchObject({ verified: false })
     })
   })
 
@@ -156,9 +167,14 @@ describe('vc-js', () => {
     })
 
     it('fails to verify Kilt Attestation Proof', async () => {
-      await expect(
-        vcjs.verifyCredential({ credential, suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await vcjs.verifyCredential({
+          credential,
+          suite,
+          purpose,
+          documentLoader,
+        })
+      ).toMatchObject({ verified: false })
     })
   })
 })

--- a/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.spec.ts
@@ -42,25 +42,26 @@ describe('jsigs', () => {
         'https://w3id.org/security/v2',
         { documentLoader, compactToRelative: false }
       )
-      await expect(purpose.match(compactedProof, {})).resolves.toBe(true)
-      await expect(
-        purpose.match(compactedProof, { document: credential, documentLoader })
-      ).resolves.toBe(true)
+      expect(await purpose.match(compactedProof, {})).toBe(true)
+      expect(
+        await purpose.match(compactedProof, {
+          document: credential,
+          documentLoader,
+        })
+      ).toBe(true)
     })
 
     it('suite matches proof', async () => {
       const proofWithContext = { ...proof, '@context': credential['@context'] }
-      await expect(suite.matchProof({ proof: proofWithContext })).resolves.toBe(
-        true
-      )
-      await expect(
-        suite.matchProof({
+      expect(await suite.matchProof({ proof: proofWithContext })).toBe(true)
+      expect(
+        await suite.matchProof({
           proof: proofWithContext,
           document: credential,
           purpose,
           documentLoader,
         })
-      ).resolves.toBe(true)
+      ).toBe(true)
     })
   })
 
@@ -70,21 +71,21 @@ describe('jsigs', () => {
     })
 
     it('verifies Kilt Credential Digest Proof', async () => {
-      await expect(
-        jsigs.verify(credential, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: true })
+      expect(
+        await jsigs.verify(credential, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: true })
     })
 
     it('verifies Kilt Credential Digest Proof with props removed', async () => {
       /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
       const { name, ...credentialSubject } = credential.credentialSubject
       expect(credentialSubject).not.toHaveProperty('name')
-      await expect(
-        jsigs.verify(
+      expect(
+        await jsigs.verify(
           { ...credential, credentialSubject },
           { suite, purpose, documentLoader }
         )
-      ).resolves.toMatchObject({ verified: true })
+      ).toMatchObject({ verified: true })
     })
   })
 
@@ -100,9 +101,9 @@ describe('jsigs', () => {
 
     it('detects tampering on props', async () => {
       tamperCred.credentialSubject.name = 'MacGyver'
-      await expect(
-        jsigs.verify(tamperCred, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await jsigs.verify(tamperCred, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: false })
     })
   })
 })
@@ -114,23 +115,28 @@ describe('vc-js', () => {
     })
 
     it('verifies Kilt Credential Digest Proof', async () => {
-      await expect(
-        vcjs.verifyCredential({ credential, suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: true })
+      expect(
+        await vcjs.verifyCredential({
+          credential,
+          suite,
+          purpose,
+          documentLoader,
+        })
+      ).toMatchObject({ verified: true })
     })
 
     it('verifies Kilt Credential Digest Proof with props removed', async () => {
       /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
       const { name, ...credentialSubject } = credential.credentialSubject
       expect(credentialSubject).not.toHaveProperty('name')
-      await expect(
-        vcjs.verifyCredential({
+      expect(
+        await vcjs.verifyCredential({
           credential: { ...credential, credentialSubject },
           suite,
           purpose,
           documentLoader,
         })
-      ).resolves.toMatchObject({ verified: true })
+      ).toMatchObject({ verified: true })
     })
   })
 
@@ -146,14 +152,14 @@ describe('vc-js', () => {
 
     it('detects tampering on props', async () => {
       tamperCred.credentialSubject.name = 'MacGyver'
-      await expect(
-        vcjs.verifyCredential({
+      expect(
+        await vcjs.verifyCredential({
           credential: tamperCred,
           suite,
           purpose,
           documentLoader,
         })
-      ).resolves.toMatchObject({ verified: false })
+      ).toMatchObject({ verified: false })
     })
   })
 })

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
@@ -80,25 +80,26 @@ describe('jsigs', () => {
         'https://w3id.org/security/v2',
         { documentLoader, compactToRelative: false }
       )
-      await expect(purpose.match(compactedProof, {})).resolves.toBe(true)
-      await expect(
-        purpose.match(compactedProof, { document: credential, documentLoader })
-      ).resolves.toBe(true)
+      expect(await purpose.match(compactedProof, {})).toBe(true)
+      expect(
+        await purpose.match(compactedProof, {
+          document: credential,
+          documentLoader,
+        })
+      ).toBe(true)
     })
 
     it('suite matches proof', async () => {
       const proofWithContext = { ...proof, '@context': credential['@context'] }
-      await expect(suite.matchProof({ proof: proofWithContext })).resolves.toBe(
-        true
-      )
-      await expect(
-        suite.matchProof({
+      expect(await suite.matchProof({ proof: proofWithContext })).toBe(true)
+      expect(
+        await suite.matchProof({
           proof: proofWithContext,
           document: credential,
           purpose,
           documentLoader,
         })
-      ).resolves.toBe(true)
+      ).toBe(true)
     })
   })
 
@@ -108,9 +109,9 @@ describe('jsigs', () => {
     })
 
     it('verifies Kilt Self Signed Proof', async () => {
-      await expect(
-        jsigs.verify(credential, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: true })
+      expect(
+        await jsigs.verify(credential, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: true })
     })
   })
 
@@ -126,9 +127,9 @@ describe('jsigs', () => {
 
     it('detects tampering', async () => {
       tamperCred.id = tamperCred.id.replace('1', '2')
-      await expect(
-        jsigs.verify(tamperCred, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await jsigs.verify(tamperCred, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: false })
     })
 
     it('detects signer mismatch', async () => {
@@ -137,9 +138,9 @@ describe('jsigs', () => {
         publicKeyHex: randomAsHex(32),
       }
       tamperCred.proof = [{ ...proof, verificationMethod }]
-      await expect(
-        jsigs.verify(tamperCred, { suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: false })
+      expect(
+        await jsigs.verify(tamperCred, { suite, purpose, documentLoader })
+      ).toMatchObject({ verified: false })
     })
   })
 })
@@ -151,9 +152,14 @@ describe('vc-js', () => {
     })
 
     it('verifies Kilt Self Signed Proof', async () => {
-      await expect(
-        vcjs.verifyCredential({ credential, suite, purpose, documentLoader })
-      ).resolves.toMatchObject({ verified: true })
+      expect(
+        await vcjs.verifyCredential({
+          credential,
+          suite,
+          purpose,
+          documentLoader,
+        })
+      ).toMatchObject({ verified: true })
     })
   })
 
@@ -169,14 +175,14 @@ describe('vc-js', () => {
 
     it('detects tampering', async () => {
       tamperCred.id = tamperCred.id.replace('1', '2')
-      await expect(
-        vcjs.verifyCredential({
+      expect(
+        await vcjs.verifyCredential({
           credential: tamperCred,
           suite,
           purpose,
           documentLoader,
         })
-      ).resolves.toMatchObject({ verified: false })
+      ).toMatchObject({ verified: false })
     })
 
     it('detects signer mismatch', async () => {
@@ -185,14 +191,14 @@ describe('vc-js', () => {
         publicKeyHex: randomAsHex(32),
       }
       tamperCred.proof = [{ ...proof, verificationMethod }]
-      await expect(
-        vcjs.verifyCredential({
+      expect(
+        await vcjs.verifyCredential({
           credential: tamperCred,
           suite,
           purpose,
           documentLoader,
         })
-      ).resolves.toMatchObject({ verified: false })
+      ).toMatchObject({ verified: false })
     })
   })
 })


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

The expect() checks of async functions in the tests can be simplified

## How to test:

yarn test

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
