### PR TITLE
feat: prefer named functions over arrow functions

### DIFF
--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -102,7 +102,9 @@ describe('Blockchain', () => {
 
   describe('parseSubscriptionOptions', () => {
     it('takes incomplete SubscriptionPromiseOptions and sets default values where needed', async () => {
-      const testFunction = () => true
+      function testFunction() {
+        return true
+      }
 
       expect(parseSubscriptionOptions()).toEqual({
         resolveOn: IS_FINALIZED,

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -25,20 +25,67 @@ export const TxOutdated = 'Transaction is outdated'
 export const TxPriority = 'Priority is too low:'
 export const TxDuplicate = 'Transaction Already Imported'
 
-export const IS_READY: SubscriptionPromise.ResultEvaluator = (result) =>
-  result.status.isReady
-export const IS_IN_BLOCK: SubscriptionPromise.ResultEvaluator = (result) =>
-  result.isInBlock
-export const EXTRINSIC_EXECUTED: SubscriptionPromise.ResultEvaluator = (
-  result
-) => ErrorHandler.extrinsicSuccessful(result)
-export const IS_FINALIZED: SubscriptionPromise.ResultEvaluator = (result) =>
-  result.isFinalized
+/**
+ * Evaluator resolves on extrinsic reaching status "is ready".
+ *
+ * @param result Submission result.
+ * @returns Whether the extrinsic reached status "is ready".
+ */
+export function IS_READY(result: ISubmittableResult): boolean {
+  return result.status.isReady
+}
 
-export const IS_ERROR: SubscriptionPromise.ResultEvaluator = (result) =>
-  result.isError || result.internalError
-export const EXTRINSIC_FAILED: SubscriptionPromise.ResultEvaluator = (result) =>
-  ErrorHandler.extrinsicFailed(result)
+/**
+ * Evaluator resolves on extrinsic reaching status "in block".
+ *
+ * @param result Submission result.
+ * @returns Whether the extrinsic reached status "in block".
+ */
+export function IS_IN_BLOCK(result: ISubmittableResult): boolean {
+  return result.isInBlock
+}
+
+/**
+ * Evaluator resolves on extrinsic reaching status "success".
+ *
+ * @param result Submission result.
+ * @returns Whether the extrinsic reached status "success".
+ */
+export function EXTRINSIC_EXECUTED(result: ISubmittableResult): boolean {
+  return ErrorHandler.extrinsicSuccessful(result)
+}
+
+/**
+ * Evaluator resolves on extrinsic reaching status "finalized".
+ *
+ * @param result Submission result.
+ * @returns Whether the extrinsic reached status "finalized".
+ */
+export function IS_FINALIZED(result: ISubmittableResult): boolean {
+  return result.isFinalized
+}
+
+/**
+ * Evaluator resolves on extrinsic reaching status "is error".
+ *
+ * @param result Submission result.
+ * @returns Whether the extrinsic reached status "is error" and the error itself.
+ */
+export function IS_ERROR(
+  result: ISubmittableResult
+): boolean | Error | undefined {
+  return result.isError || result.internalError
+}
+
+/**
+ * Evaluator resolves on extrinsic reaching status "is ready".
+ *
+ * @param result Submission result.
+ * @returns Whether the extrinsic reached status "is ready".
+ */
+export function EXTRINSIC_FAILED(result: ISubmittableResult): boolean {
+  return ErrorHandler.extrinsicFailed(result)
+}
 
 /**
  * Parses potentially incomplete or undefined options and returns complete [[Options]].
@@ -90,7 +137,8 @@ export async function submitSignedTx(
   })
 
   const api = await getConnectionOrConnect()
-  const handleDisconnect = (): void => {
+
+  function handleDisconnect(): void {
     const result = new SubmittableResult({
       events: latestResult.events || [],
       internalError: new Error('connection error'),
@@ -101,6 +149,7 @@ export async function submitSignedTx(
     })
     subscription(result)
   }
+
   api.once('disconnected', handleDisconnect)
 
   try {

--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
@@ -10,17 +10,18 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { SubscriptionPromise } from '@kiltprotocol/types'
 import { makeSubscriptionPromise } from './SubscriptionPromise'
 
 const RESOLVE = 'resolve'
 const REJECT = 'reject'
 
-const RESOLVE_ON: SubscriptionPromise.Evaluator<string> = (value) =>
-  value === RESOLVE
+function RESOLVE_ON(value: string): boolean {
+  return value === RESOLVE
+}
 
-const REJECT_ON: SubscriptionPromise.Evaluator<string> = (value) =>
-  value === REJECT && 'error'
+function REJECT_ON(value: string): boolean | string {
+  return value === REJECT && 'error'
+}
 
 it('rejects promise on timeout', async () => {
   const { promise, subscription } = makeSubscriptionPromise({

--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
@@ -69,13 +69,15 @@ export function makeSubscriptionPromiseMulti<SubscriptionType>(
   const subscriptions: Array<(value: SubscriptionType) => void> = []
   args.forEach(
     (options: SubscriptionPromise.TerminationOptions<SubscriptionType>) => {
-      const { promise, subscription } = makeSubscriptionPromise(options)
+      const { promise, subscription: sub } = makeSubscriptionPromise(options)
       promises.push(promise)
-      subscriptions.push(subscription)
+      subscriptions.push(sub)
     }
   )
-  const subscription = (value: SubscriptionType): void => {
+
+  function subscription(value: SubscriptionType): void {
     subscriptions.forEach((s) => s(value))
   }
+
   return { promises, subscription }
 }

--- a/packages/core/src/balance/Balance.spec.ts
+++ b/packages/core/src/balance/Balance.spec.ts
@@ -66,11 +66,11 @@ describe('Balance', () => {
     bob = keyring.addFromUri('//Bob')
   })
   it('should listen to balance changes', (done) => {
-    const listener = (
+    function listener(
       account: string,
       balances: Balances,
       changes: Balances
-    ): void => {
+    ): void {
       expect(account).toBe(bob.address)
       expect(balances.free.toNumber()).toBe(BALANCE)
       expect(changes.free.toNumber()).toBe(FEE)

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -131,9 +131,7 @@ describe('RequestForAttestation', () => {
   let migratedAndDeletedFullDid: DidDetails
 
   const mockResolver = (() => {
-    const resolve = async (
-      didUri: DidUri
-    ): Promise<DidResolvedDetails | null> => {
+    async function resolve(didUri: DidUri): Promise<DidResolvedDetails | null> {
       // For the mock resolver, we need to match the base URI, so we delete the fragment, if present.
       const { did } = DidUtils.parseDidUri(didUri)
       switch (did) {
@@ -161,6 +159,7 @@ describe('RequestForAttestation', () => {
           return null
       }
     }
+
     return {
       resolve,
       resolveDoc: resolve,
@@ -388,9 +387,7 @@ describe('create presentation', () => {
   let attestation: IAttestation
 
   const mockResolver = (() => {
-    const resolve = async (
-      didUri: DidUri
-    ): Promise<DidResolvedDetails | null> => {
+    async function resolve(didUri: DidUri): Promise<DidResolvedDetails | null> {
       // For the mock resolver, we need to match the base URI, so we delete the fragment, if present.
       const { did } = DidUtils.parseDidUri(didUri)
       switch (did) {
@@ -430,6 +427,7 @@ describe('create presentation', () => {
           return null
       }
     }
+
     return {
       resolve,
       resolveDoc: resolve,

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -62,9 +62,7 @@ describe('Quote', () => {
   let invalidCostQuote: IQuote
 
   const mockResolver = (() => {
-    const resolve = async (
-      didUri: string
-    ): Promise<DidResolvedDetails | null> => {
+    async function resolve(didUri: string): Promise<DidResolvedDetails | null> {
       // For the mock resolver, we need to match the base URI, so we delete the fragment, if present.
       const didWithoutFragment = didUri.split('#')[0]
       switch (didWithoutFragment) {
@@ -76,6 +74,7 @@ describe('Quote', () => {
           return null
       }
     }
+
     return {
       resolve,
       resolveDoc: resolve,
@@ -233,9 +232,7 @@ describe('Quote compression', () => {
   let compressedResultQuoteAgreement: CompressedQuoteAgreed
 
   const mockResolver = (() => {
-    const resolve = async (
-      didUri: string
-    ): Promise<DidResolvedDetails | null> => {
+    async function resolve(didUri: string): Promise<DidResolvedDetails | null> {
       // For the mock resolver, we need to match the base URI, so we delete the fragment, if present.
       const didWithoutFragment = didUri.split('#')[0]
       switch (didWithoutFragment) {
@@ -247,6 +244,7 @@ describe('Quote compression', () => {
           return null
       }
     }
+
     return {
       resolve,
       resolveDoc: resolve,

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -291,8 +291,9 @@ export interface HashingOptions {
  * @param nonce Optional nonce (as string) used to obscure hashed contents.
  * @returns 256 bit blake2 hash as hex string.
  */
-export const saltedBlake2b256: Hasher = (value, nonce) =>
-  blake2AsHex((nonce || '') + value, 256)
+export function saltedBlake2b256(value: string, nonce = ''): HexString {
+  return blake2AsHex(nonce + value, 256)
+}
 
 /**
  * Configurable computation of salted over an array of statements. Can be used to validate/reproduce salted hashes

--- a/packages/utils/src/json-schema/format.ts
+++ b/packages/utils/src/json-schema/format.ts
@@ -35,7 +35,7 @@ const FASTURIREFERENCE =
   /^(?:(?:[a-z][a-z0-9+-.]*:)?\/?\/)?(?:[^\\\s#][^\s#]*)?(?:#[^\\\s]*)?$/i
 
 // https://github.com/ExodusMovement/schemasafe/blob/master/src/formats.js
-const EMAIL = (input: string) => {
+function EMAIL(input: string): boolean {
   if (input[0] === '"') return false
   const [name, host, ...rest] = input.split('@')
   if (
@@ -65,14 +65,17 @@ const IPV6 =
   /^((([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9a-f]{1,4}:){5}(((:[0-9a-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9a-f]{1,4}:){4}(((:[0-9a-f]{1,4}){1,3})|((:[0-9a-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))$/i
 
 // https://github.com/ExodusMovement/schemasafe/blob/master/src/formats.js
-const DURATION = (input: string) =>
-  input.length > 1 &&
-  input.length < 80 &&
-  (/^P\d+([.,]\d+)?W$/.test(input) ||
-    (/^P[\dYMDTHS]*(\d[.,]\d+)?[YMDHS]$/.test(input) &&
-      /^P([.,\d]+Y)?([.,\d]+M)?([.,\d]+D)?(T([.,\d]+H)?([.,\d]+M)?([.,\d]+S)?)?$/.test(
-        input
-      )))
+function DURATION(input: string): boolean {
+  return (
+    input.length > 1 &&
+    input.length < 80 &&
+    (/^P\d+([.,]\d+)?W$/.test(input) ||
+      (/^P[\dYMDTHS]*(\d[.,]\d+)?[YMDHS]$/.test(input) &&
+        /^P([.,\d]+Y)?([.,\d]+M)?([.,\d]+D)?(T([.,\d]+H)?([.,\d]+M)?([.,\d]+S)?)?$/.test(
+          input
+        )))
+  )
+}
 
 function bind(r: RegExp) {
   return r.test.bind(r)

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -5,6 +5,8 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable max-classes-per-file */
+
 import { u8aConcat, hexToU8a, u8aToHex } from '@polkadot/util'
 import {
   signatureVerify,
@@ -46,11 +48,17 @@ export interface AttestationVerificationResult extends VerificationResult {
   status: AttestationStatus
 }
 
-const CREDENTIAL_MALFORMED_ERROR = (reason: string): Error =>
-  new Error(`Credential malformed: ${reason}`)
+export class CREDENTIAL_MALFORMED_ERROR extends Error {
+  constructor(reason: string) {
+    super(`Credential malformed: ${reason}`)
+  }
+}
 
-const PROOF_MALFORMED_ERROR = (reason: string): Error =>
-  new Error(`Proof malformed: ${reason}`)
+export class PROOF_MALFORMED_ERROR extends Error {
+  constructor(reason: string) {
+    super(`Proof malformed: ${reason}`)
+  }
+}
 
 /**
  * Verifies a KILT self signed proof (claimer signature) against a KILT style Verifiable Credential.
@@ -74,7 +82,7 @@ export async function verifySelfSignedProof(
     const type = proof['@type'] || proof.type
     if (type !== KILT_SELF_SIGNED_PROOF_TYPE)
       throw new Error('Proof type mismatch')
-    if (!proof.signature) throw PROOF_MALFORMED_ERROR('signature missing')
+    if (!proof.signature) throw new PROOF_MALFORMED_ERROR('signature missing')
     let { verificationMethod } = proof
     // we always fetch the verification method to make sure the key is in fact associated with the did
     if (typeof verificationMethod !== 'string') {
@@ -99,7 +107,7 @@ export async function verifySelfSignedProof(
       throw new Error('credential subject is not owner of signing key')
     const keyType = verificationMethod.type || verificationMethod['@type']
     if (!Object.values(VerificationKeyTypesMap).includes(keyType))
-      throw PROOF_MALFORMED_ERROR(
+      throw new PROOF_MALFORMED_ERROR(
         `signature type unknown; expected one of ${JSON.stringify(
           Object.values(VerificationKeyTypesMap)
         )}, got "${verificationMethod.type}"`
@@ -153,11 +161,13 @@ export async function verifyAttestedProof(
       throw new Error('Proof type mismatch')
     const { attester } = proof
     if (typeof attester !== 'string' || !attester)
-      throw PROOF_MALFORMED_ERROR('attester DID not understood')
+      throw new PROOF_MALFORMED_ERROR('attester DID not understood')
     if (attester !== credential.issuer)
-      throw PROOF_MALFORMED_ERROR('attester DID not matching credential issuer')
+      throw new PROOF_MALFORMED_ERROR(
+        'attester DID not matching credential issuer'
+      )
     if (typeof credential.id !== 'string' || !credential.id)
-      throw CREDENTIAL_MALFORMED_ERROR(
+      throw new CREDENTIAL_MALFORMED_ERROR(
         'claim id (=claim hash) missing / invalid'
       )
     const claimHash = fromCredentialIRI(credential.id)
@@ -172,7 +182,7 @@ export async function verifyAttestedProof(
         delegationId = null
         break
       default:
-        throw CREDENTIAL_MALFORMED_ERROR('delegationId not understood')
+        throw new CREDENTIAL_MALFORMED_ERROR('delegationId not understood')
     }
     // query on-chain data by credential id (= claim root hash)
     const onChain = await Attestation.query(claimHash)
@@ -233,10 +243,10 @@ export async function verifyCredentialDigestProof(
     if (type !== KILT_CREDENTIAL_DIGEST_PROOF_TYPE)
       throw new Error('Proof type mismatch')
     if (typeof proof.nonces !== 'object') {
-      throw PROOF_MALFORMED_ERROR('proof must contain object "nonces"')
+      throw new PROOF_MALFORMED_ERROR('proof must contain object "nonces"')
     }
     if (typeof credential.credentialSubject !== 'object')
-      throw CREDENTIAL_MALFORMED_ERROR('credential subject missing')
+      throw new CREDENTIAL_MALFORMED_ERROR('credential subject missing')
 
     // 1: check credential digest against credential contents & claim property hashes in proof
     // collect hashes from hash array, legitimations & delegationId
@@ -271,7 +281,7 @@ export async function verifyCredentialDigestProof(
             verified: false,
             errors: [
               ...r.errors,
-              PROOF_MALFORMED_ERROR(
+              new PROOF_MALFORMED_ERROR(
                 `Proof contains no digest for statement ${stmt}`
               ),
             ],


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

The declarative function syntax for named functions has some advantages over imperative assigning of arrow functions to a constant. I have updated the few occurrences of those in the codebase.

## How to test:

yarn test

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
