### PR TITLE
fix: collect keyReferences efficiently

### DIFF
--- a/packages/did/src/DidDetails/DidDetails.utils.ts
+++ b/packages/did/src/DidDetails/DidDetails.utils.ts
@@ -36,17 +36,14 @@ export function checkDidCreationDetails({
       )
     }
   })
-  const keyIds = new Set<string>(Object.keys(keys))
-  const keyReferences = new Set<string>()
 
-  // TODO: Find a more efficient way to populate the keyReferences set
-  Object.values(keyRelationships).forEach((keysRel) => {
-    keysRel.forEach((keyRel) => {
-      keyReferences.add(keyRel)
-    })
-  })
-  keyReferences.forEach((id) => {
-    if (!keyIds.has(id))
+  const providedIds = new Set(Object.keys(keys))
+  const allIds = Object.values(keyRelationships).flatMap((ids) => [
+    ...ids.values(),
+  ])
+
+  allIds.forEach((id) => {
+    if (!providedIds.has(id))
       throw new SDKErrors.ERROR_DID_ERROR(`No key with id ${id} in "keys"`)
   })
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

Addresses a TODO "Find a more efficient way to populate the keyReferences set"

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
