### PR TITLE
fix!: rename service endpoint URLs to URIs

### DIFF
--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -104,12 +104,12 @@ describe('write and didDeleteTx', () => {
         {
           id: 'test-id-1',
           types: ['test-type-1'],
-          urls: ['x:test-url-1'],
+          uris: ['x:test-url-1'],
         },
         {
           id: 'test-id-2',
           types: ['test-type-2'],
-          urls: ['x:test-url-2'],
+          uris: ['x:test-url-2'],
         },
       ],
     })
@@ -145,12 +145,12 @@ describe('write and didDeleteTx', () => {
       {
         id: 'test-id-1',
         types: ['test-type-1'],
-        urls: ['x:test-url-1'],
+        uris: ['x:test-url-1'],
       },
       {
         id: 'test-id-2',
         types: ['test-type-2'],
-        urls: ['x:test-url-2'],
+        uris: ['x:test-url-2'],
       },
     ])
 
@@ -283,7 +283,7 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
   const newEndpoint: DidServiceEndpoint = {
     id: 'new-endpoint',
     types: ['new-type'],
-    urls: ['x:new-url'],
+    uris: ['x:new-url'],
   }
   const updateEndpointCall = await DidChain.getAddEndpointExtrinsic(newEndpoint)
 
@@ -427,7 +427,7 @@ describe('DID migration', () => {
       {
         id: 'id-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       },
     ]
     const lightDidDetails = LightDidDetails.fromDetails({
@@ -581,7 +581,7 @@ describe('DID management batching', () => {
           {
             id: 'id-1',
             types: ['type-1'],
-            urls: ['x:url-1'],
+            uris: ['x:url-1'],
           },
         ],
       })
@@ -609,12 +609,12 @@ describe('DID management batching', () => {
         .addServiceEndpoint({
           id: 'id-2',
           types: ['type-2'],
-          urls: ['x:url-2'],
+          uris: ['x:url-2'],
         })
         .addServiceEndpoint({
           id: 'id-3',
           types: ['type-3'],
-          urls: ['x:url-3'],
+          uris: ['x:url-3'],
         })
 
       const extrinsic = await builder.build(sign, paymentAccount.address)
@@ -661,17 +661,17 @@ describe('DID management batching', () => {
         {
           id: 'id-3',
           types: ['type-3'],
-          urls: ['x:url-3'],
+          uris: ['x:url-3'],
         },
         {
           id: 'id-1',
           types: ['type-1'],
-          urls: ['x:url-1'],
+          uris: ['x:url-1'],
         },
         {
           id: 'id-2',
           types: ['type-2'],
-          urls: ['x:url-2'],
+          uris: ['x:url-2'],
         },
       ])
     })
@@ -737,12 +737,12 @@ describe('DID management batching', () => {
         .addServiceEndpoint({
           id: 'id-1',
           types: ['type-1'],
-          urls: ['x:url-1'],
+          uris: ['x:url-1'],
         })
         .addServiceEndpoint({
           id: 'id-2',
           types: ['type-2'],
-          urls: ['x:url-2'],
+          uris: ['x:url-2'],
         })
 
       const initialFullDid = await createBuilder.buildAndSubmit(
@@ -797,7 +797,7 @@ describe('DID management batching', () => {
         .addServiceEndpoint({
           id: 'id-1',
           types: ['type-1'],
-          urls: ['x:url-1'],
+          uris: ['x:url-1'],
         })
         .setAuthenticationKey({
           publicKey: newAuthKeypair.publicKey,
@@ -806,7 +806,7 @@ describe('DID management batching', () => {
         .addServiceEndpoint({
           id: 'id-2',
           types: ['type-2'],
-          urls: ['x:url-2'],
+          uris: ['x:url-2'],
         })
 
       // Fails if an authentication key is set twice for the same builder
@@ -848,7 +848,7 @@ describe('DID management batching', () => {
       }).addServiceEndpoint({
         id: 'id-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       })
       // Create the full DID with a service endpoint
       const fullDid = await createBuilder.buildAndSubmit(
@@ -867,14 +867,14 @@ describe('DID management batching', () => {
         .addServiceEndpoint({
           id: 'id-2',
           types: ['type-2'],
-          urls: ['x:url-2'],
+          uris: ['x:url-2'],
         })
 
       // Before consuming the builder, let's add the same service endpoint to the DID directly
       const newEndpointTx = await DidChain.getAddEndpointExtrinsic({
         id: 'id-2',
         types: ['type-22'],
-        urls: ['x:url-22'],
+        uris: ['x:url-22'],
       })
       const authorisedTx = await fullDid.authorizeExtrinsic(
         newEndpointTx,
@@ -901,7 +901,7 @@ describe('DID management batching', () => {
       ).toStrictEqual<DidServiceEndpoint>({
         id: 'id-2',
         types: ['type-22'],
-        urls: ['x:url-22'],
+        uris: ['x:url-22'],
       })
     }, 60_000)
 
@@ -913,7 +913,7 @@ describe('DID management batching', () => {
       }).addServiceEndpoint({
         id: 'id-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       })
       // Create the full DID with a service endpoint
       const fullDid = await createBuilder.buildAndSubmit(
@@ -932,14 +932,14 @@ describe('DID management batching', () => {
         .addServiceEndpoint({
           id: 'id-2',
           types: ['type-2'],
-          urls: ['x:url-2'],
+          uris: ['x:url-2'],
         })
 
       // Before consuming the builder, let's add the same service endpoint to the DID directly
       const newEndpointTx = await DidChain.getAddEndpointExtrinsic({
         id: 'id-2',
         types: ['type-22'],
-        urls: ['x:url-22'],
+        uris: ['x:url-22'],
       })
       const authorisedTx = await fullDid.authorizeExtrinsic(
         newEndpointTx,
@@ -971,7 +971,7 @@ describe('DID management batching', () => {
       ).toStrictEqual<DidServiceEndpoint>({
         id: 'id-2',
         types: ['type-22'],
-        urls: ['x:url-22'],
+        uris: ['x:url-22'],
       })
     }, 60_000)
   })
@@ -1193,7 +1193,7 @@ describe('Runtime constraints', () => {
         (_, index): DidServiceEndpoint => ({
           id: `service-${index}`,
           types: [`type-${index}`],
-          urls: [`x:url-${index}`],
+          uris: [`x:url-${index}`],
         })
       )
       await DidChain.generateCreateTxFromCreationDetails(
@@ -1209,7 +1209,7 @@ describe('Runtime constraints', () => {
       newServiceEndpoints.push({
         id: 'service-100',
         types: ['type-100'],
-        urls: ['x:url-100'],
+        uris: ['x:url-100'],
       })
       await expect(
         DidChain.generateCreateTxFromCreationDetails(
@@ -1237,7 +1237,7 @@ describe('Runtime constraints', () => {
               // Maximum is 50
               id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               types: ['type-a'],
-              urls: ['x:url-a'],
+              uris: ['x:url-a'],
             },
           ],
         },
@@ -1254,7 +1254,7 @@ describe('Runtime constraints', () => {
                 // One more than the maximum
                 id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                 types: ['type-a'],
-                urls: ['x:url-a'],
+                uris: ['x:url-a'],
               },
             ],
           },
@@ -1272,7 +1272,7 @@ describe('Runtime constraints', () => {
         id: 'id-1',
         // Maximum is 1
         types: Array(1).map((_, index): string => `type-${index}`),
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       }
       await DidChain.generateCreateTxFromCreationDetails(
         {
@@ -1306,7 +1306,7 @@ describe('Runtime constraints', () => {
         id: 'id-1',
         // Maximum is 1
         types: ['type-1'],
-        urls: Array(1).map((_, index): string => `x:url-${index}`),
+        uris: Array(1).map((_, index): string => `x:url-${index}`),
       }
       await DidChain.generateCreateTxFromCreationDetails(
         {
@@ -1318,7 +1318,7 @@ describe('Runtime constraints', () => {
         sign
       )
       // One more than the maximum
-      newEndpoint.urls.push('x:new-url')
+      newEndpoint.uris.push('x:new-url')
       await expect(
         DidChain.generateCreateTxFromCreationDetails(
           {
@@ -1345,7 +1345,7 @@ describe('Runtime constraints', () => {
               id: 'id-1',
               // Maximum is 50
               types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-              urls: ['x:url-1'],
+              uris: ['x:url-1'],
             },
           ],
         },
@@ -1362,7 +1362,7 @@ describe('Runtime constraints', () => {
                 id: 'id-1',
                 // One more than the maximum
                 types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-                urls: ['x:url-1'],
+                uris: ['x:url-1'],
               },
             ],
           },
@@ -1385,7 +1385,7 @@ describe('Runtime constraints', () => {
               id: 'id-1',
               types: ['type-1'],
               // Maximum is 200
-              urls: [
+              uris: [
                 'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               ],
             },
@@ -1404,7 +1404,7 @@ describe('Runtime constraints', () => {
                 id: 'id-1',
                 types: ['type-1'],
                 // One more than the maximum
-                urls: [
+                uris: [
                   'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                 ],
               },
@@ -1426,14 +1426,14 @@ describe('Runtime constraints', () => {
         // Maximum is 50
         id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         types: ['type-a'],
-        urls: ['x:url-a'],
+        uris: ['x:url-a'],
       })
       await expect(
         DidChain.getAddEndpointExtrinsic({
           // One more than maximum
           id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           types: ['type-a'],
-          urls: ['x:url-a'],
+          uris: ['x:url-a'],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"The service ID \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
@@ -1445,7 +1445,7 @@ describe('Runtime constraints', () => {
         id: 'id-1',
         // Maximum is 1
         types: Array(1).map((_, index): string => `type-${index}`),
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       }
       await DidChain.getAddEndpointExtrinsic(newEndpoint)
       // One more than the maximum
@@ -1462,11 +1462,11 @@ describe('Runtime constraints', () => {
         id: 'id-1',
         // Maximum is 1
         types: ['type-1'],
-        urls: Array(1).map((_, index): string => `x:url-${index}`),
+        uris: Array(1).map((_, index): string => `x:url-${index}`),
       }
       await DidChain.getAddEndpointExtrinsic(newEndpoint)
       // One more than the maximum
-      newEndpoint.urls.push('x:new-url')
+      newEndpoint.uris.push('x:new-url')
       await expect(
         DidChain.getAddEndpointExtrinsic(newEndpoint)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1479,14 +1479,14 @@ describe('Runtime constraints', () => {
         id: 'id-1',
         // Maximum is 50
         types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       })
       await expect(
         DidChain.getAddEndpointExtrinsic({
           id: 'id-1',
           // One more than the maximum
           types: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-          urls: ['x:url-1'],
+          uris: ['x:url-1'],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"The service with ID \\"id-1\\" has the type \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
@@ -1498,7 +1498,7 @@ describe('Runtime constraints', () => {
         id: 'id-1',
         types: ['type-1'],
         // Maximum is 200
-        urls: [
+        uris: [
           'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         ],
       })
@@ -1507,7 +1507,7 @@ describe('Runtime constraints', () => {
           id: 'id-1',
           types: ['type-1'],
           // One more than the maximum
-          urls: [
+          uris: [
             'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           ],
         })

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1301,7 +1301,7 @@ describe('Runtime constraints', () => {
       )
     }, 30_000)
 
-    it('should not be possible to create a DID with a service endpoint that has too many URLs', async () => {
+    it('should not be possible to create a DID with a service endpoint that has too many URIs', async () => {
       const newEndpoint: DidServiceEndpoint = {
         id: 'id-1',
         // Maximum is 1
@@ -1331,7 +1331,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"id-1\\" has too many URLs (2). Max number of URLs allowed per service is 1."`
+        `"The service with ID \\"id-1\\" has too many URIs (2). Max number of URIs allowed per service is 1."`
       )
     }, 30_000)
 
@@ -1375,7 +1375,7 @@ describe('Runtime constraints', () => {
       )
     }, 30_000)
 
-    it('should not be possible to create a DID with a service endpoint that has a URL that is too long', async () => {
+    it('should not be possible to create a DID with a service endpoint that has a URI that is too long', async () => {
       await DidChain.generateCreateTxFromCreationDetails(
         {
           authenticationKey: testAuthKey,
@@ -1415,7 +1415,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"id-1\\" has the URL \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (202 bytes). Max number of bytes allowed for a service URL is 200."`
+        `"The service with ID \\"id-1\\" has the URI \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (202 bytes). Max number of bytes allowed for a service URI is 200."`
       )
     }, 30_000)
   })
@@ -1457,7 +1457,7 @@ describe('Runtime constraints', () => {
       )
     }, 30_000)
 
-    it('should not be possible to add a service endpoint that has too many URLs', async () => {
+    it('should not be possible to add a service endpoint that has too many URIs', async () => {
       const newEndpoint: DidServiceEndpoint = {
         id: 'id-1',
         // Maximum is 1
@@ -1470,7 +1470,7 @@ describe('Runtime constraints', () => {
       await expect(
         DidChain.getAddEndpointExtrinsic(newEndpoint)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"id-1\\" has too many URLs (2). Max number of URLs allowed per service is 1."`
+        `"The service with ID \\"id-1\\" has too many URIs (2). Max number of URIs allowed per service is 1."`
       )
     }, 30_000)
 
@@ -1493,7 +1493,7 @@ describe('Runtime constraints', () => {
       )
     }, 30_000)
 
-    it('should not be possible to add a service endpoint that has a URL that is too long', async () => {
+    it('should not be possible to add a service endpoint that has a URI that is too long', async () => {
       await DidChain.getAddEndpointExtrinsic({
         id: 'id-1',
         types: ['type-1'],
@@ -1512,7 +1512,7 @@ describe('Runtime constraints', () => {
           ],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"id-1\\" has the URL \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (201 bytes). Max number of bytes allowed for a service URL is 200."`
+        `"The service with ID \\"id-1\\" has the URI \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (201 bytes). Max number of bytes allowed for a service URI is 200."`
       )
     }, 30_000)
   })

--- a/packages/did/src/Did.chain.spec.ts
+++ b/packages/did/src/Did.chain.spec.ts
@@ -60,7 +60,7 @@ describe('services validation', () => {
         await getAddEndpointExtrinsic({
           id: 'service_1',
           types: [],
-          urls: [uri],
+          uris: [uri],
         })
       ).toBeDefined()
     }
@@ -73,7 +73,7 @@ describe('services validation', () => {
         await getAddEndpointExtrinsic({
           id,
           types: [],
-          urls: [],
+          uris: [],
         })
       ).toBeDefined()
     }
@@ -86,7 +86,7 @@ describe('services validation', () => {
         getAddEndpointExtrinsic({
           id,
           types: [],
-          urls: [],
+          uris: [],
         })
       ).rejects.toThrow('ID')
     }
@@ -99,7 +99,7 @@ describe('services validation', () => {
         getAddEndpointExtrinsic({
           id: 'service_1',
           types: [],
-          urls: [uri],
+          uris: [uri],
         })
       ).rejects.toThrow('URI')
     }

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -439,7 +439,7 @@ function checkServiceEndpointInput(
  * Additionally, each service endpoint must respect the following conditions:
  *     - The service endpoint ID is at most 50 ASCII characters long and is a valid URI fragment according to RFC#3986.
  *     - The service endpoint has at most 1 service type, with a value that is at most 50 ASCII characters long.
- *     - The service endpoint has at most 1 URL, with a value that is at most 200 ASCII characters long, and which is a valid URI according to RFC#3986.
+ *     - The service endpoint has at most 1 URI, with a value that is at most 200 ASCII characters long, and which is a valid URI according to RFC#3986.
  * @param submitterAddress The KILT address authorised to submit the creation operation.
  * @param sign The sign callback.
  *
@@ -682,7 +682,7 @@ export async function getAddKeyExtrinsic(
  * The service endpoint must respect the following conditions:
  *     - The service endpoint ID is at most 50 ASCII characters long and is a valid URI fragment according to RFC#3986.
  *     - The service endpoint has at most 1 service type, with a value that is at most 50 ASCII characters long.
- *     - The service endpoint has at most 1 URL, with a value that is at most 200 ASCII characters long, and which is a valid URI according to RFC#3986.
+ *     - The service endpoint has at most 1 URI, with a value that is at most 200 ASCII characters long, and which is a valid URI according to RFC#3986.
  * @returns An extrinsic that must be authorised (signed) by the FullDid with which the service endpoint should be associated.
  */
 export async function getAddEndpointExtrinsic(

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -9,15 +9,15 @@ import type {
   BTreeMap,
   BTreeSet,
   Enum,
+  GenericAccountId,
   Option,
   Struct,
-  Vec,
-  u8,
-  u64,
-  GenericAccountId,
   Text,
   u128,
   u32,
+  u64,
+  u8,
+  Vec,
 } from '@polkadot/types'
 import type {
   BlockNumber,
@@ -32,16 +32,16 @@ import type { ApiPromise } from '@polkadot/api'
 import {
   Deposit,
   DidEncryptionKey,
+  DidIdentifier,
   DidKey,
   DidServiceEndpoint,
   DidSignature,
   DidVerificationKey,
-  DidIdentifier,
   IIdentity,
   KeyRelationship,
+  NewDidKey,
   SignCallback,
   SigningOptions,
-  NewDidKey,
   SubmittableExtrinsic,
   VerificationKeyType,
   verificationKeyTypes,
@@ -273,17 +273,47 @@ export async function queryKey(
   return didDetails.publicKeys.find((key) => key.id === keyId) || null
 }
 
-function decodeServiceChainRecord(
-  serviceDetails: IServiceEndpointChainRecordCodec
-): DidServiceEndpoint {
-  const id = hexToString(serviceDetails.id.toString())
+interface BlockchainEndpoint {
+  id: DidServiceEndpoint['id']
+  serviceTypes: DidServiceEndpoint['types']
+  // The blockchain uses the original name `urls` which is not spec-compliant
+  urls: DidServiceEndpoint['uris']
+}
+
+function endpointToBlockchainEndpoint({
+  id,
+  types,
+  uris,
+}: DidServiceEndpoint): BlockchainEndpoint {
   return {
     id,
-    types: serviceDetails.serviceTypes.map((type) =>
-      hexToString(type.toString())
-    ),
-    uris: serviceDetails.urls.map((url) => hexToString(url.toString())),
+    serviceTypes: types,
+    urls: uris,
   }
+}
+
+function blockchainEndpointToEndpoint({
+  id,
+  serviceTypes,
+  urls,
+}: BlockchainEndpoint): DidServiceEndpoint {
+  return {
+    id,
+    types: serviceTypes,
+    uris: urls,
+  }
+}
+
+function decodeServiceChainRecord({
+  id,
+  serviceTypes,
+  urls,
+}: IServiceEndpointChainRecordCodec): DidServiceEndpoint {
+  return blockchainEndpointToEndpoint({
+    id: hexToString(id.toString()),
+    serviceTypes: serviceTypes.map((type) => hexToString(type.toString())),
+    urls: urls.map((url) => hexToString(url.toString())),
+  })
 }
 
 /**
@@ -495,13 +525,7 @@ export async function generateCreateTxFromCreationDetails(
     checkServiceEndpointInput(api, service)
   })
 
-  const newServiceDetails = serviceEndpoints.map(({ id, types, uris }) => {
-    return {
-      id,
-      urls: uris,
-      serviceTypes: types,
-    }
-  })
+  const newServiceDetails = serviceEndpoints.map(endpointToBlockchainEndpoint)
 
   const rawCreationDetails = {
     did: details.identifier,
@@ -693,12 +717,7 @@ export async function getAddEndpointExtrinsic(
 ): Promise<Extrinsic> {
   const api = await BlockchainApiConnection.getConnectionOrConnect()
   checkServiceEndpointInput(api, endpoint)
-
-  return api.tx.did.addServiceEndpoint({
-    id: endpoint.id,
-    serviceTypes: endpoint.types,
-    urls: endpoint.uris,
-  })
+  return api.tx.did.addServiceEndpoint(endpointToBlockchainEndpoint(endpoint))
 }
 
 /**

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -282,7 +282,7 @@ function decodeServiceChainRecord(
     types: serviceDetails.serviceTypes.map((type) =>
       hexToString(type.toString())
     ),
-    urls: serviceDetails.urls.map((url) => hexToString(url.toString())),
+    uris: serviceDetails.urls.map((url) => hexToString(url.toString())),
   }
 }
 
@@ -495,9 +495,12 @@ export async function generateCreateTxFromCreationDetails(
     checkServiceEndpointInput(api, service)
   })
 
-  const newServiceDetails = serviceEndpoints.map((service) => {
-    const { id, urls } = service
-    return { id, urls, serviceTypes: service.types }
+  const newServiceDetails = serviceEndpoints.map(({ id, types, uris }) => {
+    return {
+      id,
+      urls: uris,
+      serviceTypes: types,
+    }
   })
 
   const rawCreationDetails = {
@@ -692,8 +695,9 @@ export async function getAddEndpointExtrinsic(
   checkServiceEndpointInput(api, endpoint)
 
   return api.tx.did.addServiceEndpoint({
+    id: endpoint.id,
     serviceTypes: endpoint.types,
-    ...endpoint,
+    urls: endpoint.uris,
   })
 }
 

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -326,7 +326,7 @@ export function isUriFragment(str: string): boolean {
 /**
  * Performs sanity checks on service endpoint data, making sure that the following conditions are met:
  *   - The `id` property is a string containing a valid URI fragment according to RFC#3986, not a complete DID URI.
- *   - If the `urls` property contains one or more strings, they must be valid URIs according to RFC#3986.
+ *   - If the `uris` property contains one or more strings, they must be valid URIs according to RFC#3986.
  *
  * @param endpoint A service endpoint object to check.
  * @returns Validation result and errors, if any.
@@ -349,11 +349,11 @@ export function checkServiceEndpointSyntax(
       )
     )
   }
-  endpoint.urls.forEach((url) => {
-    if (!isUri(url)) {
+  endpoint.uris.forEach((uri) => {
+    if (!isUri(uri)) {
       errors.push(
         new SDKErrors.DidError(
-          `A service URI must be a URI according to RFC#3986, which "${url}" (service id "${endpoint.id}") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.`
+          `A service URI must be a URI according to RFC#3986, which "${uri}" (service id "${endpoint.id}") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.`
         )
       )
     }
@@ -365,7 +365,7 @@ export function checkServiceEndpointSyntax(
  * Performs size checks on service endpoint data, making sure that the following conditions are met:
  *   - The `endpoint.id` is at most 50 ASCII characters long.
  *   - The `endpoint.types` array has at most 1 service type, with a value that is at most 50 ASCII characters long.
- *   - The `endpoint.urls` array has at most 1 URI, with a value that is at most 200 ASCII characters long.
+ *   - The `endpoint.uris` array has at most 1 URI, with a value that is at most 200 ASCII characters long.
  *
  * @param api An api instance required for reading up-to-date size constraints from the blockchain runtime.
  * @param endpoint A service endpoint object to check.
@@ -405,10 +405,10 @@ export function checkServiceEndpointSizeConstraints(
       )
     )
   }
-  if (endpoint.urls.length > maxNumberOfUrlsPerService) {
+  if (endpoint.uris.length > maxNumberOfUrlsPerService) {
     errors.push(
       new SDKErrors.DidError(
-        `The service with ID "${endpoint.id}" has too many URIs (${endpoint.urls.length}). Max number of URIs allowed per service is ${maxNumberOfUrlsPerService}.`
+        `The service with ID "${endpoint.id}" has too many URIs (${endpoint.uris.length}). Max number of URIs allowed per service is ${maxNumberOfUrlsPerService}.`
       )
     )
   }
@@ -422,12 +422,12 @@ export function checkServiceEndpointSizeConstraints(
       )
     }
   })
-  endpoint.urls.forEach((url) => {
-    const urlEncodedLength = stringToU8a(url).length
-    if (urlEncodedLength > maxServiceUrlLength) {
+  endpoint.uris.forEach((uri) => {
+    const uriEncodedLength = stringToU8a(uri).length
+    if (uriEncodedLength > maxServiceUrlLength) {
       errors.push(
         new SDKErrors.DidError(
-          `The service with ID "${endpoint.id}" has the URI "${url}" that is too long (${urlEncodedLength} bytes). Max number of bytes allowed for a service URI is ${maxServiceUrlLength}.`
+          `The service with ID "${endpoint.id}" has the URI "${uri}" that is too long (${uriEncodedLength} bytes). Max number of bytes allowed for a service URI is ${maxServiceUrlLength}.`
         )
       )
     }

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -353,7 +353,7 @@ export function checkServiceEndpointSyntax(
     if (!isUri(url)) {
       errors.push(
         new SDKErrors.DidError(
-          `A service URL must be a URI according to RFC#3986, which "${url}" (service id "${endpoint.id}") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.`
+          `A service URI must be a URI according to RFC#3986, which "${url}" (service id "${endpoint.id}") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.`
         )
       )
     }
@@ -365,7 +365,7 @@ export function checkServiceEndpointSyntax(
  * Performs size checks on service endpoint data, making sure that the following conditions are met:
  *   - The `endpoint.id` is at most 50 ASCII characters long.
  *   - The `endpoint.types` array has at most 1 service type, with a value that is at most 50 ASCII characters long.
- *   - The `endpoint.urls` array has at most 1 URL, with a value that is at most 200 ASCII characters long.
+ *   - The `endpoint.urls` array has at most 1 URI, with a value that is at most 200 ASCII characters long.
  *
  * @param api An api instance required for reading up-to-date size constraints from the blockchain runtime.
  * @param endpoint A service endpoint object to check.
@@ -408,7 +408,7 @@ export function checkServiceEndpointSizeConstraints(
   if (endpoint.urls.length > maxNumberOfUrlsPerService) {
     errors.push(
       new SDKErrors.DidError(
-        `The service with ID "${endpoint.id}" has too many URLs (${endpoint.urls.length}). Max number of URLs allowed per service is ${maxNumberOfUrlsPerService}.`
+        `The service with ID "${endpoint.id}" has too many URIs (${endpoint.urls.length}). Max number of URIs allowed per service is ${maxNumberOfUrlsPerService}.`
       )
     )
   }
@@ -427,7 +427,7 @@ export function checkServiceEndpointSizeConstraints(
     if (urlEncodedLength > maxServiceUrlLength) {
       errors.push(
         new SDKErrors.DidError(
-          `The service with ID "${endpoint.id}" has the URL "${url}" that is too long (${urlEncodedLength} bytes). Max number of bytes allowed for a service URL is ${maxServiceUrlLength}.`
+          `The service with ID "${endpoint.id}" has the URI "${url}" that is too long (${urlEncodedLength} bytes). Max number of bytes allowed for a service URI is ${maxServiceUrlLength}.`
         )
       )
     }

--- a/packages/did/src/DidBatcher/FullDidBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidBuilder.spec.ts
@@ -137,7 +137,7 @@ describe('FullDidBuilder', () => {
     const newServiceEndpoint: DidServiceEndpoint = {
       id: 'id-new',
       types: ['type-new'],
-      urls: ['x:url-new'],
+      uris: ['x:url-new'],
     }
 
     describe('.addServiceEndpoint()', () => {
@@ -169,7 +169,7 @@ describe('FullDidBuilder', () => {
               newServiceEndpoint.id,
               {
                 types: newServiceEndpoint.types,
-                urls: newServiceEndpoint.urls,
+                uris: newServiceEndpoint.uris,
               },
             ],
           ])

--- a/packages/did/src/DidBatcher/FullDidBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidBuilder.ts
@@ -186,7 +186,7 @@ export abstract class FullDidBuilder {
     // Otherwise we can safely mark the service endpoint for addition.
     this.newServiceEndpoints.set(id, {
       types: details.types,
-      urls: details.urls,
+      uris: details.uris,
     })
     return this
   }

--- a/packages/did/src/DidBatcher/FullDidCreationBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidCreationBuilder.spec.ts
@@ -47,12 +47,12 @@ describe('FullDidCreationBuilder', () => {
       const service1: DidServiceEndpoint = {
         id: 'id-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       }
       const service2: DidServiceEndpoint = {
         id: 'id-2',
         types: ['type-2'],
-        urls: ['x:url-2'],
+        uris: ['x:url-2'],
       }
       const lightDidDetails = LightDidDetails.fromDetails({
         authenticationKey: authKey,
@@ -84,8 +84,8 @@ describe('FullDidCreationBuilder', () => {
           Map<DidServiceEndpoint['id'], Omit<DidServiceEndpoint, 'id'>>
         >(
           new Map([
-            [service1.id, { types: service1.types, urls: service1.urls }],
-            [service2.id, { types: service2.types, urls: service2.urls }],
+            [service1.id, { types: service1.types, uris: service1.uris }],
+            [service2.id, { types: service2.types, uris: service2.uris }],
           ])
         )
       })

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
@@ -449,9 +449,9 @@ describe('FullDidUpdateBuilder', () => {
         expect(() => builder.addServiceEndpoint(newInvalidServiceEndpoint))
           .toThrowErrorMatchingInlineSnapshot(`
           "Service endpoint with ID \\"id-new\\" violates size and/or content constraints: 
-            1. A service URL must be a URI according to RFC#3986, which \\"type-new\\" (service id \\"id-new\\") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.
+            1. A service URI must be a URI according to RFC#3986, which \\"type-new\\" (service id \\"id-new\\") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.
             2. The service with ID \\"id-new\\" has too many types (2). Max number of types allowed per service is 1.
-            3. The service with ID \\"id-new\\" has too many URLs (2). Max number of URLs allowed per service is 1.
+            3. The service with ID \\"id-new\\" has too many URIs (2). Max number of URIs allowed per service is 1.
             4. The service with ID \\"id-new\\" has the type \\"Ξέρω-ότι-η-θάλασσα-είναι-μπλε\\" that is too long (53 bytes). Max number of bytes allowed for a service type is 50."
         `)
       })

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
@@ -411,17 +411,17 @@ describe('FullDidUpdateBuilder', () => {
     const newServiceEndpoint: DidServiceEndpoint = {
       id: 'id-new',
       types: ['type-new'],
-      urls: ['x:url-new'],
+      uris: ['x:url-new'],
     }
     const newInvalidServiceEndpoint: DidServiceEndpoint = {
       id: 'id-new',
       types: ['type-new', 'Ξέρω-ότι-η-θάλασσα-είναι-μπλε'],
-      urls: ['x:url-new', 'type-new'],
+      uris: ['x:url-new', 'type-new'],
     }
     beforeAll(async () => {
       const { keypair } = makeSigningKeyTool()
       fullDid = await createLocalDemoFullDidFromKeypair(keypair, {
-        endpoints: { 'id-old': { types: ['type-old'], urls: ['url-old'] } },
+        endpoints: { 'id-old': { types: ['type-old'], uris: ['url-old'] } },
       })
     })
 
@@ -474,7 +474,7 @@ describe('FullDidUpdateBuilder', () => {
               newServiceEndpoint.id,
               {
                 types: newServiceEndpoint.types,
-                urls: newServiceEndpoint.urls,
+                uris: newServiceEndpoint.uris,
               },
             ],
           ])

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -71,12 +71,12 @@ const existingServiceEndpoints: DidServiceEndpoint[] = [
   {
     id: 'service#1',
     types: ['type-1'],
-    urls: ['url-1'],
+    uris: ['url-1'],
   },
   {
     id: 'service#2',
     types: ['type-2'],
-    urls: ['url-2'],
+    uris: ['url-2'],
   },
 ]
 
@@ -212,7 +212,7 @@ describe('When creating an instance from the chain', () => {
     ).toStrictEqual<DidServiceEndpoint>({
       id: 'service#1',
       types: ['type-1'],
-      urls: ['url-1'],
+      uris: ['url-1'],
     })
     expect(fullDidDetails?.getEndpoints('type-1')).toStrictEqual<
       DidServiceEndpoint[]
@@ -220,7 +220,7 @@ describe('When creating an instance from the chain', () => {
       {
         id: 'service#1',
         types: ['type-1'],
-        urls: ['url-1'],
+        uris: ['url-1'],
       },
     ])
 
@@ -229,7 +229,7 @@ describe('When creating an instance from the chain', () => {
     ).toStrictEqual<DidServiceEndpoint>({
       id: 'service#2',
       types: ['type-2'],
-      urls: ['url-2'],
+      uris: ['url-2'],
     })
     expect(fullDidDetails?.getEndpoints('type-2')).toStrictEqual<
       DidServiceEndpoint[]
@@ -237,7 +237,7 @@ describe('When creating an instance from the chain', () => {
       {
         id: 'service#2',
         types: ['type-2'],
-        urls: ['url-2'],
+        uris: ['url-2'],
       },
     ])
   })

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -85,7 +85,7 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.uri).toStrictEqual(expectedDid)
     // Verify base58 encoding
     expect(lightDidDetails?.uri).toStrictEqual(
-      `did:kilt:light:00${authKey.address}:z14eMxMS7xSK8fMxpGvesppXFH9Ujjd1asWF2XxNRixGvQFeRsNriHen6CWAG66kWYWkUmAUkyqG9rKPP9xJ6A3uNHb9puJ6cq4nh4DARDhLA81QHHW4Jcvwe5WaynsZgvGhH1BEY2gdoFb8vGYdNA7VKyyicVuUj2kubvYNZ3Y5mRtYv68BECTw3jg9vqv8WSueTuRM9Tg4d4uLDKMDgFmVwZ7UZDhMErGZ1Zeq`
+      `did:kilt:light:00${authKey.address}:z14eMxMS7xSK8fMxpGvesppXFH9Ujjd1asWF2XxNRixGvQFeRsNriHen6CWAG66kWYWkUmAUkyqG9rKPP9xJ6A3uNHb9puJ6cq4nh4DARDhLA81QHHW4Jcvwe5WaynsZgvGhH18faKEFraMUeVFcqRoYctvTatCwndWGkkvHXJHZmXaNNU3QRm7kvV1Q6uJcJhZSGgbiYmY5xprchLXmooSZNBicRSTFUeRgmrAu`
     )
 
     expect(lightDidDetails?.getKey('authentication')).toStrictEqual<DidKey>({
@@ -324,7 +324,7 @@ describe('When creating an instance from a URI', () => {
 
     // Verify base58 encoding
     expect(builtLightDidDetails.uri).toStrictEqual(
-      `did:kilt:light:00${expectedLightDidDetails.identifier}:z14eMxMS7xSK8fMxpGvesppXFH9Ujjd1asWF2XxNRixGvQFeRsNriHen6CWAG66kWYWkUmAUkyqG9rKPP9xJ6A3uNHb9puJ6cq4nh4DARDhLA81QHHW4Jcvwe5WaynsZgvGhH1BEY2gdoFb8vGYdNA7VKyyicVuUj2kubvYNZ3Y5mRtYv68BECTw3jg9vqv8WSueTuRM9Tg4d4uLDKMDgFmVwZ7UZDhMErGZ1Zeq`
+      `did:kilt:light:00${expectedLightDidDetails.identifier}:z14eMxMS7xSK8fMxpGvesppXFH9Ujjd1asWF2XxNRixGvQFeRsNriHen6CWAG66kWYWkUmAUkyqG9rKPP9xJ6A3uNHb9puJ6cq4nh4DARDhLA81QHHW4Jcvwe5WaynsZgvGhH18faKEFraMUeVFcqRoYctvTatCwndWGkkvHXJHZmXaNNU3QRm7kvV1Q6uJcJhZSGgbiYmY5xprchLXmooSZNBicRSTFUeRgmrAu`
     )
     expect(builtLightDidDetails?.authenticationKey.id).toStrictEqual(
       'authentication'

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -46,12 +46,12 @@ describe('When creating an instance from the details', () => {
       {
         id: 'service-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       },
       {
         id: 'service-2',
         types: ['type-21', 'type-22'],
-        urls: ['x:url-21', 'x:url-22'],
+        uris: ['x:url-21', 'x:url-22'],
       },
     ]
     const validOptions: LightDidCreationDetails = {
@@ -130,7 +130,7 @@ describe('When creating an instance from the details', () => {
     ).toStrictEqual<DidServiceEndpoint>({
       id: 'service-1',
       types: ['type-1'],
-      urls: ['x:url-1'],
+      uris: ['x:url-1'],
     })
     expect(lightDidDetails?.getEndpoints('type-1')).toStrictEqual<
       DidServiceEndpoint[]
@@ -138,7 +138,7 @@ describe('When creating an instance from the details', () => {
       {
         id: 'service-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       },
     ])
 
@@ -147,7 +147,7 @@ describe('When creating an instance from the details', () => {
     ).toStrictEqual<DidServiceEndpoint>({
       id: 'service-2',
       types: ['type-21', 'type-22'],
-      urls: ['x:url-21', 'x:url-22'],
+      uris: ['x:url-21', 'x:url-22'],
     })
     expect(lightDidDetails?.getEndpoints('type-21')).toStrictEqual<
       DidServiceEndpoint[]
@@ -155,7 +155,7 @@ describe('When creating an instance from the details', () => {
       {
         id: 'service-2',
         types: ['type-21', 'type-22'],
-        urls: ['x:url-21', 'x:url-22'],
+        uris: ['x:url-21', 'x:url-22'],
       },
     ])
   })
@@ -292,12 +292,12 @@ describe('When creating an instance from a URI', () => {
       {
         id: 'service-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       },
       {
         id: 'service-2',
         types: ['type-21', 'type-22'],
-        urls: ['x:url-21', 'x:url-22'],
+        uris: ['x:url-21', 'x:url-22'],
       },
     ]
     const creationOptions: LightDidCreationDetails = {
@@ -344,12 +344,12 @@ describe('When creating an instance from a URI', () => {
       {
         id: 'service-1',
         types: ['type-1'],
-        urls: ['x:url-1'],
+        uris: ['x:url-1'],
       },
       {
         id: 'service-2',
         types: ['type-21', 'type-22'],
-        urls: ['x:url-21', 'x:url-22'],
+        uris: ['x:url-21', 'x:url-22'],
       },
     ]
     const creationOptions: LightDidCreationDetails = {

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -121,18 +121,26 @@ export function checkLightDidCreationDetails(
 }
 
 /**
- * The initial interface of Endpoint was using `urls` instead of `uris`,
+ * The initial interface of Endpoint was using `urls` instead of spec-compliant `uris`,
  * and we have to keep it for the backward compatibility with existing light DIDs.
  */
 interface LegacyEndpoint extends Omit<DidServiceEndpoint, 'uris'> {
   urls: string[]
 }
 
-function urisToUrls({ id, types, uris }: DidServiceEndpoint): LegacyEndpoint {
+function modernEndpointToLegacy({
+  id,
+  types,
+  uris,
+}: DidServiceEndpoint): LegacyEndpoint {
   return { id, types, urls: uris }
 }
 
-function urlsToUris({ id, types, urls }: LegacyEndpoint): DidServiceEndpoint {
+function legacyEndpointToModern({
+  id,
+  types,
+  urls,
+}: LegacyEndpoint): DidServiceEndpoint {
   return { id, types, uris: urls }
 }
 
@@ -164,7 +172,7 @@ export function serializeAndEncodeAdditionalLightDidDetails({
     objectToSerialize[ENCRYPTION_KEY_MAP_KEY] = encryptionKey
   }
   if (serviceEndpoints && serviceEndpoints.length > 0) {
-    const legacyFormatEndpoints = serviceEndpoints.map(urisToUrls)
+    const legacyFormatEndpoints = serviceEndpoints.map(modernEndpointToLegacy)
     objectToSerialize[SERVICES_KEY_MAP_KEY] = legacyFormatEndpoints
   }
 
@@ -192,6 +200,8 @@ export function decodeAndDeserializeAdditionalLightDidDetails(
 
   return {
     encryptionKey: deserialized[ENCRYPTION_KEY_MAP_KEY],
-    serviceEndpoints: deserialized[SERVICES_KEY_MAP_KEY]?.map(urlsToUris), // modernize the legacy format
+    serviceEndpoints: deserialized[SERVICES_KEY_MAP_KEY]?.map(
+      legacyEndpointToModern
+    ),
   }
 }

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -120,36 +120,12 @@ export function checkLightDidCreationDetails(
   })
 }
 
-/**
- * The initial interface of Endpoint was using `urls` instead of spec-compliant `uris`,
- * and we have to keep it for the backward compatibility with existing light DIDs.
- */
-interface LegacyEndpoint extends Omit<DidServiceEndpoint, 'uris'> {
-  urls: string[]
-}
-
-function modernEndpointToLegacy({
-  id,
-  types,
-  uris,
-}: DidServiceEndpoint): LegacyEndpoint {
-  return { id, types, urls: uris }
-}
-
-function legacyEndpointToModern({
-  id,
-  types,
-  urls,
-}: LegacyEndpoint): DidServiceEndpoint {
-  return { id, types, uris: urls }
-}
-
 const ENCRYPTION_KEY_MAP_KEY = 'e'
 const SERVICES_KEY_MAP_KEY = 's'
 
 interface SerializableStructure {
   [ENCRYPTION_KEY_MAP_KEY]?: NewDidEncryptionKey
-  [SERVICES_KEY_MAP_KEY]?: LegacyEndpoint[]
+  [SERVICES_KEY_MAP_KEY]?: DidServiceEndpoint[]
 }
 
 /**
@@ -172,8 +148,7 @@ export function serializeAndEncodeAdditionalLightDidDetails({
     objectToSerialize[ENCRYPTION_KEY_MAP_KEY] = encryptionKey
   }
   if (serviceEndpoints && serviceEndpoints.length > 0) {
-    const legacyFormatEndpoints = serviceEndpoints.map(modernEndpointToLegacy)
-    objectToSerialize[SERVICES_KEY_MAP_KEY] = legacyFormatEndpoints
+    objectToSerialize[SERVICES_KEY_MAP_KEY] = serviceEndpoints
   }
 
   if (Object.keys(objectToSerialize).length === 0) {
@@ -200,8 +175,6 @@ export function decodeAndDeserializeAdditionalLightDidDetails(
 
   return {
     encryptionKey: deserialized[ENCRYPTION_KEY_MAP_KEY],
-    serviceEndpoints: deserialized[SERVICES_KEY_MAP_KEY]?.map(
-      legacyEndpointToModern
-    ),
+    serviceEndpoints: deserialized[SERVICES_KEY_MAP_KEY],
   }
 }

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -293,15 +293,15 @@ describe('When exporting a DID Document from a light DID', () => {
     expect(didDoc).toMatchInlineSnapshot(`
       Object {
         "authentication": Array [
-          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#authentication",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#authentication",
         ],
-        "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD",
+        "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y",
         "keyAgreement": Array [
-          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#encryption",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#encryption",
         ],
         "service": Array [
           Object {
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#id-1",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#id-1",
             "serviceEndpoint": Array [
               "x:url-id-1",
             ],
@@ -310,7 +310,7 @@ describe('When exporting a DID Document from a light DID', () => {
             ],
           },
           Object {
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#id-2",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#id-2",
             "serviceEndpoint": Array [
               "x:url-id-2",
             ],
@@ -321,14 +321,14 @@ describe('When exporting a DID Document from a light DID', () => {
         ],
         "verificationMethod": Array [
           Object {
-            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD",
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#authentication",
+            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#authentication",
             "publicKeyBase58": "11111111111111111111111111111111",
             "type": "Ed25519VerificationKey2018",
           },
           Object {
-            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD",
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#encryption",
+            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#encryption",
             "publicKeyBase58": "11111111111111111111111111111111",
             "type": "X25519KeyAgreementKey2019",
           },
@@ -346,15 +346,15 @@ describe('When exporting a DID Document from a light DID', () => {
           "https://www.w3.org/ns/did/v1",
         ],
         "authentication": Array [
-          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#authentication",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#authentication",
         ],
-        "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD",
+        "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y",
         "keyAgreement": Array [
-          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#encryption",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#encryption",
         ],
         "service": Array [
           Object {
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#id-1",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#id-1",
             "serviceEndpoint": Array [
               "x:url-id-1",
             ],
@@ -363,7 +363,7 @@ describe('When exporting a DID Document from a light DID', () => {
             ],
           },
           Object {
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#id-2",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#id-2",
             "serviceEndpoint": Array [
               "x:url-id-2",
             ],
@@ -374,14 +374,14 @@ describe('When exporting a DID Document from a light DID', () => {
         ],
         "verificationMethod": Array [
           Object {
-            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD",
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#authentication",
+            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#authentication",
             "publicKeyBase58": "11111111111111111111111111111111",
             "type": "Ed25519VerificationKey2018",
           },
           Object {
-            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD",
-            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92gfAP9rxwnAYtVpSURWBmreSbN1snYMwoDZfLdzMUdwGhHn9Qx13mXVkHRLmbs8c8Ve6X5aKFSJGy9xD#encryption",
+            "controller": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y",
+            "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z12Wrs96dsMieVXwA6iiQakN3jrPpq2AHJnPu7PQJMbMs89qcTUmV1fNSEtQpsEfLDpUtqE67KBHWBBhVU7ZzFLTKz9agh8dsDNoacGg7MQLkqvzTRUE42m4df4RGKtJ92geoaqk2PZ2Rk9pDx65NpUtQUkb6hfpQPGhgJgYvtL1he6SFPGBXQsCqird5d7HvmTPPz33Een3AnU8y#encryption",
             "publicKeyBase58": "11111111111111111111111111111111",
             "type": "X25519KeyAgreementKey2019",
           },

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -64,7 +64,7 @@ function generateServiceEndpointDetails(serviceId: string): DidServiceEndpoint {
   return {
     id: serviceId,
     types: [`type-${serviceId}`],
-    urls: [`x:url-${serviceId}`],
+    uris: [`x:url-${serviceId}`],
   }
 }
 

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
@@ -91,7 +91,7 @@ function exportToJsonDidDocument(details: IDidDetails): DidDocument {
     result.service = serviceEndpoints.map((service) => ({
       id: `${details.uri}#${service.id}`,
       type: service.types,
-      serviceEndpoint: service.urls,
+      serviceEndpoint: service.uris,
     }))
   }
 

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -186,7 +186,7 @@ export async function resolveServiceEndpoint(
       return {
         uri: serviceUri,
         type: serviceEndpoint.types,
-        serviceEndpoint: serviceEndpoint.urls,
+        serviceEndpoint: serviceEndpoint.uris,
       }
     }
     case 'light': {
@@ -201,7 +201,7 @@ export async function resolveServiceEndpoint(
       return {
         uri: serviceUri,
         type: serviceEndpoint.types,
-        serviceEndpoint: serviceEndpoint.urls,
+        serviceEndpoint: serviceEndpoint.uris,
       }
     }
     default:

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -78,7 +78,7 @@ function generateServiceEndpointDetails(serviceId: string): DidServiceEndpoint {
   return {
     id: serviceId,
     types: [`type-${serviceId}`],
-    urls: [`x:url-${serviceId}`],
+    uris: [`x:url-${serviceId}`],
   }
 }
 
@@ -360,12 +360,12 @@ describe('When resolving a full DID', () => {
       {
         id: 'id-1',
         types: ['type-id-1'],
-        urls: ['x:url-id-1'],
+        uris: ['x:url-id-1'],
       },
       {
         id: 'id-2',
         types: ['type-id-2'],
-        urls: ['x:url-id-2'],
+        uris: ['x:url-id-2'],
       },
     ])
   })
@@ -478,12 +478,12 @@ describe('When resolving a light DID', () => {
       {
         id: 'service-1',
         types: ['type-service-1'],
-        urls: ['x:url-service-1'],
+        uris: ['x:url-service-1'],
       },
       {
         id: 'service-2',
         types: ['type-service-2'],
-        urls: ['x:url-service-2'],
+        uris: ['x:url-service-2'],
       },
     ])
   })

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -122,7 +122,7 @@ beforeAll(async () => {
   aliceLightDidWithDetails = LightDidDetails.fromDetails({
     authenticationKey: aliceAuthKey.authenticationKey,
     encryptionKey: aliceEncKey.keypair,
-    serviceEndpoints: [{ id: 'id-1', types: ['type-1'], urls: ['x:url-1'] }],
+    serviceEndpoints: [{ id: 'id-1', types: ['type-1'], uris: ['x:url-1'] }],
   })
   aliceFullDid = await createLocalDemoFullDidFromLightDid(aliceLightDid)
 
@@ -135,7 +135,7 @@ beforeAll(async () => {
   bobLightDidWithDetails = LightDidDetails.fromDetails({
     authenticationKey: bobAuthKey.authenticationKey,
     encryptionKey: bobEncKey.keypair,
-    serviceEndpoints: [{ id: 'id-1', types: ['type-1'], urls: ['x:url-1'] }],
+    serviceEndpoints: [{ id: 'id-1', types: ['type-1'], uris: ['x:url-1'] }],
   })
   bobFullDid = await createLocalDemoFullDidFromLightDid(bobLightDid)
 })

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -147,7 +147,7 @@ export type DidServiceEndpoint = {
   /**
    * A list of URIs the endpoint exposes its services at.
    */
-  urls: string[]
+  uris: string[]
 }
 
 /**

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -145,7 +145,7 @@ export type DidServiceEndpoint = {
    */
   types: string[]
   /**
-   * A list of URLs the endpoint exposes its services at.
+   * A list of URIs the endpoint exposes its services at.
    */
   urls: string[]
 }

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -79,7 +79,7 @@ export type DidPublicServiceEndpoint = {
   /**
    * The set of services exposed by this endpoint.
    */
-  serviceEndpoint: DidServiceEndpoint['urls']
+  serviceEndpoint: DidServiceEndpoint['uris']
 }
 
 /**


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1889

DID service endpoint URIs are not URLs.

## How to test:

yarn test

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
