### PR TITLE
feat: remove enums

### DIFF
--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -15,7 +15,7 @@ import type {
   KeyringPair,
   SignCallback,
 } from '@kiltprotocol/types'
-import { Permission, Permissions } from '@kiltprotocol/types'
+import { Permission, PermissionType } from '@kiltprotocol/types'
 import {
   createFullDidFromSeed,
   KeyTool,
@@ -82,7 +82,7 @@ async function addDelegation(
   delegee: FullDidDetails,
   delegatorSign: SignCallback,
   delegeeSign: SignCallback,
-  permissions: Permissions[] = [Permission.ATTEST, Permission.DELEGATE]
+  permissions: PermissionType[] = [Permission.ATTEST, Permission.DELEGATE]
 ): Promise<DelegationNode> {
   const delegationNode = DelegationNode.newNode({
     hierarchyId,

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -15,7 +15,7 @@ import type {
   KeyringPair,
   SignCallback,
 } from '@kiltprotocol/types'
-import { Permission } from '@kiltprotocol/types'
+import { Permission, Permissions } from '@kiltprotocol/types'
 import {
   createFullDidFromSeed,
   KeyTool,
@@ -82,7 +82,7 @@ async function addDelegation(
   delegee: FullDidDetails,
   delegatorSign: SignCallback,
   delegeeSign: SignCallback,
-  permissions: Permission[] = [Permission.ATTEST, Permission.DELEGATE]
+  permissions: Permissions[] = [Permission.ATTEST, Permission.DELEGATE]
 ): Promise<DelegationNode> {
   const delegationNode = DelegationNode.newNode({
     hierarchyId,

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -12,7 +12,7 @@ import { BN } from '@polkadot/util'
 
 import { Keyring, ss58Format } from '@kiltprotocol/utils'
 import { makeSigningKeyTool } from '@kiltprotocol/testing'
-import { DidMigrationCallback, SigningAlgorithms } from '@kiltprotocol/did'
+import { DidMigrationCallback } from '@kiltprotocol/did'
 import {
   Blockchain,
   BlockchainApiConnection,
@@ -89,7 +89,7 @@ export const devBob = keyring.createFromUri('//Bob')
 export const devCharlie = keyring.createFromUri('//Charlie')
 
 export function addressFromRandom(): IIdentity['address'] {
-  return makeSigningKeyTool(SigningAlgorithms.Ed25519).keypair.address
+  return makeSigningKeyTool('ed25519').keypair.address
 }
 
 export async function isCtypeOnChain(ctype: ICType): Promise<boolean> {

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -25,12 +25,10 @@ import type {
   IRequestForAttestation,
   SignCallback,
 } from '@kiltprotocol/types'
-import { VerificationKeyType } from '@kiltprotocol/types'
 import {
   DidDetails,
   FullDidDetails,
   LightDidDetails,
-  SigningAlgorithms,
   Utils as DidUtils,
 } from '@kiltprotocol/did'
 import {
@@ -233,10 +231,10 @@ describe('RequestForAttestation', () => {
     ).toBe(true)
   })
   it('verify credentials signed by a light DID', async () => {
-    const { keypair, sign } = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+    const { keypair, sign } = makeSigningKeyTool('ed25519')
     identityDave = await LightDidDetails.fromIdentifier(
       encodeAddress(keypair.publicKey, ss58Format),
-      VerificationKeyType.Ed25519
+      'ed25519'
     )
 
     const credential = await buildCredential(
@@ -263,10 +261,10 @@ describe('RequestForAttestation', () => {
   })
 
   it('fail to verify credentials signed by a light DID after it has been migrated and deleted', async () => {
-    const migratedAndDeleted = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+    const migratedAndDeleted = makeSigningKeyTool('ed25519')
     migratedAndDeletedLightDid = LightDidDetails.fromIdentifier(
       encodeAddress(migratedAndDeleted.keypair.publicKey, ss58Format),
-      VerificationKeyType.Ed25519
+      'ed25519'
     )
     migratedAndDeletedFullDid = new FullDidDetails({
       identifier: migratedAndDeletedLightDid.identifier,
@@ -441,12 +439,12 @@ describe('create presentation', () => {
     unmigratedClaimerKey = makeSigningKeyTool()
     unmigratedClaimerLightDid = LightDidDetails.fromIdentifier(
       encodeAddress(unmigratedClaimerKey.keypair.publicKey, ss58Format),
-      VerificationKeyType.Sr25519
+      'sr25519'
     )
     const migratedClaimerKey = makeSigningKeyTool()
     migratedClaimerLightDid = LightDidDetails.fromIdentifier(
       encodeAddress(migratedClaimerKey.keypair.publicKey, ss58Format),
-      VerificationKeyType.Sr25519
+      'sr25519'
     )
     // Change also the authentication key of the full DID to properly verify signature verification,
     // so that it uses a completely different key and the credential is still correctly verified.
@@ -458,10 +456,10 @@ describe('create presentation', () => {
         id: 'new-auth',
       }
     )
-    migratedThenDeletedKey = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+    migratedThenDeletedKey = makeSigningKeyTool('ed25519')
     migratedThenDeletedClaimerLightDid = LightDidDetails.fromIdentifier(
       encodeAddress(migratedThenDeletedKey.keypair.publicKey, ss58Format),
-      VerificationKeyType.Ed25519
+      'ed25519'
     )
     migratedThenDeletedClaimerFullDid = createMinimalFullDidFromLightDid(
       migratedThenDeletedClaimerLightDid as LightDidDetails

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -30,7 +30,6 @@ import type {
   IRequestForAttestation,
   SignCallback,
 } from '@kiltprotocol/types'
-import { KeyRelationship } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import * as Attestation from '../attestation/index.js'
 import { verifyClaimAgainstSchema } from '../ctype/index.js'
@@ -243,11 +242,11 @@ export async function createPresentation({
     excludedClaimProperties
   )
 
-  const keys = claimerDid.getVerificationKeys(KeyRelationship.authentication)
+  const keys = claimerDid.getVerificationKeys('authentication')
   const selectedKeyId = (await keySelection(keys))?.id
 
   if (!selectedKeyId) {
-    throw new SDKErrors.ERROR_UNSUPPORTED_KEY(KeyRelationship.authentication)
+    throw new SDKErrors.ERROR_UNSUPPORTED_KEY('authentication')
   }
 
   await RequestForAttestation.signWithDidKey(

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -20,7 +20,7 @@ import type {
   IDelegationNode,
   IDelegationHierarchyDetails,
 } from '@kiltprotocol/types'
-import { Permission } from '@kiltprotocol/types'
+import { Permission, Permissions } from '@kiltprotocol/types'
 import type { Option } from '@polkadot/types'
 import type { Struct, Vec } from '@polkadot/types/codec'
 import type { AccountId, Hash } from '@polkadot/types/interfaces/runtime'
@@ -66,8 +66,8 @@ export function decodeDelegationHierarchyDetails(
  * @param bitset The u32 number used as the bitset to encode permissions.
  * @returns The permission set.
  */
-function decodePermissions(bitset: number): Permission[] {
-  const permissions: Permission[] = []
+function decodePermissions(bitset: number): Permissions[] {
+  const permissions: Permissions[] = []
   // eslint-disable-next-line no-bitwise
   if (bitset & Permission.ATTEST) {
     permissions.push(Permission.ATTEST)

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -20,7 +20,7 @@ import type {
   IDelegationNode,
   IDelegationHierarchyDetails,
 } from '@kiltprotocol/types'
-import { Permission, Permissions } from '@kiltprotocol/types'
+import { Permission, PermissionType } from '@kiltprotocol/types'
 import type { Option } from '@polkadot/types'
 import type { Struct, Vec } from '@polkadot/types/codec'
 import type { AccountId, Hash } from '@polkadot/types/interfaces/runtime'
@@ -66,8 +66,8 @@ export function decodeDelegationHierarchyDetails(
  * @param bitset The u32 number used as the bitset to encode permissions.
  * @returns The permission set.
  */
-function decodePermissions(bitset: number): Permissions[] {
-  const permissions: Permissions[] = []
+function decodePermissions(bitset: number): PermissionType[] {
+  const permissions: PermissionType[] = []
   // eslint-disable-next-line no-bitwise
   if (bitset & Permission.ATTEST) {
     permissions.push(Permission.ATTEST)

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -12,7 +12,6 @@ import {
   IDelegationHierarchyDetails,
   IDelegationNode,
   IDidDetails,
-  KeyRelationship,
   SignCallback,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
@@ -281,7 +280,7 @@ export class DelegationNode implements IDelegationNode {
     } = {}
   ): Promise<DidChain.SignatureEnum> {
     const authenticationKey = await keySelection(
-      delegeeDid.getVerificationKeys(KeyRelationship.authentication)
+      delegeeDid.getVerificationKeys('authentication')
     )
     if (!authenticationKey) {
       throw new SDKErrors.ERROR_DID_ERROR(

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -26,11 +26,7 @@ import type {
   IRequestForAttestation,
 } from '@kiltprotocol/types'
 import { Crypto } from '@kiltprotocol/utils'
-import {
-  DidDetails,
-  SigningAlgorithms,
-  Utils as DidUtils,
-} from '@kiltprotocol/did'
+import { DidDetails, Utils as DidUtils } from '@kiltprotocol/did'
 import {
   createLocalDemoFullDidFromKeypair,
   makeSigningKeyTool,
@@ -42,10 +38,10 @@ import { QuoteSchema } from './QuoteSchema'
 
 describe('Quote', () => {
   let claimerIdentity: DidDetails
-  const claimer = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+  const claimer = makeSigningKeyTool('ed25519')
 
   let attesterIdentity: DidDetails
-  const attester = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+  const attester = makeSigningKeyTool('ed25519')
 
   let invalidCost: ICostBreakdown
   let date: string
@@ -250,8 +246,8 @@ describe('Quote compression', () => {
   })()
 
   beforeAll(async () => {
-    const claimer = makeSigningKeyTool(SigningAlgorithms.Ed25519)
-    const attester = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+    const claimer = makeSigningKeyTool('ed25519')
+    const attester = makeSigningKeyTool('ed25519')
 
     claimerIdentity = await createLocalDemoFullDidFromKeypair(claimer.keypair)
     attesterIdentity = await createLocalDemoFullDidFromKeypair(attester.keypair)

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -32,7 +32,6 @@ import type {
   IRequestForAttestation,
   SignCallback,
 } from '@kiltprotocol/types'
-import { KeyRelationship } from '@kiltprotocol/types'
 import { Crypto, JsonSchema, SDKErrors } from '@kiltprotocol/utils'
 import {
   DidDetails,
@@ -97,7 +96,7 @@ export async function createAttesterSignedQuote(
   }
 
   const authenticationKey = await keySelection(
-    attesterIdentity.getVerificationKeys(KeyRelationship.authentication)
+    attesterIdentity.getVerificationKeys('authentication')
   )
   if (!authenticationKey) {
     throw new SDKErrors.ERROR_DID_ERROR(
@@ -138,7 +137,7 @@ export async function verifyAttesterSignedQuote(
   const result = await verifyDidSignature({
     signature: attesterSignature,
     message: Crypto.hashObjectAsStr(basicQuote),
-    expectedVerificationMethod: KeyRelationship.authentication,
+    expectedVerificationMethod: 'authentication',
     resolver,
   })
 
@@ -191,12 +190,12 @@ export async function createQuoteAgreement(
   await verifyDidSignature({
     signature: attesterSignature,
     message: Crypto.hashObjectAsStr(basicQuote),
-    expectedVerificationMethod: KeyRelationship.authentication,
+    expectedVerificationMethod: 'authentication',
     resolver,
   })
 
   const claimerAuthenticationKey = await keySelection(
-    claimerIdentity.getVerificationKeys(KeyRelationship.authentication)
+    claimerIdentity.getVerificationKeys('authentication')
   )
   if (!claimerAuthenticationKey) {
     throw new SDKErrors.ERROR_DID_ERROR(

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -30,7 +30,6 @@ import type {
   IRequestForAttestation,
   SignCallback,
 } from '@kiltprotocol/types'
-import { KeyRelationship } from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import {
   DidDetails,
@@ -312,7 +311,7 @@ export async function verifySignature(
   const { verified } = await verifyDidSignature({
     signature: claimerSignature,
     message: signingData,
-    expectedVerificationMethod: KeyRelationship.authentication,
+    expectedVerificationMethod: 'authentication',
     resolver,
   })
   return verified

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -9,13 +9,7 @@
  * @group unit/did
  */
 
-import {
-  DidSignature,
-  KeyRelationship,
-  KeyringPair,
-  SignCallback,
-  VerificationKeyType,
-} from '@kiltprotocol/types'
+import { DidSignature, KeyringPair, SignCallback } from '@kiltprotocol/types'
 import Keyring from '@polkadot/keyring'
 import {
   mnemonicGenerate,
@@ -41,10 +35,7 @@ describe('light DID', () => {
     keypair = new Keyring({ type: 'sr25519', ss58Format }).addFromMnemonic(
       mnemonicGenerate()
     )
-    details = LightDidDetails.fromIdentifier(
-      keypair.address,
-      VerificationKeyType.Sr25519
-    )
+    details = LightDidDetails.fromIdentifier(keypair.address, 'sr25519')
     sign = async ({ data, alg }) => ({ data: keypair.sign(data), alg })
   })
 
@@ -75,7 +66,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: true,
@@ -95,7 +86,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: true,
@@ -115,7 +106,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.assertionMethod,
+        expectedVerificationMethod: 'assertionMethod',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,
@@ -135,7 +126,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,
@@ -154,7 +145,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING.substring(1),
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,
@@ -175,7 +166,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,
@@ -201,7 +192,7 @@ describe('light DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,
@@ -231,7 +222,7 @@ describe('full DID', () => {
       uri: `did:kilt:${keypair.address}`,
       keys: {
         '0x12345': {
-          type: VerificationKeyType.Sr25519,
+          type: 'sr25519',
           publicKey: keypair.publicKey,
         },
       },
@@ -267,7 +258,7 @@ describe('full DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: true,
@@ -287,7 +278,7 @@ describe('full DID', () => {
       await verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: true,
@@ -313,7 +304,7 @@ describe('full DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,
@@ -333,7 +324,7 @@ describe('full DID', () => {
       await verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: KeyRelationship.authentication,
+        expectedVerificationMethod: 'authentication',
       })
     ).toMatchObject<VerificationResult>({
       verified: false,

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -14,6 +14,7 @@ import {
   DidKey,
   DidPublicKey,
   EncryptionKeyType,
+  encryptionKeyTypes,
   IDidDetails,
   DidIdentifier,
   NewDidKey,
@@ -21,6 +22,7 @@ import {
   DidServiceEndpoint,
   EncryptionAlgorithms,
   SigningAlgorithms,
+  verificationKeyTypes,
 } from '@kiltprotocol/types'
 import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
 
@@ -171,9 +173,9 @@ export function isSameSubject(
 }
 
 const signatureAlgForKeyType: Record<VerificationKeyType, SigningAlgorithms> = {
-  [VerificationKeyType.Ed25519]: SigningAlgorithms.Ed25519,
-  [VerificationKeyType.Sr25519]: SigningAlgorithms.Sr25519,
-  [VerificationKeyType.Ecdsa]: SigningAlgorithms.EcdsaSecp256k1,
+  ed25519: 'ed25519',
+  sr25519: 'sr25519',
+  ecdsa: 'ecdsa-secp256k1',
 }
 const keyTypeForSignatureAlg = Object.entries(signatureAlgForKeyType).reduce(
   (obj, [key, value]) => ({ ...obj, [value]: key }),
@@ -206,7 +208,7 @@ export function getVerificationKeyTypeForSigningAlgorithm(
 
 const encryptionAlgForKeyType: Record<EncryptionKeyType, EncryptionAlgorithms> =
   {
-    [EncryptionKeyType.X25519]: EncryptionAlgorithms.NaclBox,
+    x25519: 'x25519-xsalsa20-poly1305',
   }
 
 /**
@@ -223,7 +225,7 @@ export function getEncryptionAlgorithmForEncryptionKeyType(
 
 const keyTypeForEncryptionAlg: Record<EncryptionAlgorithms, EncryptionKeyType> =
   {
-    [EncryptionAlgorithms.NaclBox]: EncryptionKeyType.X25519,
+    'x25519-xsalsa20-poly1305': 'x25519',
   }
 
 /**
@@ -245,7 +247,7 @@ export function getEncryptionKeyTypeForEncryptionAlgorithm(
  * @returns True if the key is a verification key, false otherwise.
  */
 export function isVerificationKey(key: NewDidKey | DidKey): boolean {
-  return Object.values(VerificationKeyType).some((kt) => kt === key.type)
+  return verificationKeyTypes.some((kt) => kt === key.type)
 }
 
 /**
@@ -255,7 +257,7 @@ export function isVerificationKey(key: NewDidKey | DidKey): boolean {
  * @returns True if the key is an encryption key, false otherwise.
  */
 export function isEncryptionKey(key: NewDidKey | DidKey): boolean {
-  return Object.values(EncryptionKeyType).some((kt) => kt === key.type)
+  return encryptionKeyTypes.some((kt) => kt === key.type)
 }
 
 /**

--- a/packages/did/src/DidBatcher/DidBatchBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/DidBatchBuilder.spec.ts
@@ -17,7 +17,6 @@ import {
   KeyringPair,
   NewDidKey,
   SignCallback,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 import {
   createLocalDemoFullDidFromKeypair,
@@ -40,9 +39,9 @@ jest.mock('../Did.chain.js', () => ({
     ): Promise<Extrinsic> => {
       const keyAsEnum = formatPublicKey(key)
       switch (keyRelationship) {
-        case KeyRelationship.capabilityDelegation:
+        case 'capabilityDelegation':
           return mockApi.tx.did.setDelegationKey(keyAsEnum)
-        case KeyRelationship.assertionMethod:
+        case 'assertionMethod':
           return mockApi.tx.did.setAttestationKey(keyAsEnum)
         default:
           return mockApi.tx.did.setAuthenticationKey(keyAsEnum)
@@ -64,9 +63,9 @@ describe('DidBatchBuilder', () => {
   describe('.addSingleExtrinsic()', () => {
     it('fails if the extrinsic is a DID extrinsic', async () => {
       const builder = new DidBatchBuilder(mockApi, fullDid)
-      const ext = await getSetKeyExtrinsic(KeyRelationship.assertionMethod, {
+      const ext = await getSetKeyExtrinsic('assertionMethod', {
         publicKey: Uint8Array.from(new Array(32).fill(1)),
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
       })
       expect(() => builder.addSingleExtrinsic(ext)).toThrow()
     })
@@ -118,15 +117,15 @@ describe('DidBatchBuilder', () => {
         builder.batches
       ).toStrictEqual([
         {
-          keyRelationship: KeyRelationship.assertionMethod,
+          keyRelationship: 'assertionMethod',
           extrinsics: [ctype1Extrinsic, ctype2Extrinsic],
         },
         {
-          keyRelationship: KeyRelationship.capabilityDelegation,
+          keyRelationship: 'capabilityDelegation',
           extrinsics: [delegationExtrinsic],
         },
         {
-          keyRelationship: KeyRelationship.assertionMethod,
+          keyRelationship: 'assertionMethod',
           extrinsics: [ctype3Extrinsic],
         },
       ])

--- a/packages/did/src/DidBatcher/FullDidBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidBuilder.spec.ts
@@ -15,13 +15,11 @@ import {
   DidEncryptionKey,
   DidKey,
   DidServiceEndpoint,
-  EncryptionKeyType,
   SignCallback,
   NewDidEncryptionKey,
   NewDidKey,
   NewDidVerificationKey,
   SubmittableExtrinsic,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 import { computeKeyId, ApiMocks } from '@kiltprotocol/testing'
 
@@ -51,7 +49,7 @@ describe('FullDidBuilder', () => {
   describe('Key agreement keys', () => {
     const newEncryptionKey: NewDidEncryptionKey = {
       publicKey: Uint8Array.from(Array(32).fill(1)),
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
     }
     describe('.addEncryptionKey()', () => {
       it('fails if the key has been marked for addition', async () => {
@@ -81,7 +79,7 @@ describe('FullDidBuilder', () => {
   describe('Attestation keys', () => {
     const newAttestationKey: NewDidVerificationKey = {
       publicKey: Uint8Array.from(Array(32).fill(11)),
-      type: VerificationKeyType.Ecdsa,
+      type: 'ecdsa',
     }
     describe('.setAttestationKey()', () => {
       it('fails if another key has already been marked for addition', async () => {
@@ -110,7 +108,7 @@ describe('FullDidBuilder', () => {
   describe('Delegation keys', () => {
     const newDelegationKey: NewDidVerificationKey = {
       publicKey: Uint8Array.from(Array(32).fill(21)),
-      type: VerificationKeyType.Ed25519,
+      type: 'ed25519',
     }
     describe('.setDelegation()', () => {
       it('fails if another key has already been marked for addition', async () => {

--- a/packages/did/src/DidBatcher/FullDidCreationBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidCreationBuilder.spec.ts
@@ -16,11 +16,9 @@ import {
   DidEncryptionKey,
   DidKey,
   DidServiceEndpoint,
-  EncryptionKeyType,
   NewDidEncryptionKey,
   NewDidKey,
   NewDidVerificationKey,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 
 import { FullDidCreationBuilder } from './FullDidCreationBuilder'
@@ -40,11 +38,11 @@ describe('FullDidCreationBuilder', () => {
     describe('.fromLightDidDetails()', () => {
       const authKey: NewLightDidAuthenticationKey = {
         publicKey: Uint8Array.from(Array(32).fill(0)),
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
       }
       const encKey: NewDidEncryptionKey = {
         publicKey: Uint8Array.from(Array(32).fill(0)),
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       }
       const service1: DidServiceEndpoint = {
         id: 'id-1',

--- a/packages/did/src/DidBatcher/FullDidCreationBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidCreationBuilder.ts
@@ -14,7 +14,6 @@ import {
   SignCallback,
   NewDidVerificationKey,
   SubmittableExtrinsic,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 
 import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
@@ -31,10 +30,10 @@ function encodeVerificationKeyToAddress({
   type,
 }: Pick<DidVerificationKey, 'publicKey' | 'type'>): IIdentity['address'] {
   switch (type) {
-    case VerificationKeyType.Ed25519:
-    case VerificationKeyType.Sr25519:
+    case 'ed25519':
+    case 'sr25519':
       return encodeAddress(publicKey, ss58Format)
-    case VerificationKeyType.Ecdsa: {
+    case 'ecdsa': {
       // Taken from https://github.com/polkadot-js/common/blob/master/packages/keyring/src/pair/index.ts#L44
       const pk = publicKey.length > 32 ? blake2AsU8a(publicKey) : publicKey
       return encodeAddress(pk, ss58Format)

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
@@ -22,14 +22,11 @@ import {
   DidKey,
   DidServiceEndpoint,
   DidVerificationKey,
-  EncryptionKeyType,
-  KeyRelationship,
   KeyringPair,
   NewDidEncryptionKey,
   NewDidKey,
   NewDidVerificationKey,
   SignCallback,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 
 import { FullDidUpdateBuilder } from './FullDidUpdateBuilder'
@@ -64,7 +61,7 @@ describe('FullDidUpdateBuilder', () => {
       >(
         new Map(
           fullDid
-            .getEncryptionKeys(KeyRelationship.keyAgreement)
+            .getEncryptionKeys('keyAgreement')
             .map(({ id, ...details }) => [id, { ...details }])
         )
       )
@@ -99,7 +96,7 @@ describe('FullDidUpdateBuilder', () => {
     })
     const newAuthenticationKey: NewDidVerificationKey = {
       publicKey: Uint8Array.from(Array(33).fill(1)),
-      type: VerificationKeyType.Ecdsa,
+      type: 'ecdsa',
     }
 
     it('fails if the authentication key is set twice', async () => {
@@ -127,12 +124,12 @@ describe('FullDidUpdateBuilder', () => {
     let fullDid: FullDidDetails
     const newEncryptionKey: NewDidEncryptionKey = {
       publicKey: Uint8Array.from(Array(32).fill(1)),
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
     }
     beforeAll(async () => {
       const { keypair } = makeSigningKeyTool()
       fullDid = await createLocalDemoFullDidFromKeypair(keypair, {
-        keyRelationships: new Set([KeyRelationship.keyAgreement]),
+        keyRelationships: new Set(['keyAgreement']),
       })
     })
 
@@ -237,12 +234,12 @@ describe('FullDidUpdateBuilder', () => {
     let fullDid: FullDidDetails
     const newAttestationKey: NewDidVerificationKey = {
       publicKey: Uint8Array.from(Array(33).fill(11)),
-      type: VerificationKeyType.Ecdsa,
+      type: 'ecdsa',
     }
     beforeAll(async () => {
       const { keypair } = makeSigningKeyTool()
       fullDid = await createLocalDemoFullDidFromKeypair(keypair, {
-        keyRelationships: new Set([KeyRelationship.assertionMethod]),
+        keyRelationships: new Set(['assertionMethod']),
       })
     })
     describe('.setAttestationKey()', () => {
@@ -325,12 +322,12 @@ describe('FullDidUpdateBuilder', () => {
     let fullDid: FullDidDetails
     const newDelegationKey: NewDidVerificationKey = {
       publicKey: Uint8Array.from(Array(33).fill(21)),
-      type: VerificationKeyType.Ecdsa,
+      type: 'ecdsa',
     }
     beforeAll(async () => {
       const { keypair } = makeSigningKeyTool()
       fullDid = await createLocalDemoFullDidFromKeypair(keypair, {
-        keyRelationships: new Set([KeyRelationship.capabilityDelegation]),
+        keyRelationships: new Set(['capabilityDelegation']),
       })
     })
     describe('.setDelegationKey()', () => {

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
@@ -21,7 +21,6 @@ import type {
   SubmittableExtrinsic,
   IDidDetails,
 } from '@kiltprotocol/types'
-import { KeyRelationship } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 
 import { FullDidDetails } from '../DidDetails/FullDidDetails.js'
@@ -101,7 +100,7 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     this.oldDelegationKey = details.delegationKey
 
     details
-      .getEncryptionKeys(KeyRelationship.keyAgreement)
+      .getEncryptionKeys('keyAgreement')
       .forEach(({ id, ...keyDetails }) =>
         this.oldKeyAgreementKeys.set(id, keyDetails)
       )

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -18,7 +18,6 @@ import {
   DidIdentifier,
   SignCallback,
   VerificationKeyType,
-  KeyRelationship,
   VerificationKeyRelationship,
   EncryptionKeyRelationship,
 } from '@kiltprotocol/types'
@@ -78,9 +77,7 @@ export abstract class DidDetails implements IDidDetails {
    * @returns The first authentication key, in the order they are stored internally, of the given DID.
    */
   public get authenticationKey(): DidVerificationKey {
-    const firstAuthenticationKey = this.getVerificationKeys(
-      KeyRelationship.authentication
-    )[0]
+    const firstAuthenticationKey = this.getVerificationKeys('authentication')[0]
     if (!firstAuthenticationKey) {
       throw new SDKErrors.ERROR_DID_ERROR(
         'Unexpected error. Any DID should always have at least one authentication key.'
@@ -95,7 +92,7 @@ export abstract class DidDetails implements IDidDetails {
    * @returns The first encryption key, in the order they are stored internally, of the given DID.
    */
   public get encryptionKey(): DidEncryptionKey | undefined {
-    return this.getEncryptionKeys(KeyRelationship.keyAgreement)[0]
+    return this.getEncryptionKeys('keyAgreement')[0]
   }
 
   /**
@@ -104,7 +101,7 @@ export abstract class DidDetails implements IDidDetails {
    * @returns The first attestation key, in the order they are stored internally, of the given DID.
    */
   public get attestationKey(): DidVerificationKey | undefined {
-    return this.getVerificationKeys(KeyRelationship.assertionMethod)[0]
+    return this.getVerificationKeys('assertionMethod')[0]
   }
 
   /**
@@ -113,7 +110,7 @@ export abstract class DidDetails implements IDidDetails {
    * @returns The first delegation key, in the order they are stored internally, of the given DID.
    */
   public get delegationKey(): DidVerificationKey | undefined {
-    return this.getVerificationKeys(KeyRelationship.capabilityDelegation)[0]
+    return this.getVerificationKeys('capabilityDelegation')[0]
   }
 
   /**

--- a/packages/did/src/DidDetails/DidDetails.utils.ts
+++ b/packages/did/src/DidDetails/DidDetails.utils.ts
@@ -9,7 +9,7 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import { KeyRelationship } from '@kiltprotocol/types'
+import { keyRelationships as allKeyRelationships } from '@kiltprotocol/types'
 
 import type { DidConstructorDetails } from '../types.js'
 import { validateKiltDidUri } from '../Did.utils.js'
@@ -20,19 +20,16 @@ export function checkDidCreationDetails({
   keyRelationships,
 }: DidConstructorDetails): void {
   validateKiltDidUri(uri, false)
-  if (keyRelationships[KeyRelationship.authentication]?.size !== 1) {
+  if (keyRelationships.authentication?.size !== 1) {
     throw Error(
-      `One and only one ${KeyRelationship.authentication} key is required on any instance of DidDetails`
+      `One and only one ${'authentication'} key is required on any instance of DidDetails`
     )
   }
-  const allowedKeyRelationships = new Set([
-    ...Object.values(KeyRelationship),
-    'none',
-  ])
+  const allowedKeyRelationships = new Set([...allKeyRelationships, 'none'])
   Object.keys(keyRelationships).forEach((keyRel) => {
     if (!allowedKeyRelationships.has(keyRel)) {
       throw Error(
-        `key relationship ${keyRel} is not recognized. Allowed: ${KeyRelationship}`
+        `key relationship ${keyRel} is not recognized. Allowed: ${allKeyRelationships}`
       )
     }
   })

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -7,14 +7,7 @@
 
 import { BN } from '@polkadot/util'
 
-import {
-  DidKey,
-  DidServiceEndpoint,
-  DidIdentifier,
-  KeyRelationship,
-  VerificationKeyType,
-  EncryptionKeyType,
-} from '@kiltprotocol/types'
+import { DidKey, DidServiceEndpoint, DidIdentifier } from '@kiltprotocol/types'
 
 import type { IDidChainRecordJSON } from '../Did.chain'
 import { getKiltDidFromIdentifier } from '../Did.utils'
@@ -40,31 +33,31 @@ const existingDidDetails: IDidChainRecordJSON = {
     {
       id: 'auth#1',
       publicKey: new Uint8Array(32).fill(0),
-      type: VerificationKeyType.Sr25519,
+      type: 'sr25519',
       includedAt: new BN(0),
     },
     {
       id: 'enc#1',
       publicKey: new Uint8Array(32).fill(1),
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
       includedAt: new BN(0),
     },
     {
       id: 'enc#2',
       publicKey: new Uint8Array(32).fill(2),
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
       includedAt: new BN(0),
     },
     {
       id: 'att#1',
       publicKey: new Uint8Array(32).fill(3),
-      type: VerificationKeyType.Ed25519,
+      type: 'ed25519',
       includedAt: new BN(0),
     },
     {
       id: 'del#1',
       publicKey: new Uint8Array(32).fill(4),
-      type: VerificationKeyType.Ecdsa,
+      type: 'ecdsa',
       includedAt: new BN(0),
     },
   ],
@@ -133,16 +126,16 @@ describe('When creating an instance from the chain', () => {
     expect(fullDidDetails?.getKey('auth#1')).toStrictEqual<DidKey>({
       id: 'auth#1',
       publicKey: new Uint8Array(32).fill(0),
-      type: VerificationKeyType.Sr25519,
+      type: 'sr25519',
       includedAt: new BN(0),
     })
-    expect(
-      fullDidDetails?.getVerificationKeys(KeyRelationship.authentication)
-    ).toStrictEqual<DidKey[]>([
+    expect(fullDidDetails?.getVerificationKeys('authentication')).toStrictEqual<
+      DidKey[]
+    >([
       {
         id: 'auth#1',
         publicKey: new Uint8Array(32).fill(0),
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
         includedAt: new BN(0),
       },
     ])
@@ -151,28 +144,28 @@ describe('When creating an instance from the chain', () => {
     expect(fullDidDetails?.getKey('enc#1')).toStrictEqual<DidKey>({
       id: 'enc#1',
       publicKey: new Uint8Array(32).fill(1),
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
       includedAt: new BN(0),
     })
     expect(fullDidDetails?.getKey('enc#2')).toStrictEqual<DidKey>({
       id: 'enc#2',
       publicKey: new Uint8Array(32).fill(2),
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
       includedAt: new BN(0),
     })
-    expect(
-      fullDidDetails?.getEncryptionKeys(KeyRelationship.keyAgreement)
-    ).toStrictEqual<DidKey[]>([
+    expect(fullDidDetails?.getEncryptionKeys('keyAgreement')).toStrictEqual<
+      DidKey[]
+    >([
       {
         id: 'enc#1',
         publicKey: new Uint8Array(32).fill(1),
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
         includedAt: new BN(0),
       },
       {
         id: 'enc#2',
         publicKey: new Uint8Array(32).fill(2),
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
         includedAt: new BN(0),
       },
     ])
@@ -181,16 +174,16 @@ describe('When creating an instance from the chain', () => {
     expect(fullDidDetails?.getKey('att#1')).toStrictEqual<DidKey>({
       id: 'att#1',
       publicKey: new Uint8Array(32).fill(3),
-      type: VerificationKeyType.Ed25519,
+      type: 'ed25519',
       includedAt: new BN(0),
     })
     expect(
-      fullDidDetails?.getVerificationKeys(KeyRelationship.assertionMethod)
+      fullDidDetails?.getVerificationKeys('assertionMethod')
     ).toStrictEqual<DidKey[]>([
       {
         id: 'att#1',
         publicKey: new Uint8Array(32).fill(3),
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
         includedAt: new BN(0),
       },
     ])
@@ -199,16 +192,16 @@ describe('When creating an instance from the chain', () => {
     expect(fullDidDetails?.getKey('del#1')).toStrictEqual<DidKey>({
       id: 'del#1',
       publicKey: new Uint8Array(32).fill(4),
-      type: VerificationKeyType.Ecdsa,
+      type: 'ecdsa',
       includedAt: new BN(0),
     })
     expect(
-      fullDidDetails?.getVerificationKeys(KeyRelationship.capabilityDelegation)
+      fullDidDetails?.getVerificationKeys('capabilityDelegation')
     ).toStrictEqual<DidKey[]>([
       {
         id: 'del#1',
         publicKey: new Uint8Array(32).fill(4),
-        type: VerificationKeyType.Ecdsa,
+        type: 'ecdsa',
         includedAt: new BN(0),
       },
     ])

--- a/packages/did/src/DidDetails/FullDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.utils.ts
@@ -12,7 +12,6 @@ import type { Extrinsic } from '@polkadot/types/interfaces'
 import { BN } from '@polkadot/util'
 
 import type { VerificationKeyRelationship } from '@kiltprotocol/types'
-import { KeyRelationship } from '@kiltprotocol/types'
 
 interface MethodMapping<V extends string> {
   default: V
@@ -27,17 +26,17 @@ type SectionMapping<V extends string> = Record<string, MethodMapping<V>>
 const methodMapping: SectionMapping<
   VerificationKeyRelationship | 'paymentAccount'
 > = {
-  attestation: { default: KeyRelationship.assertionMethod },
-  ctype: { default: KeyRelationship.assertionMethod },
-  delegation: { default: KeyRelationship.capabilityDelegation },
+  attestation: { default: 'assertionMethod' },
+  ctype: { default: 'assertionMethod' },
+  delegation: { default: 'capabilityDelegation' },
   did: {
     create: 'paymentAccount',
     reclaimDeposit: 'paymentAccount',
     submitDidCall: 'paymentAccount',
-    default: KeyRelationship.authentication,
+    default: 'authentication',
   },
-  didLookup: { default: KeyRelationship.authentication },
-  web3Names: { default: KeyRelationship.authentication },
+  didLookup: { default: 'authentication' },
+  web3Names: { default: 'authentication' },
   // Batch calls are not included here
   default: { default: 'paymentAccount' },
 }

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -7,14 +7,7 @@
 
 import { Keyring } from '@polkadot/api'
 
-import {
-  DidKey,
-  DidServiceEndpoint,
-  DidUri,
-  EncryptionKeyType,
-  KeyRelationship,
-  VerificationKeyType,
-} from '@kiltprotocol/types'
+import { DidKey, DidServiceEndpoint, DidUri } from '@kiltprotocol/types'
 import { ss58Format } from '@kiltprotocol/utils'
 
 import { getKiltDidFromIdentifier } from '../Did.utils'
@@ -64,11 +57,11 @@ describe('When creating an instance from the details', () => {
     const validOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
       encryptionKey: {
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
       serviceEndpoints: endpoints,
     }
@@ -79,7 +72,7 @@ describe('When creating an instance from the details', () => {
     const encodedDetails = serializeAndEncodeAdditionalLightDidDetails({
       encryptionKey: {
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
       serviceEndpoints: endpoints,
     })!
@@ -98,15 +91,15 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.getKey('authentication')).toStrictEqual<DidKey>({
       id: 'authentication',
       publicKey: authKey.publicKey,
-      type: VerificationKeyType.Sr25519,
+      type: 'sr25519',
     })
     expect(
-      lightDidDetails?.getVerificationKeys(KeyRelationship.authentication)
+      lightDidDetails?.getVerificationKeys('authentication')
     ).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
     ])
     expect(lightDidDetails?.authenticationKey.id).toStrictEqual(
@@ -116,15 +109,15 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.getKey('encryption')).toStrictEqual<DidKey>({
       id: 'encryption',
       publicKey: encKey.publicKey,
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
     })
-    expect(
-      lightDidDetails?.getEncryptionKeys(KeyRelationship.keyAgreement)
-    ).toStrictEqual<DidKey[]>([
+    expect(lightDidDetails?.getEncryptionKeys('keyAgreement')).toStrictEqual<
+      DidKey[]
+    >([
       {
         id: 'encryption',
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
     ])
     expect(lightDidDetails?.encryptionKey?.id).toStrictEqual('encryption')
@@ -176,11 +169,11 @@ describe('When creating an instance from the details', () => {
     const validOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
       },
       encryptionKey: {
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
     }
     const lightDidDetails = LightDidDetails.fromDetails(validOptions)
@@ -190,7 +183,7 @@ describe('When creating an instance from the details', () => {
     const encodedDetails = serializeAndEncodeAdditionalLightDidDetails({
       encryptionKey: {
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
     })!
     const expectedDid = getKiltDidFromIdentifier(
@@ -208,15 +201,15 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.getKey('authentication')).toStrictEqual<DidKey>({
       id: 'authentication',
       publicKey: authKey.publicKey,
-      type: VerificationKeyType.Ed25519,
+      type: 'ed25519',
     })
     expect(
-      lightDidDetails?.getVerificationKeys(KeyRelationship.authentication)
+      lightDidDetails?.getVerificationKeys('authentication')
     ).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
       },
     ])
     expect(lightDidDetails?.authenticationKey.id).toStrictEqual(
@@ -226,15 +219,15 @@ describe('When creating an instance from the details', () => {
     expect(lightDidDetails?.getKey('encryption')).toStrictEqual<DidKey>({
       id: 'encryption',
       publicKey: encKey.publicKey,
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
     })
-    expect(
-      lightDidDetails?.getEncryptionKeys(KeyRelationship.keyAgreement)
-    ).toStrictEqual<DidKey[]>([
+    expect(lightDidDetails?.getEncryptionKeys('keyAgreement')).toStrictEqual<
+      DidKey[]
+    >([
       {
         id: 'encryption',
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
     ])
     expect(lightDidDetails?.encryptionKey?.id).toStrictEqual('encryption')
@@ -261,7 +254,7 @@ describe('When creating an instance from the details', () => {
       authenticationKey: {
         publicKey: authKey.publicKey,
         // @ts-ignore Not an authentication key type
-        type: VerificationKeyType.Ecdsa,
+        type: 'ecdsa',
       },
     }
     expect(() => LightDidDetails.fromDetails(invalidOptions)).toThrowError()
@@ -276,7 +269,7 @@ describe('When creating an instance from the details', () => {
     const invalidOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
       },
       encryptionKey: {
         publicKey: encKey.publicKey,
@@ -310,11 +303,11 @@ describe('When creating an instance from a URI', () => {
     const creationOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
       encryptionKey: {
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
       serviceEndpoints: endpoints,
     }
@@ -362,11 +355,11 @@ describe('When creating an instance from a URI', () => {
     const creationOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
       encryptionKey: {
         publicKey: encKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
       serviceEndpoints: endpoints,
     }
@@ -412,7 +405,7 @@ describe('When creating an instance from an identifier', () => {
     const creationOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
     }
 
@@ -421,14 +414,14 @@ describe('When creating an instance from an identifier', () => {
     // We are sure this is correct because of the described case above
     const builtLightDidDetails = LightDidDetails.fromIdentifier(
       authKey.address,
-      VerificationKeyType.Sr25519
+      'sr25519'
     )
 
     expect(builtLightDidDetails).toStrictEqual<LightDidDetails>(
       expectedLightDidDetails
     )
     expect(builtLightDidDetails.authKeyEncoding).toStrictEqual(
-      getEncodingForVerificationKeyType(VerificationKeyType.Sr25519)
+      getEncodingForVerificationKeyType('sr25519')
     )
 
     expect(builtLightDidDetails?.authenticationKey.id).toStrictEqual(
@@ -448,7 +441,7 @@ describe('When creating an instance from an identifier', () => {
     const creationOptions: LightDidCreationDetails = {
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
       },
     }
 
@@ -457,14 +450,14 @@ describe('When creating an instance from an identifier', () => {
     // We are sure this is correct because of the described case above
     const builtLightDidDetails = LightDidDetails.fromIdentifier(
       authKey.address,
-      VerificationKeyType.Ed25519
+      'ed25519'
     )
 
     expect(builtLightDidDetails).toStrictEqual<LightDidDetails>(
       expectedLightDidDetails
     )
     expect(builtLightDidDetails.authKeyEncoding).toStrictEqual(
-      getEncodingForVerificationKeyType(VerificationKeyType.Ed25519)
+      getEncodingForVerificationKeyType('ed25519')
     )
 
     expect(builtLightDidDetails?.authenticationKey.id).toStrictEqual(

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -14,7 +14,6 @@ import type {
   IIdentity,
   SignCallback,
 } from '@kiltprotocol/types'
-import { VerificationKeyType } from '@kiltprotocol/types'
 
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
@@ -206,7 +205,7 @@ export class LightDidDetails extends DidDetails {
    */
   public static fromIdentifier(
     identifier: DidIdentifier,
-    keyType: LightDidSupportedVerificationKeyType = VerificationKeyType.Sr25519
+    keyType: LightDidSupportedVerificationKeyType = 'sr25519'
   ): LightDidDetails {
     const authenticationKey: NewLightDidAuthenticationKey = {
       publicKey: decodeAddress(identifier, false, ss58Format),

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -12,6 +12,7 @@ import type {
   DidUri,
   IDidDetails,
   IIdentity,
+  LightDidSupportedVerificationKeyType,
   SignCallback,
 } from '@kiltprotocol/types'
 
@@ -22,7 +23,6 @@ import { FullDidCreationBuilder } from '../DidBatcher/FullDidCreationBuilder.js'
 
 import type {
   DidConstructorDetails,
-  LightDidSupportedVerificationKeyType,
   MapKeysToRelationship,
   NewLightDidAuthenticationKey,
   PublicKeys,

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -14,6 +14,7 @@ import { base58Decode, base58Encode } from '@polkadot/util-crypto'
 
 import type {
   DidServiceEndpoint,
+  LightDidSupportedVerificationKeyType,
   NewDidEncryptionKey,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
@@ -22,10 +23,7 @@ import { encryptionKeyTypes, VerificationKeyType } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 
 import { checkServiceEndpointSyntax } from '../Did.utils.js'
-import {
-  LightDidSupportedVerificationKeyType,
-  NewLightDidAuthenticationKey,
-} from '../types.js'
+import { NewLightDidAuthenticationKey } from '../types.js'
 
 // Ecdsa not supported.
 export function getEncodingForVerificationKeyType(

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -8,7 +8,7 @@
 // This module is not part of the public-facing api.
 /* eslint-disable jsdoc/require-jsdoc */
 
-import { encode as cborEncode, decode as cborDecode } from 'cbor'
+import { decode as cborDecode, encode as cborEncode } from 'cbor'
 
 import { base58Decode, base58Encode } from '@polkadot/util-crypto'
 
@@ -17,7 +17,7 @@ import type {
   NewDidEncryptionKey,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
-import { EncryptionKeyType, VerificationKeyType } from '@kiltprotocol/types'
+import { encryptionKeyTypes, VerificationKeyType } from '@kiltprotocol/types'
 
 import { SDKErrors } from '@kiltprotocol/utils'
 
@@ -32,28 +32,29 @@ export function getEncodingForVerificationKeyType(
   type: VerificationKeyType
 ): string | undefined {
   switch (type) {
-    case VerificationKeyType.Sr25519:
+    case 'sr25519':
       return '00'
-    case VerificationKeyType.Ed25519:
+    case 'ed25519':
       return '01'
     default:
       return undefined
   }
 }
+
 export function getVerificationKeyTypeForEncoding(
   encoding: string
 ): LightDidSupportedVerificationKeyType | undefined {
   switch (encoding) {
     case '00':
-      return VerificationKeyType.Sr25519
+      return 'sr25519'
     case '01':
-      return VerificationKeyType.Ed25519
+      return 'ed25519'
     default:
       return undefined
   }
 }
 
-const supportedEncryptionKeyTypes = new Set(Object.values(EncryptionKeyType))
+const supportedEncryptionKeyTypes = new Set(encryptionKeyTypes)
 
 /**
  * The options that can be used to create a light DID.

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -10,10 +10,8 @@ import { BN } from '@polkadot/util'
 import {
   DidKey,
   DidServiceEndpoint,
-  EncryptionKeyType,
   DidIdentifier,
   NewDidVerificationKey,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 
 import type { IDidChainRecordJSON } from '../Did.chain'
@@ -30,7 +28,7 @@ const identifier = '4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs'
 function generateAuthenticationKeyDetails(): DidKey {
   return {
     id: 'auth',
-    type: VerificationKeyType.Ed25519,
+    type: 'ed25519',
     publicKey: new Uint8Array(32).fill(0),
   }
 }
@@ -38,7 +36,7 @@ function generateAuthenticationKeyDetails(): DidKey {
 function generateEncryptionKeyDetails(): DidKey {
   return {
     id: 'enc',
-    type: EncryptionKeyType.X25519,
+    type: 'x25519',
     publicKey: new Uint8Array(32).fill(0),
     includedAt: new BN(15),
   }
@@ -47,7 +45,7 @@ function generateEncryptionKeyDetails(): DidKey {
 function generateAttestationKeyDetails(): DidKey {
   return {
     id: 'att',
-    type: VerificationKeyType.Sr25519,
+    type: 'sr25519',
     publicKey: new Uint8Array(32).fill(0),
     includedAt: new BN(20),
   }
@@ -56,7 +54,7 @@ function generateAttestationKeyDetails(): DidKey {
 function generateDelegationKeyDetails(): DidKey {
   return {
     id: 'del',
-    type: VerificationKeyType.Ecdsa,
+    type: 'ecdsa',
     publicKey: new Uint8Array(32).fill(0),
     includedAt: new BN(25),
   }
@@ -280,11 +278,11 @@ describe('When exporting a DID Document from a light DID', () => {
   const lightDidDetails = LightDidDetails.fromDetails({
     authenticationKey: {
       publicKey: authKey.publicKey,
-      type: VerificationKeyType.Ed25519,
+      type: 'ed25519',
     },
     encryptionKey: {
       publicKey: encKey.publicKey,
-      type: EncryptionKeyType.X25519,
+      type: 'x25519',
     },
     serviceEndpoints,
   })

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
@@ -14,7 +14,6 @@ import type {
   JsonLDDidDocument,
 } from '@kiltprotocol/types'
 import {
-  KeyRelationship,
   VerificationKeyTypesMap,
   EncryptionKeyTypesMap,
 } from '@kiltprotocol/types'
@@ -28,7 +27,7 @@ function exportToJsonDidDocument(details: IDidDetails): DidDocument {
 
   // Populate the `verificationMethod` array and then sets the `authentication` array with the key IDs (or undefined if no auth key is present - which should never happen)
   const authenticationKeysIds = details
-    .getVerificationKeys(KeyRelationship.authentication)
+    .getVerificationKeys('authentication')
     .map((authKey) => {
       result.verificationMethod.push({
         id: `${details.uri}#${authKey.id}`,
@@ -43,7 +42,7 @@ function exportToJsonDidDocument(details: IDidDetails): DidDocument {
   }
 
   const keyAgreementKeysIds = details
-    .getEncryptionKeys(KeyRelationship.keyAgreement)
+    .getEncryptionKeys('keyAgreement')
     .map((keyAgrKey) => {
       result.verificationMethod.push({
         id: `${details.uri}#${keyAgrKey.id}`,
@@ -58,7 +57,7 @@ function exportToJsonDidDocument(details: IDidDetails): DidDocument {
   }
 
   const assertionKeysIds = details
-    .getVerificationKeys(KeyRelationship.assertionMethod)
+    .getVerificationKeys('assertionMethod')
     .map((assKey) => {
       result.verificationMethod.push({
         id: `${details.uri}#${assKey.id}`,
@@ -73,7 +72,7 @@ function exportToJsonDidDocument(details: IDidDetails): DidDocument {
   }
 
   const delegationKeyIds = details
-    .getVerificationKeys(KeyRelationship.capabilityDelegation)
+    .getVerificationKeys('capabilityDelegation')
     .map((delKey) => {
       result.verificationMethod.push({
         id: `${details.uri}#${delKey.id}`,

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -18,11 +18,9 @@ import {
   DidResourceUri,
   DidServiceEndpoint,
   DidUri,
-  EncryptionKeyType,
   IDidDetails,
   ResolvedDidKey,
   ResolvedDidServiceEndpoint,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 import { ss58Format } from '@kiltprotocol/utils'
 
@@ -46,7 +44,7 @@ const deletedIdentifier = '4rrVTLAXgeoE8jo8si571HnqHtd5WmvLuzfH6e1xBsVXsRo7'
 function generateAuthenticationKeyDetails(): DidKey {
   return {
     id: 'auth',
-    type: VerificationKeyType.Ed25519,
+    type: 'ed25519',
     publicKey: new Uint8Array(32).fill(0),
   }
 }
@@ -54,7 +52,7 @@ function generateAuthenticationKeyDetails(): DidKey {
 function generateEncryptionKeyDetails(): DidKey {
   return {
     id: 'enc',
-    type: EncryptionKeyType.X25519,
+    type: 'x25519',
     publicKey: new Uint8Array(32).fill(1),
     includedAt: new BN(15),
   }
@@ -63,7 +61,7 @@ function generateEncryptionKeyDetails(): DidKey {
 function generateAttestationKeyDetails(): DidKey {
   return {
     id: 'att',
-    type: VerificationKeyType.Sr25519,
+    type: 'sr25519',
     publicKey: new Uint8Array(32).fill(2),
     includedAt: new BN(20),
   }
@@ -72,7 +70,7 @@ function generateAttestationKeyDetails(): DidKey {
 function generateDelegationKeyDetails(): DidKey {
   return {
     id: 'del',
-    type: VerificationKeyType.Ecdsa,
+    type: 'ecdsa',
     publicKey: new Uint8Array(32).fill(3),
     includedAt: new BN(25),
   }
@@ -205,7 +203,7 @@ describe('When resolving a key', () => {
       controller: fullDid,
       publicKey: new Uint8Array(32).fill(0),
       uri: keyIdUri,
-      type: VerificationKeyType.Ed25519,
+      type: 'ed25519',
     })
   })
 
@@ -303,7 +301,7 @@ describe('When resolving a full DID', () => {
     expect(details?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'auth',
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
         publicKey: new Uint8Array(32).fill(0),
       },
     ])
@@ -325,24 +323,24 @@ describe('When resolving a full DID', () => {
     expect(details?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'auth',
-        type: VerificationKeyType.Ed25519,
+        type: 'ed25519',
         publicKey: new Uint8Array(32).fill(0),
       },
       {
         id: 'enc',
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
         publicKey: new Uint8Array(32).fill(1),
         includedAt: new BN(15),
       },
       {
         id: 'att',
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
         publicKey: new Uint8Array(32).fill(2),
         includedAt: new BN(20),
       },
       {
         id: 'del',
-        type: VerificationKeyType.Ecdsa,
+        type: 'ecdsa',
         publicKey: new Uint8Array(32).fill(3),
         includedAt: new BN(25),
       },
@@ -427,7 +425,7 @@ describe('When resolving a light DID', () => {
     const lightDidWithAuthenticationKey = LightDidDetails.fromDetails({
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
     })
     const { details, metadata } = (await DidResolver.resolve(
@@ -443,7 +441,7 @@ describe('When resolving a light DID', () => {
     expect(lightDidWithAuthenticationKey?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
         publicKey: authKey.publicKey,
       },
     ])
@@ -453,11 +451,11 @@ describe('When resolving a light DID', () => {
     const lightDid = LightDidDetails.fromDetails({
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
       encryptionKey: {
         publicKey: encryptionKey.publicKey,
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
       },
       serviceEndpoints: [
         generateServiceEndpointDetails('service-1'),
@@ -475,12 +473,12 @@ describe('When resolving a light DID', () => {
     expect(lightDid?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
         publicKey: authKey.publicKey,
       },
       {
         id: 'encryption',
-        type: EncryptionKeyType.X25519,
+        type: 'x25519',
         publicKey: encryptionKey.publicKey,
       },
     ])
@@ -518,7 +516,7 @@ describe('When resolving a light DID', () => {
     expect(details?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
         publicKey: decodeAddress(
           identifierWithAuthenticationKey,
           false,
@@ -547,7 +545,7 @@ describe('When resolving a light DID', () => {
     const lightDid = LightDidDetails.fromDetails({
       authenticationKey: {
         publicKey: authKey.publicKey,
-        type: VerificationKeyType.Sr25519,
+        type: 'sr25519',
       },
     })
     const keyIdUri: DidUri = `${lightDid.uri}#auth`

--- a/packages/did/src/types.ts
+++ b/packages/did/src/types.ts
@@ -13,10 +13,9 @@ import type {
   KeyRelationship,
   NewDidEncryptionKey,
   NewDidVerificationKey,
-  VerificationKeyType,
 } from '@kiltprotocol/types'
 
-export { SigningAlgorithms, EncryptionAlgorithms } from '@kiltprotocol/types'
+export { SigningAlgorithms } from '@kiltprotocol/types'
 
 /**
  * Map from a key relationship (including the 'none' relationship) -> set of key IDs.
@@ -59,9 +58,7 @@ export type FullDidCreationDetails = {
 }
 
 // Ecdsa not supported.
-export type LightDidSupportedVerificationKeyType =
-  | VerificationKeyType.Ed25519
-  | VerificationKeyType.Sr25519
+export type LightDidSupportedVerificationKeyType = 'ed25519' | 'sr25519'
 
 /**
  * A new public key specified when creating a new light DID.

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -148,7 +148,7 @@ describe('Messaging', () => {
   it('verify message encryption and signing', async () => {
     const message = new Message(
       {
-        type: Message.BodyType.REQUEST_CREDENTIAL,
+        type: 'request-credential',
         content: {
           cTypes: [{ cTypeHash: `${Crypto.hashStr('0x12345678')}` }],
         },
@@ -264,7 +264,7 @@ describe('Messaging', () => {
         requestForAttestation: content,
         quote: bothSigned,
       },
-      type: Message.BodyType.REQUEST_ATTESTATION,
+      type: 'request-attestation',
     }
 
     // Should not throw if the owner and sender DID is the same.
@@ -301,7 +301,7 @@ describe('Messaging', () => {
       content: {
         attestation,
       },
-      type: Message.BodyType.SUBMIT_ATTESTATION,
+      type: 'submit-attestation',
     }
 
     // Should not throw if the owner and sender DID is the same.
@@ -333,7 +333,7 @@ describe('Messaging', () => {
 
     const submitClaimsForCTypeBody: ISubmitCredential = {
       content: [credential],
-      type: Message.BodyType.SUBMIT_CREDENTIAL,
+      type: 'submit-credential',
     }
 
     // Should not throw if the owner and sender DID is the same.
@@ -400,7 +400,7 @@ describe('Messaging', () => {
         requestForAttestation: content,
         quote: bothSigned,
       },
-      type: Message.BodyType.REQUEST_ATTESTATION,
+      type: 'request-attestation',
     }
 
     // Create request for attestation to the light DID with encoded details
@@ -443,7 +443,7 @@ describe('Messaging', () => {
         requestForAttestation: contentWithEncodedDetails,
         quote: bothSignedEncodedDetails,
       },
-      type: Message.BodyType.REQUEST_ATTESTATION,
+      type: 'request-attestation',
     }
 
     // Should not throw if the owner and sender DID is the same.
@@ -501,7 +501,7 @@ describe('Messaging', () => {
       content: {
         attestation,
       },
-      type: Message.BodyType.SUBMIT_ATTESTATION,
+      type: 'submit-attestation',
     }
 
     const attestationWithEncodedDetails = {
@@ -516,7 +516,7 @@ describe('Messaging', () => {
       content: {
         attestation: attestationWithEncodedDetails,
       },
-      type: Message.BodyType.SUBMIT_ATTESTATION,
+      type: 'submit-attestation',
     }
 
     // Should not throw if the owner and sender DID is the same.
@@ -569,7 +569,7 @@ describe('Messaging', () => {
 
     const submitClaimsForCTypeBody: ISubmitCredential = {
       content: [credential],
-      type: Message.BodyType.SUBMIT_CREDENTIAL,
+      type: 'submit-credential',
     }
 
     const credentialWithEncodedDetails: ICredential = {
@@ -579,7 +579,7 @@ describe('Messaging', () => {
 
     const submitClaimsForCTypeBodyWithEncodedDetails: ISubmitCredential = {
       content: [credentialWithEncodedDetails],
-      type: Message.BodyType.SUBMIT_CREDENTIAL,
+      type: 'submit-credential',
     }
 
     // Should not throw if the owner and sender DID is the same.

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -15,7 +15,6 @@ import {
   DidResolvedDetails,
   DidResourceUri,
   DidUri,
-  EncryptionAlgorithms,
   ICredential,
   IDidDetails,
   IDidResolver,
@@ -32,7 +31,6 @@ import { Quote, RequestForAttestation } from '@kiltprotocol/core'
 import {
   FullDidDetails,
   LightDidDetails,
-  SigningAlgorithms,
   Utils as DidUtils,
 } from '@kiltprotocol/did'
 import {
@@ -119,7 +117,7 @@ const mockResolver = {
 } as IDidResolver
 
 beforeAll(async () => {
-  const aliceAuthKey = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+  const aliceAuthKey = makeSigningKeyTool('ed25519')
   aliceSign = aliceAuthKey.sign
   aliceLightDid = LightDidDetails.fromDetails({
     authenticationKey: aliceAuthKey.authenticationKey,
@@ -132,7 +130,7 @@ beforeAll(async () => {
   })
   aliceFullDid = await createLocalDemoFullDidFromLightDid(aliceLightDid)
 
-  const bobAuthKey = makeSigningKeyTool(SigningAlgorithms.Ed25519)
+  const bobAuthKey = makeSigningKeyTool('ed25519')
   bobSign = bobAuthKey.sign
   bobLightDid = LightDidDetails.fromDetails({
     authenticationKey: bobAuthKey.authenticationKey,
@@ -201,7 +199,7 @@ describe('Messaging', () => {
     ).rejects.toThrowError(SDKErrors.ERROR_DECODING_MESSAGE)
 
     const encryptedWrongBody = await aliceEncKey.encrypt({
-      alg: EncryptionAlgorithms.NaclBox,
+      alg: 'x25519-xsalsa20-poly1305',
       data: Crypto.coToUInt8('{ wrong JSON'),
       publicKey: aliceLightDid.encryptionKey!.publicKey,
       peerPublicKey: bobLightDid.encryptionKey!.publicKey,

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -21,12 +21,7 @@ import {
   MessageBodyType,
 } from '@kiltprotocol/types'
 import { SDKErrors, UUID } from '@kiltprotocol/utils'
-import {
-  DidDetails,
-  DidResolver,
-  EncryptionAlgorithms,
-  Utils as DidUtils,
-} from '@kiltprotocol/did'
+import { DidDetails, DidResolver, Utils as DidUtils } from '@kiltprotocol/did'
 import { hexToU8a, stringToU8a, u8aToHex, u8aToString } from '@polkadot/util'
 import {
   compressMessage,
@@ -142,7 +137,7 @@ export class Message implements IMessage {
       DidUtils.getEncryptionAlgorithmForEncryptionKeyType(
         receiverKeyDetails.type as EncryptionKeyType
       )
-    if (receiverKeyAlgType !== EncryptionAlgorithms.NaclBox) {
+    if (receiverKeyAlgType !== 'x25519-xsalsa20-poly1305') {
       throw new SDKErrors.ERROR_ENCRYPTION_ERROR(
         'Only the "x25519-xsalsa20-poly1305" encryption algorithm currently supported.'
       )
@@ -284,7 +279,7 @@ export class Message implements IMessage {
       DidUtils.getEncryptionAlgorithmForEncryptionKeyType(
         senderKey.type as EncryptionKeyType
       )
-    if (senderKeyAlgType !== EncryptionAlgorithms.NaclBox) {
+    if (senderKeyAlgType !== 'x25519-xsalsa20-poly1305') {
       throw new SDKErrors.ERROR_ENCRYPTION_ERROR(
         'Only the "x25519-xsalsa20-poly1305" encryption algorithm currently supported.'
       )

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -18,7 +18,6 @@ import {
   IEncryptedMessageContents,
   IMessage,
   MessageBody,
-  MessageBodyType,
 } from '@kiltprotocol/types'
 import { SDKErrors, UUID } from '@kiltprotocol/utils'
 import { DidDetails, DidResolver, Utils as DidUtils } from '@kiltprotocol/did'
@@ -33,11 +32,6 @@ import {
 
 export class Message implements IMessage {
   /**
-   * Lists all possible body types of [[Message]].
-   */
-  public static readonly BodyType = MessageBodyType
-
-  /**
    * Verifies that the sender of a [[Message]] is also the owner of it, e.g the owner's and sender's DIDs refer to the same subject.
    *
    * @param message The [[Message]] object which needs to be decrypted.
@@ -47,7 +41,7 @@ export class Message implements IMessage {
    */
   public static ensureOwnerIsSender({ body, sender }: IMessage): void {
     switch (body.type) {
-      case Message.BodyType.REQUEST_ATTESTATION:
+      case 'request-attestation':
         {
           const requestAttestation = body
           if (
@@ -60,7 +54,7 @@ export class Message implements IMessage {
           }
         }
         break
-      case Message.BodyType.SUBMIT_ATTESTATION:
+      case 'submit-attestation':
         {
           const submitAttestation = body
           if (
@@ -73,7 +67,7 @@ export class Message implements IMessage {
           }
         }
         break
-      case Message.BodyType.SUBMIT_CREDENTIAL:
+      case 'submit-credential':
         {
           const submitClaimsForCtype = body
           submitClaimsForCtype.content.forEach((claim) => {

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -629,125 +629,119 @@ describe('Messaging Utilities', () => {
 
     requestTermsBody = {
       content: requestTermsContent,
-      type: Message.BodyType.REQUEST_TERMS,
+      type: 'request-terms',
     }
 
     compressedRequestTermsBody = [
-      Message.BodyType.REQUEST_TERMS,
+      'request-terms',
       compressedRequestTermsContent,
     ]
 
     submitTermsBody = {
       content: submitTermsContent,
-      type: Message.BodyType.SUBMIT_TERMS,
+      type: 'submit-terms',
     }
 
-    compressedSubmitTermsBody = [
-      Message.BodyType.SUBMIT_TERMS,
-      compressedSubmitTermsContent,
-    ]
+    compressedSubmitTermsBody = ['submit-terms', compressedSubmitTermsContent]
 
     rejectTermsBody = {
       content: rejectTermsContent,
-      type: Message.BodyType.REJECT_TERMS,
+      type: 'reject-terms',
     }
 
-    compressedRejectTermsBody = [
-      Message.BodyType.REJECT_TERMS,
-      compressedRejectTermsContent,
-    ]
+    compressedRejectTermsBody = ['reject-terms', compressedRejectTermsContent]
 
     requestAttestationBody = {
       content: requestAttestationContent,
-      type: Message.BodyType.REQUEST_ATTESTATION,
+      type: 'request-attestation',
     }
 
     compressedRequestAttestationBody = [
-      Message.BodyType.REQUEST_ATTESTATION,
+      'request-attestation',
       compressedRequestAttestationContent,
     ]
 
     submitAttestationBody = {
       content: submitAttestationContent,
-      type: Message.BodyType.SUBMIT_ATTESTATION,
+      type: 'submit-attestation',
     }
 
     compressedSubmitAttestationBody = [
-      Message.BodyType.SUBMIT_ATTESTATION,
+      'submit-attestation',
       compressedSubmitAttestationContent,
     ]
 
     rejectAttestationForClaimBody = {
       content: requestAttestationContent.requestForAttestation.rootHash,
-      type: Message.BodyType.REJECT_ATTESTATION,
+      type: 'reject-attestation',
     }
     requestCredentialBody = {
       content: requestCredentialContent,
-      type: Message.BodyType.REQUEST_CREDENTIAL,
+      type: 'request-credential',
     }
 
     compressedRequestCredentialBody = [
-      Message.BodyType.REQUEST_CREDENTIAL,
+      'request-credential',
       compressedRequestCredentialContent,
     ]
 
     submitCredentialBody = {
       content: submitCredentialContent,
-      type: Message.BodyType.SUBMIT_CREDENTIAL,
+      type: 'submit-credential',
     }
 
     compressedSubmitCredentialBody = [
-      Message.BodyType.SUBMIT_CREDENTIAL,
+      'submit-credential',
       compressedSubmitCredentialContent,
     ]
 
     acceptCredentialBody = {
       content: [claim.cTypeHash],
-      type: Message.BodyType.ACCEPT_CREDENTIAL,
+      type: 'accept-credential',
     }
 
     rejectCredentialBody = {
       content: [claim.cTypeHash],
-      type: Message.BodyType.REJECT_CREDENTIAL,
+      type: 'reject-credential',
     }
 
     requestAcceptDelegationBody = {
       content: requestAcceptDelegationContent,
-      type: Message.BodyType.REQUEST_ACCEPT_DELEGATION,
+      type: 'request-accept-delegation',
     }
 
     compressedRequestAcceptDelegationBody = [
-      Message.BodyType.REQUEST_ACCEPT_DELEGATION,
+      'request-accept-delegation',
       compressedRequestAcceptDelegationContent,
     ]
 
     submitAcceptDelegationBody = {
       content: submitAcceptDelegationContent,
-      type: Message.BodyType.SUBMIT_ACCEPT_DELEGATION,
+      type: 'submit-accept-delegation',
     }
 
     compressedSubmitAcceptDelegationBody = [
-      Message.BodyType.SUBMIT_ACCEPT_DELEGATION,
+      'submit-accept-delegation',
       compressedSubmitAcceptDelegationContent,
     ]
 
     rejectAcceptDelegationBody = {
       content: rejectAcceptDelegationContent,
-      type: Message.BodyType.REJECT_ACCEPT_DELEGATION,
+      type: 'reject-accept-delegation',
     }
 
     compressedRejectAcceptDelegationBody = [
-      Message.BodyType.REJECT_ACCEPT_DELEGATION,
+      'reject-accept-delegation',
       compressedRejectAcceptDelegationContent,
     ]
 
     informCreateDelegationBody = {
       content: informCreateDelegationContent,
-      type: Message.BodyType.INFORM_CREATE_DELEGATION,
+      type: 'inform-create-delegation',
     }
 
     compressedInformCreateDelegationBody = [
-      Message.BodyType.INFORM_CREATE_DELEGATION,
+      'inform-create-delegation',
       compressedInformCreateDelegationContent,
     ]
   })
@@ -861,7 +855,7 @@ describe('Messaging Utilities', () => {
 
     const malformed = {
       content: '',
-      type: 'Message.BodyType',
+      type: 'MessageBodyType',
     } as unknown as MessageBody
 
     expect(() => MessageUtils.compressMessage(malformed)).toThrowError(

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -7,27 +7,25 @@
 
 import {
   Attestation,
-  Credential,
   Claim,
+  Credential,
   CType,
   Quote,
   RequestForAttestation,
 } from '@kiltprotocol/core'
 import type {
-  ICredential,
   CompressedCredential,
   CompressedMessageBody,
-  MessageBody,
   CompressedRequestCredentialContent,
+  ICredential,
   ICType,
-  IMessage,
   IDelegationData,
+  IMessage,
+  MessageBody,
 } from '@kiltprotocol/types'
 import { DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import { isHex, isJsonObject } from '@polkadot/util'
 import { isDidSignature, Utils as DidUtils } from '@kiltprotocol/did'
-
-import { Message } from './Message.js'
 
 /**
  * Checks if delegation data is well formed.
@@ -79,11 +77,11 @@ export function errorCheckDelegationData(
  */
 export function errorCheckMessageBody(body: MessageBody): void {
   switch (body.type) {
-    case Message.BodyType.REQUEST_TERMS: {
+    case 'request-terms': {
       Claim.verifyDataStructure(body.content)
       break
     }
-    case Message.BodyType.SUBMIT_TERMS: {
+    case 'submit-terms': {
       Claim.verifyDataStructure(body.content.claim)
       body.content.legitimations.map((credential) =>
         Credential.verifyDataStructure(credential)
@@ -102,7 +100,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
       }
       break
     }
-    case Message.BodyType.REJECT_TERMS: {
+    case 'reject-terms': {
       Claim.verifyDataStructure(body.content.claim)
       if (body.content.delegationId) {
         DataUtils.validateHash(
@@ -115,7 +113,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
       )
       break
     }
-    case Message.BodyType.REQUEST_ATTESTATION: {
+    case 'request-attestation': {
       RequestForAttestation.verifyDataStructure(
         body.content.requestForAttestation
       )
@@ -124,17 +122,17 @@ export function errorCheckMessageBody(body: MessageBody): void {
       }
       break
     }
-    case Message.BodyType.SUBMIT_ATTESTATION: {
+    case 'submit-attestation': {
       Attestation.verifyDataStructure(body.content.attestation)
       break
     }
-    case Message.BodyType.REJECT_ATTESTATION: {
+    case 'reject-attestation': {
       if (!isHex(body.content)) {
         throw new SDKErrors.ERROR_HASH_MALFORMED()
       }
       break
     }
-    case Message.BodyType.REQUEST_CREDENTIAL: {
+    case 'request-credential': {
       body.content.cTypes.forEach(
         ({ cTypeHash, trustedAttesters, requiredProperties }): void => {
           DataUtils.validateHash(
@@ -152,13 +150,13 @@ export function errorCheckMessageBody(body: MessageBody): void {
       )
       break
     }
-    case Message.BodyType.SUBMIT_CREDENTIAL: {
+    case 'submit-credential': {
       body.content.map((credential) =>
         Credential.verifyDataStructure(credential)
       )
       break
     }
-    case Message.BodyType.ACCEPT_CREDENTIAL: {
+    case 'accept-credential': {
       body.content.map((cTypeHash) =>
         DataUtils.validateHash(
           cTypeHash,
@@ -167,7 +165,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
       )
       break
     }
-    case Message.BodyType.REJECT_CREDENTIAL: {
+    case 'reject-credential': {
       body.content.map((cTypeHash) =>
         DataUtils.validateHash(
           cTypeHash,
@@ -176,7 +174,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
       )
       break
     }
-    case Message.BodyType.REQUEST_ACCEPT_DELEGATION: {
+    case 'request-accept-delegation': {
       errorCheckDelegationData(body.content.delegationData)
       isDidSignature(body.content.signatures.inviter)
       if (!isJsonObject(body.content.metaData)) {
@@ -184,18 +182,18 @@ export function errorCheckMessageBody(body: MessageBody): void {
       }
       break
     }
-    case Message.BodyType.SUBMIT_ACCEPT_DELEGATION: {
+    case 'submit-accept-delegation': {
       errorCheckDelegationData(body.content.delegationData)
       isDidSignature(body.content.signatures.inviter)
       isDidSignature(body.content.signatures.invitee)
       break
     }
 
-    case Message.BodyType.REJECT_ACCEPT_DELEGATION: {
+    case 'reject-accept-delegation': {
       errorCheckDelegationData(body.content)
       break
     }
-    case Message.BodyType.INFORM_CREATE_DELEGATION: {
+    case 'inform-create-delegation': {
       DataUtils.validateHash(
         body.content.delegationId,
         'inform create delegation message delegation id invalid'
@@ -272,11 +270,11 @@ export function verifyRequiredCTypeProperties(
 export function compressMessage(body: MessageBody): CompressedMessageBody {
   let compressedContents: CompressedMessageBody[1]
   switch (body.type) {
-    case Message.BodyType.REQUEST_TERMS: {
+    case 'request-terms': {
       compressedContents = Claim.compress(body.content)
       break
     }
-    case Message.BodyType.SUBMIT_TERMS: {
+    case 'submit-terms': {
       compressedContents = [
         Claim.compress(body.content.claim),
         body.content.legitimations.map(
@@ -293,7 +291,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       ]
       break
     }
-    case Message.BodyType.REJECT_TERMS: {
+    case 'reject-terms': {
       compressedContents = [
         Claim.compress(body.content.claim),
         body.content.legitimations.map((val) => Credential.compress(val)),
@@ -301,7 +299,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       ]
       break
     }
-    case Message.BodyType.REQUEST_ATTESTATION: {
+    case 'request-attestation': {
       compressedContents = [
         RequestForAttestation.compress(body.content.requestForAttestation),
         body.content.quote
@@ -310,11 +308,11 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       ]
       break
     }
-    case Message.BodyType.SUBMIT_ATTESTATION: {
+    case 'submit-attestation': {
       compressedContents = Attestation.compress(body.content.attestation)
       break
     }
-    case Message.BodyType.REQUEST_CREDENTIAL: {
+    case 'request-credential': {
       const compressedCtypes: CompressedRequestCredentialContent[0] =
         body.content.cTypes.map(
           ({ cTypeHash, trustedAttesters, requiredProperties }) => [
@@ -326,7 +324,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       compressedContents = [compressedCtypes, body.content.challenge]
       break
     }
-    case Message.BodyType.SUBMIT_CREDENTIAL: {
+    case 'submit-credential': {
       compressedContents = body.content.map(
         (credential: ICredential | CompressedCredential) =>
           Array.isArray(credential)
@@ -335,7 +333,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       )
       break
     }
-    case Message.BodyType.REQUEST_ACCEPT_DELEGATION: {
+    case 'request-accept-delegation': {
       compressedContents = [
         [
           body.content.delegationData.account,
@@ -352,7 +350,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       ]
       break
     }
-    case Message.BodyType.SUBMIT_ACCEPT_DELEGATION: {
+    case 'submit-accept-delegation': {
       compressedContents = [
         [
           body.content.delegationData.account,
@@ -372,7 +370,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       ]
       break
     }
-    case Message.BodyType.REJECT_ACCEPT_DELEGATION: {
+    case 'reject-accept-delegation': {
       compressedContents = [
         body.content.account,
         body.content.id,
@@ -382,7 +380,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       ]
       break
     }
-    case Message.BodyType.INFORM_CREATE_DELEGATION: {
+    case 'inform-create-delegation': {
       compressedContents = [body.content.delegationId, body.content.isPCR]
       break
     }
@@ -405,11 +403,11 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
   // Each index matches the object keys from the given [[MessageBodyType]].
   let decompressedContents: MessageBody['content']
   switch (body[0]) {
-    case Message.BodyType.REQUEST_TERMS: {
+    case 'request-terms': {
       decompressedContents = Claim.decompress(body[1])
       break
     }
-    case Message.BodyType.SUBMIT_TERMS: {
+    case 'submit-terms': {
       decompressedContents = {
         claim: Claim.decompress(body[1][0]),
         legitimations: body[1][1].map(
@@ -427,7 +425,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
 
       break
     }
-    case Message.BodyType.REJECT_TERMS: {
+    case 'reject-terms': {
       decompressedContents = {
         claim: Claim.decompress(body[1][0]),
         legitimations: body[1][1].map((val) => Credential.decompress(val)),
@@ -435,7 +433,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
       }
       break
     }
-    case Message.BodyType.REQUEST_ATTESTATION: {
+    case 'request-attestation': {
       decompressedContents = {
         requestForAttestation: RequestForAttestation.decompress(body[1][0]),
         quote: body[1][1]
@@ -445,13 +443,13 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
 
       break
     }
-    case Message.BodyType.SUBMIT_ATTESTATION: {
+    case 'submit-attestation': {
       decompressedContents = {
         attestation: Attestation.decompress(body[1]),
       }
       break
     }
-    case Message.BodyType.REQUEST_CREDENTIAL: {
+    case 'request-credential': {
       decompressedContents = {
         cTypes: body[1][0].map((val) => ({
           cTypeHash: val[0],
@@ -462,7 +460,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
       }
       break
     }
-    case Message.BodyType.SUBMIT_CREDENTIAL: {
+    case 'submit-credential': {
       decompressedContents = body[1].map(
         (credential: ICredential | CompressedCredential) =>
           !Array.isArray(credential)
@@ -472,7 +470,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
 
       break
     }
-    case Message.BodyType.REQUEST_ACCEPT_DELEGATION: {
+    case 'request-accept-delegation': {
       decompressedContents = {
         delegationData: {
           account: body[1][0][0],
@@ -488,7 +486,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
       }
       break
     }
-    case Message.BodyType.SUBMIT_ACCEPT_DELEGATION: {
+    case 'submit-accept-delegation': {
       decompressedContents = {
         delegationData: {
           account: body[1][0][0],
@@ -504,7 +502,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
       }
       break
     }
-    case Message.BodyType.REJECT_ACCEPT_DELEGATION: {
+    case 'reject-accept-delegation': {
       decompressedContents = {
         account: body[1][0],
         id: body[1][1],
@@ -514,7 +512,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
       }
       break
     }
-    case Message.BodyType.INFORM_CREATE_DELEGATION: {
+    case 'inform-create-delegation': {
       decompressedContents = {
         delegationId: body[1][0],
         isPCR: body[1][1],

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -56,7 +56,7 @@ export function makeEncryptCallback({
   secretKey,
 }: {
   secretKey: Uint8Array
-  type: EncryptionKeyType.X25519
+  type: 'x25519'
 }): EncryptCallback {
   return async function encryptCallback({ data, peerPublicKey, alg }) {
     const { box, nonce } = Crypto.encryptAsymmetric(
@@ -80,7 +80,7 @@ export function makeDecryptCallback({
   secretKey,
 }: {
   secretKey: Uint8Array
-  type: EncryptionKeyType.X25519
+  type: 'x25519'
 }): DecryptCallback {
   return async function decryptCallback({ data, nonce, peerPublicKey, alg }) {
     const decrypted = Crypto.decryptAsymmetric(
@@ -114,7 +114,7 @@ export function makeEncryptionKeyTool(seed: string): EncryptionKeyTool {
   const keypair = {
     secretKey,
     publicKey,
-    type: EncryptionKeyType.X25519,
+    type: 'x25519' as EncryptionKeyType,
   }
 
   const encrypt = makeEncryptCallback(keypair)
@@ -144,9 +144,9 @@ export function makeSignCallback(keypair: KeyringPair): SignCallback {
 }
 
 const keypairTypeForAlg: Record<SigningAlgorithms, KeypairType> = {
-  [SigningAlgorithms.Ed25519]: 'ed25519',
-  [SigningAlgorithms.Sr25519]: 'sr25519',
-  [SigningAlgorithms.EcdsaSecp256k1]: 'ecdsa',
+  ed25519: 'ed25519',
+  sr25519: 'sr25519',
+  'ecdsa-secp256k1': 'ecdsa',
 }
 
 export interface KeyTool {
@@ -162,7 +162,7 @@ export interface KeyTool {
  * @returns The keypair, matching sign callback, a key usable as DID authentication key.
  */
 export function makeSigningKeyTool(
-  alg: SigningAlgorithms = SigningAlgorithms.Sr25519
+  alg: SigningAlgorithms = 'sr25519'
 ): KeyTool {
   const type = keypairTypeForAlg[alg]
   const seed = randomAsHex(32)
@@ -228,9 +228,9 @@ export async function createLocalDemoFullDidFromKeypair(
   keypair: KeyringPair,
   {
     keyRelationships = new Set([
-      KeyRelationship.assertionMethod,
-      KeyRelationship.capabilityDelegation,
-      KeyRelationship.keyAgreement,
+      'assertionMethod',
+      'capabilityDelegation',
+      'keyAgreement',
     ]),
     endpoints = {},
   }: {
@@ -257,7 +257,7 @@ export async function createLocalDemoFullDidFromKeypair(
     serviceEndpoints: endpoints,
   }
 
-  if (keyRelationships.has(KeyRelationship.keyAgreement)) {
+  if (keyRelationships.has('keyAgreement')) {
     const encryptionKeypair = makeEncryptionKeyTool(
       `${keypair.publicKey}//enc`
     ).keypair
@@ -268,14 +268,14 @@ export async function createLocalDemoFullDidFromKeypair(
     fullDidCreationDetails.keyRelationships.keyAgreement = new Set([encKey.id])
     fullDidCreationDetails.keys[encKey.id] = encKey
   }
-  if (keyRelationships.has(KeyRelationship.assertionMethod)) {
+  if (keyRelationships.has('assertionMethod')) {
     const attKey = makeDidKeyFromKeypair(keypair.derive('//att'))
     fullDidCreationDetails.keyRelationships.assertionMethod = new Set([
       attKey.id,
     ])
     fullDidCreationDetails.keys[attKey.id] = attKey
   }
-  if (keyRelationships.has(KeyRelationship.capabilityDelegation)) {
+  if (keyRelationships.has('capabilityDelegation')) {
     const delKey = makeDidKeyFromKeypair(keypair.derive('//del'))
     fullDidCreationDetails.keyRelationships.capabilityDelegation = new Set([
       delKey.id,

--- a/packages/types/src/CryptoCallbacks.ts
+++ b/packages/types/src/CryptoCallbacks.ts
@@ -7,15 +7,9 @@
 
 import type { SignerPayloadJSON } from '@polkadot/types/types'
 
-export enum SigningAlgorithms {
-  Ed25519 = 'ed25519',
-  Sr25519 = 'sr25519',
-  EcdsaSecp256k1 = 'ecdsa-secp256k1',
-}
+export type SigningAlgorithms = 'ed25519' | 'sr25519' | 'ecdsa-secp256k1'
 
-export enum EncryptionAlgorithms {
-  NaclBox = 'x25519-xsalsa20-poly1305',
-}
+export type EncryptionAlgorithms = 'x25519-xsalsa20-poly1305'
 
 /**
  * Base interface for all {en/de}cryption & signing requests.
@@ -89,7 +83,7 @@ export interface SigningOptions<A extends SigningAlgorithms = any> {
  * @returns [[ResponseData]] which additionally contains a `nonce` randomly generated in the encryption process (required for decryption).
  */
 export interface EncryptCallback<
-  A extends EncryptionAlgorithms.NaclBox = EncryptionAlgorithms.NaclBox
+  A extends 'x25519-xsalsa20-poly1305' = 'x25519-xsalsa20-poly1305'
 > {
   (
     requestData: RequestData<A> & {
@@ -107,7 +101,7 @@ export interface EncryptCallback<
  * @returns A Promise resolving to [[ResponseData]] containing the decrypted message or rejecting if key or algorithm is unknown or if they do not match.
  */
 export interface DecryptCallback<
-  A extends EncryptionAlgorithms.NaclBox = EncryptionAlgorithms.NaclBox
+  A extends 'x25519-xsalsa20-poly1305' = 'x25519-xsalsa20-poly1305'
 > {
   (
     requestData: RequestData<A> & {

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -9,10 +9,11 @@ import type { ICType } from './CType'
 import type { IDidDetails } from './DidDetails'
 
 /* eslint-disable no-bitwise */
-export enum Permission {
-  ATTEST = 1 << 0, // 0001
-  DELEGATE = 1 << 1, // 0010
-}
+export const Permission = {
+  ATTEST: 1 << 0, // 0001
+  DELEGATE: 1 << 1, // 0010
+} as const
+export type Permissions = typeof Permission[keyof typeof Permission]
 
 export interface IDelegationNode {
   id: string
@@ -20,7 +21,7 @@ export interface IDelegationNode {
   parentId?: IDelegationNode['id']
   childrenIds: Array<IDelegationNode['id']>
   account: IDidDetails['uri']
-  permissions: Permission[]
+  permissions: Permissions[]
   revoked: boolean
 }
 

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -13,7 +13,7 @@ export const Permission = {
   ATTEST: 1 << 0, // 0001
   DELEGATE: 1 << 1, // 0010
 } as const
-export type Permissions = typeof Permission[keyof typeof Permission]
+export type PermissionType = typeof Permission[keyof typeof Permission]
 
 export interface IDelegationNode {
   id: string
@@ -21,7 +21,7 @@ export interface IDelegationNode {
   parentId?: IDelegationNode['id']
   childrenIds: Array<IDelegationNode['id']>
   account: IDidDetails['uri']
-  permissions: Permissions[]
+  permissions: PermissionType[]
   revoked: boolean
 }
 

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -30,42 +30,39 @@ export type DidUri =
 /**
  * DID keys are purpose-bound. Their role or purpose is indicated by the verification or key relationship type.
  */
-export enum KeyRelationship {
-  authentication = 'authentication',
-  capabilityDelegation = 'capabilityDelegation',
-  assertionMethod = 'assertionMethod',
-  keyAgreement = 'keyAgreement',
-}
+export const keyRelationships = [
+  'authentication',
+  'capabilityDelegation',
+  'assertionMethod',
+  'keyAgreement',
+] as const
+export type KeyRelationship = typeof keyRelationships[number]
 
 /**
  * Subset of key relationships which pertain to signing/verification keys.
  */
 export type VerificationKeyRelationship =
-  | KeyRelationship.authentication
-  | KeyRelationship.capabilityDelegation
-  | KeyRelationship.assertionMethod
+  | 'authentication'
+  | 'capabilityDelegation'
+  | 'assertionMethod'
+
 /**
  * Possible types for a DID verification key.
  */
-export enum VerificationKeyType {
-  Sr25519 = 'sr25519',
-  Ed25519 = 'ed25519',
-  Ecdsa = 'ecdsa',
-}
-export type LightDidSupportedVerificationKeyType =
-  | VerificationKeyType.Ed25519
-  | VerificationKeyType.Sr25519
+export const verificationKeyTypes = ['sr25519', 'ed25519', 'ecdsa'] as const
+export type VerificationKeyType = typeof verificationKeyTypes[number]
+
+export type LightDidSupportedVerificationKeyType = 'ed25519' | 'sr25519'
 
 /**
  * Subset of key relationships which pertain to key agreement/encryption keys.
  */
-export type EncryptionKeyRelationship = KeyRelationship.keyAgreement
+export type EncryptionKeyRelationship = 'keyAgreement'
 /**
  * Possible types for a DID encryption key.
  */
-export enum EncryptionKeyType {
-  X25519 = 'x25519',
-}
+export const encryptionKeyTypes = ['x25519'] as const
+export type EncryptionKeyType = typeof encryptionKeyTypes[number]
 
 /**
  * Type of a new key material to add under a DID.
@@ -157,6 +154,7 @@ export interface IDidDetails {
    * The decentralized identifier (DID) to which the remaining info pertains.
    */
   uri: DidUri
+
   /**
    * Retrieves a particular public key record via its id.
    *
@@ -164,6 +162,7 @@ export interface IDidDetails {
    * @returns [[DidKey]] or undefined if no key with this id is present.
    */
   getKey(id: DidKey['id']): DidKey | undefined
+
   /**
    * Retrieves public key details from the [[IDidDetails]].
    *
@@ -174,6 +173,7 @@ export interface IDidDetails {
   getVerificationKeys(
     relationship: VerificationKeyRelationship
   ): DidVerificationKey[]
+
   /**
    * Retrieves public key details from the [[IDidDetails]].
    *
@@ -182,13 +182,16 @@ export interface IDidDetails {
    * @returns An array of all or selected [[DidEncryptionKey]]s, depending on the `relationship` parameter.
    */
   getEncryptionKeys(relationship: EncryptionKeyRelationship): DidEncryptionKey[]
+
   getKeys(): DidKey[]
+
   /**
    * Retrieves the service endpoint associated with the DID, if any.
    *
    * @param id The identifier of the service endpoint, without the DID prefix.
    */
   getEndpoint(id: DidServiceEndpoint['id']): DidServiceEndpoint | undefined
+
   /**
    * Retrieves all the service endpoints associated with the DID.
    *

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -41,10 +41,10 @@ export type KeyRelationship = typeof keyRelationships[number]
 /**
  * Subset of key relationships which pertain to signing/verification keys.
  */
-export type VerificationKeyRelationship =
-  | 'authentication'
-  | 'capabilityDelegation'
-  | 'assertionMethod'
+export type VerificationKeyRelationship = Extract<
+  KeyRelationship,
+  'authentication' | 'capabilityDelegation' | 'assertionMethod'
+>
 
 /**
  * Possible types for a DID verification key.
@@ -52,12 +52,15 @@ export type VerificationKeyRelationship =
 export const verificationKeyTypes = ['sr25519', 'ed25519', 'ecdsa'] as const
 export type VerificationKeyType = typeof verificationKeyTypes[number]
 
-export type LightDidSupportedVerificationKeyType = 'ed25519' | 'sr25519'
+export type LightDidSupportedVerificationKeyType = Extract<
+  VerificationKeyType,
+  'ed25519' | 'sr25519'
+>
 
 /**
  * Subset of key relationships which pertain to key agreement/encryption keys.
  */
-export type EncryptionKeyRelationship = 'keyAgreement'
+export type EncryptionKeyRelationship = Extract<KeyRelationship, 'keyAgreement'>
 /**
  * Possible types for a DID encryption key.
  */

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -13,31 +13,28 @@ import {
   DidUri,
 } from './DidDetails.js'
 
-export enum DidDocumentPublicKeyType {
-  Ed25519VerificationKey = 'Ed25519VerificationKey2018',
-  Sr25519VerificationKey = 'Sr25519VerificationKey2020',
-  EcdsaVerificationKey = 'EcdsaSecp256k1VerificationKey2019',
-  X25519EncryptionKey = 'X25519KeyAgreementKey2019',
-}
+export type DidDocumentPublicKeyType =
+  | 'Ed25519VerificationKey2018'
+  | 'Sr25519VerificationKey2020'
+  | 'EcdsaSecp256k1VerificationKey2019'
+  | 'X25519KeyAgreementKey2019'
 
 export const VerificationKeyTypesMap: Record<
   VerificationKeyType,
   DidDocumentPublicKeyType
 > = {
   // proposed and used by dock.io, e.g. https://github.com/w3c-ccg/security-vocab/issues/32, https://github.com/docknetwork/sdk/blob/9c818b03bfb4fdf144c20678169c7aad3935ad96/src/utils/vc/contexts/security_context.js
-  [VerificationKeyType.Sr25519]:
-    DidDocumentPublicKeyType.Sr25519VerificationKey,
+  sr25519: 'Sr25519VerificationKey2020',
   // these are part of current w3 security vocab, see e.g. https://www.w3.org/ns/did/v1
-  [VerificationKeyType.Ed25519]:
-    DidDocumentPublicKeyType.Ed25519VerificationKey,
-  [VerificationKeyType.Ecdsa]: DidDocumentPublicKeyType.EcdsaVerificationKey,
+  ed25519: 'Ed25519VerificationKey2018',
+  ecdsa: 'EcdsaSecp256k1VerificationKey2019',
 }
 
 export const EncryptionKeyTypesMap: Record<
   EncryptionKeyType,
   DidDocumentPublicKeyType
 > = {
-  [EncryptionKeyType.X25519]: DidDocumentPublicKeyType.X25519EncryptionKey,
+  x25519: 'X25519KeyAgreementKey2019',
 }
 
 /**

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -20,31 +20,25 @@ import type {
 import type { CompressedTerms, ITerms } from './Terms.js'
 import type { DidPublicKey, IClaimContents } from './index.js'
 
-export enum MessageBodyType {
-  ERROR = 'error',
-  REJECT = 'reject',
-
-  REQUEST_TERMS = 'request-terms',
-  SUBMIT_TERMS = 'submit-terms',
-  REJECT_TERMS = 'reject-terms',
-
-  REQUEST_ATTESTATION = 'request-attestation',
-  SUBMIT_ATTESTATION = 'submit-attestation',
-  REJECT_ATTESTATION = 'reject-attestation',
-
-  REQUEST_PAYMENT = 'request-payment',
-  CONFIRM_PAYMENT = 'confirm-payment',
-
-  REQUEST_CREDENTIAL = 'request-credential',
-  SUBMIT_CREDENTIAL = 'submit-credential',
-  ACCEPT_CREDENTIAL = 'accept-credential',
-  REJECT_CREDENTIAL = 'reject-credential',
-
-  REQUEST_ACCEPT_DELEGATION = 'request-accept-delegation',
-  SUBMIT_ACCEPT_DELEGATION = 'submit-accept-delegation',
-  REJECT_ACCEPT_DELEGATION = 'reject-accept-delegation',
-  INFORM_CREATE_DELEGATION = 'inform-create-delegation',
-}
+export type MessageBodyType =
+  | 'error'
+  | 'reject'
+  | 'request-terms'
+  | 'submit-terms'
+  | 'reject-terms'
+  | 'request-attestation'
+  | 'submit-attestation'
+  | 'reject-attestation'
+  | 'request-payment'
+  | 'confirm-payment'
+  | 'request-credential'
+  | 'submit-credential'
+  | 'accept-credential'
+  | 'reject-credential'
+  | 'request-accept-delegation'
+  | 'submit-accept-delegation'
+  | 'reject-accept-delegation'
+  | 'inform-create-delegation'
 
 export type CompressedDelegationData = [
   IDelegationNode['account'],
@@ -66,7 +60,7 @@ export interface IError extends IMessageBodyBase {
     /** Optional human-readable description of the error. */
     message?: string
   }
-  type: MessageBodyType.ERROR
+  type: 'error'
 }
 
 export interface IReject extends IMessageBodyBase {
@@ -76,66 +70,67 @@ export interface IReject extends IMessageBodyBase {
     /** Optional human-readable description of the rejection. */
     message?: string
   }
-  type: MessageBodyType.REJECT
+  type: 'reject'
 }
 
 export interface IRequestTerms extends IMessageBodyBase {
   content: PartialClaim
-  type: MessageBodyType.REQUEST_TERMS
+  type: 'request-terms'
 }
+
 export interface ISubmitTerms extends IMessageBodyBase {
   content: ITerms
-  type: MessageBodyType.SUBMIT_TERMS
+  type: 'submit-terms'
 }
+
 export interface IRejectTerms extends IMessageBodyBase {
   content: {
     claim: PartialClaim
     legitimations: ICredential[]
     delegationId?: IDelegationNode['id']
   }
-  type: MessageBodyType.REJECT_TERMS
+  type: 'reject-terms'
 }
 
 export interface ISubmitCredential extends IMessageBodyBase {
   content: ICredential[]
-  type: MessageBodyType.SUBMIT_CREDENTIAL
+  type: 'submit-credential'
 }
 
 export interface IAcceptCredential extends IMessageBodyBase {
   content: Array<ICType['hash']>
-  type: MessageBodyType.ACCEPT_CREDENTIAL
-}
-export interface IRejectCredential extends IMessageBodyBase {
-  content: Array<ICType['hash']>
-  type: MessageBodyType.REJECT_CREDENTIAL
+  type: 'accept-credential'
 }
 
-export type CompressedSubmitTerms = [
-  MessageBodyType.SUBMIT_TERMS,
-  CompressedTerms
-]
+export interface IRejectCredential extends IMessageBodyBase {
+  content: Array<ICType['hash']>
+  type: 'reject-credential'
+}
+
+export type CompressedSubmitTerms = ['submit-terms', CompressedTerms]
+
 export type CompressedSubmitAttestation = [
-  MessageBodyType.SUBMIT_ATTESTATION,
+  'submit-attestation',
   CompressedAttestation
 ]
 export type CompressedRejectAttestation = [
-  MessageBodyType.REJECT_ATTESTATION,
+  'reject-attestation',
   IRequestForAttestation['rootHash']
 ]
 export type CompressedSubmitCredentials = [
-  MessageBodyType.SUBMIT_CREDENTIAL,
+  'submit-credential',
   CompressedCredential[]
 ]
 export type CompressedAcceptCredential = [
-  MessageBodyType.ACCEPT_CREDENTIAL,
+  'accept-credential',
   Array<ICType['hash']>
 ]
 export type CompressedRejectCredential = [
-  MessageBodyType.REJECT_CREDENTIAL,
+  'reject-credential',
   Array<ICType['hash']>
 ]
 export type CompressedRejectAcceptDelegation = [
-  MessageBodyType.REJECT_ACCEPT_DELEGATION,
+  'reject-accept-delegation',
   CompressedDelegationData
 ]
 
@@ -146,7 +141,7 @@ export interface IRequestAttestationContent {
 
 export interface IRequestAttestation extends IMessageBodyBase {
   content: IRequestAttestationContent
-  type: MessageBodyType.REQUEST_ATTESTATION
+  type: 'request-attestation'
 }
 
 export interface ISubmitAttestationContent {
@@ -155,12 +150,12 @@ export interface ISubmitAttestationContent {
 
 export interface ISubmitAttestation extends IMessageBodyBase {
   content: ISubmitAttestationContent
-  type: MessageBodyType.SUBMIT_ATTESTATION
+  type: 'submit-attestation'
 }
 
 export interface IRejectAttestation extends IMessageBodyBase {
   content: IRequestForAttestation['rootHash']
-  type: MessageBodyType.REJECT_ATTESTATION
+  type: 'reject-attestation'
 }
 
 export interface IRequestPaymentContent {
@@ -179,7 +174,7 @@ export interface IConfirmPaymentContent {
 
 export interface IConfirmPayment extends IMessageBodyBase {
   content: IConfirmPaymentContent
-  type: MessageBodyType.CONFIRM_PAYMENT
+  type: 'confirm-payment'
 }
 
 export interface IRequestCredentialContent {
@@ -193,12 +188,12 @@ export interface IRequestCredentialContent {
 
 export interface IRequestCredential extends IMessageBodyBase {
   content: IRequestCredentialContent
-  type: MessageBodyType.REQUEST_CREDENTIAL
+  type: 'request-credential'
 }
 
 export interface IRequestPayment extends IMessageBodyBase {
   content: IRequestPaymentContent
-  type: MessageBodyType.REQUEST_PAYMENT
+  type: 'request-payment'
 }
 
 export interface IDelegationData {
@@ -208,10 +203,12 @@ export interface IDelegationData {
   permissions: IDelegationNode['permissions']
   isPCR: boolean
 }
+
 export interface IRejectAcceptDelegation extends IMessageBodyBase {
   content: IDelegationData
-  type: MessageBodyType.REJECT_ACCEPT_DELEGATION
+  type: 'reject-accept-delegation'
 }
+
 export interface IRequestDelegationApproval {
   delegationData: IDelegationData
   metaData?: AnyJson
@@ -222,7 +219,7 @@ export interface IRequestDelegationApproval {
 
 export interface IRequestAcceptDelegation extends IMessageBodyBase {
   content: IRequestDelegationApproval
-  type: MessageBodyType.REQUEST_ACCEPT_DELEGATION
+  type: 'request-accept-delegation'
 }
 
 export interface ISubmitDelegationApproval {
@@ -232,18 +229,20 @@ export interface ISubmitDelegationApproval {
     invitee: DidSignature
   }
 }
+
 export interface ISubmitAcceptDelegation extends IMessageBodyBase {
   content: ISubmitDelegationApproval
-  type: MessageBodyType.SUBMIT_ACCEPT_DELEGATION
+  type: 'submit-accept-delegation'
 }
 
 export interface IInformDelegationCreation {
   delegationId: IDelegationNode['id']
   isPCR: boolean
 }
+
 export interface IInformCreateDelegation extends IMessageBodyBase {
   content: IInformDelegationCreation
-  type: MessageBodyType.INFORM_CREATE_DELEGATION
+  type: 'inform-create-delegation'
 }
 
 export type CompressedInformDelegationCreation = [
@@ -252,7 +251,7 @@ export type CompressedInformDelegationCreation = [
 ]
 
 export type CompressedInformCreateDelegation = [
-  MessageBodyType.INFORM_CREATE_DELEGATION,
+  'inform-create-delegation',
   CompressedInformDelegationCreation
 ]
 
@@ -261,20 +260,14 @@ export type CompressedPartialClaim = [
   IClaim['owner'] | undefined,
   IClaimContents | undefined
 ]
-export type CompressedRequestTerms = [
-  MessageBodyType.REQUEST_TERMS,
-  CompressedPartialClaim
-]
+export type CompressedRequestTerms = ['request-terms', CompressedPartialClaim]
 
 export type CompressedRejectedTerms = [
   CompressedPartialClaim,
   CompressedCredential[],
   IDelegationNode['id'] | undefined
 ]
-export type CompressedRejectTerms = [
-  MessageBodyType.REJECT_TERMS,
-  CompressedRejectedTerms
-]
+export type CompressedRejectTerms = ['reject-terms', CompressedRejectedTerms]
 
 export type CompressedRequestCredentialContent = [
   Array<
@@ -288,7 +281,7 @@ export type CompressedRequestCredentialContent = [
 ]
 
 export type CompressedRequestCredentials = [
-  MessageBodyType.REQUEST_CREDENTIAL,
+  'request-credential',
   CompressedRequestCredentialContent
 ]
 
@@ -298,7 +291,7 @@ export type CompressedRequestAttestationContent = [
 ]
 
 export type CompressedRequestAttestation = [
-  MessageBodyType.REQUEST_ATTESTATION,
+  'request-attestation',
   CompressedRequestAttestationContent
 ]
 
@@ -308,7 +301,7 @@ export type CompressedRequestDelegationApproval = [
   AnyJson
 ]
 export type CompressedRequestAcceptDelegation = [
-  MessageBodyType.REQUEST_ACCEPT_DELEGATION,
+  'request-accept-delegation',
   CompressedRequestDelegationApproval
 ]
 
@@ -318,7 +311,7 @@ export type CompressedSubmitDelegationApproval = [
   [DidSignature['signature'], DidSignature['keyUri']]
 ]
 export type CompressedSubmitAcceptDelegation = [
-  MessageBodyType.SUBMIT_ACCEPT_DELEGATION,
+  'submit-accept-delegation',
   CompressedSubmitDelegationApproval
 ]
 

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -10,7 +10,6 @@
  */
 
 import {
-  DidDocumentPublicKeyType,
   DidUri,
   ICredential,
   ICType,
@@ -210,7 +209,7 @@ describe('proofs', () => {
     const keyId = VC.proof[0].verificationMethod
     const verificationMethod: IPublicKeyRecord = {
       uri: keyId,
-      type: DidDocumentPublicKeyType.Ed25519VerificationKey,
+      type: 'Ed25519VerificationKey2018',
       publicKeyBase58: base58Encode(
         Crypto.decodeAddress(DidUtils.parseDidUri(keyId).identifier)
       ),
@@ -310,7 +309,7 @@ describe('proofs', () => {
     expect(result.errors).toEqual([])
     expect(result).toMatchObject({
       verified: true,
-      status: verificationUtils.AttestationStatus.valid,
+      status: 'valid',
     })
   })
 
@@ -389,7 +388,7 @@ describe('proofs', () => {
         await verificationUtils.verifyAttestedProof(VC, VC.proof[1])
       ).toMatchObject({
         verified: false,
-        status: verificationUtils.AttestationStatus.invalid,
+        status: 'invalid',
       })
     })
 
@@ -419,7 +418,7 @@ describe('proofs', () => {
       )
       expect(result).toMatchObject({
         verified: false,
-        status: verificationUtils.AttestationStatus.invalid,
+        status: 'invalid',
       })
     })
 
@@ -435,7 +434,7 @@ describe('proofs', () => {
       )
       expect(result).toMatchObject({
         verified: false,
-        status: verificationUtils.AttestationStatus.invalid,
+        status: 'invalid',
       })
     })
 
@@ -451,7 +450,7 @@ describe('proofs', () => {
       )
       expect(result).toMatchObject({
         verified: false,
-        status: verificationUtils.AttestationStatus.revoked,
+        status: 'revoked',
       })
     })
   })

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
@@ -15,11 +15,7 @@ import jsonld from 'jsonld'
 
 import { base58Encode, randomAsHex } from '@polkadot/util-crypto'
 
-import {
-  DidDocumentPublicKeyType,
-  DidPublicKey,
-  DidUri,
-} from '@kiltprotocol/types'
+import { DidPublicKey, DidUri } from '@kiltprotocol/types'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import { Crypto } from '@kiltprotocol/utils'
 
@@ -55,7 +51,7 @@ beforeAll(async () => {
         uri: uri as DidPublicKey['uri'],
         publicKeyBase58: base58Encode(Crypto.decodeAddress(identifier)),
         controller: did,
-        type: DidDocumentPublicKeyType.Ed25519VerificationKey,
+        type: 'Ed25519VerificationKey2018',
       }
       if (fragment) {
         return { documentUrl: uri, document: key }

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -37,12 +37,7 @@ export interface VerificationResult {
   errors: Error[]
 }
 
-export enum AttestationStatus {
-  valid = 'valid',
-  invalid = 'invalid',
-  revoked = 'revoked',
-  unknown = 'unknown',
-}
+export type AttestationStatus = 'valid' | 'invalid' | 'revoked' | 'unknown'
 
 export interface AttestationVerificationResult extends VerificationResult {
   status: AttestationStatus
@@ -153,7 +148,7 @@ export async function verifyAttestedProof(
   credential: VerifiableCredential,
   proof: AttestedProof
 ): Promise<AttestationVerificationResult> {
-  let status: AttestationStatus = AttestationStatus.unknown
+  let status: AttestationStatus = 'unknown'
   try {
     // check proof
     const type = proof['@type'] || proof.type
@@ -188,14 +183,14 @@ export async function verifyAttestedProof(
     const onChain = await Attestation.query(claimHash)
     // if not found, credential has not been attested, proof is invalid
     if (!onChain) {
-      status = AttestationStatus.invalid
+      status = 'invalid'
       throw new Error(
         `attestation for credential with id ${claimHash} not found`
       )
     }
     // if data on proof does not correspond to data on chain, proof is incorrect
     if (onChain.owner !== attester || onChain.delegationId !== delegationId) {
-      status = AttestationStatus.invalid
+      status = 'invalid'
       throw new Error(
         `proof not matching on-chain data: proof ${{
           attester,
@@ -205,7 +200,7 @@ export async function verifyAttestedProof(
     }
     // if proof data is valid but attestation is flagged as revoked, credential is no longer valid
     if (onChain.revoked) {
-      status = AttestationStatus.revoked
+      status = 'revoked'
       throw new Error('attestation revoked')
     }
   } catch (e) {
@@ -215,7 +210,7 @@ export async function verifyAttestedProof(
       status,
     }
   }
-  return { verified: true, errors: [], status: AttestationStatus.valid }
+  return { verified: true, errors: [], status: 'valid' }
 }
 
 /**

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -35,7 +35,6 @@ const {
   Blockchain,
   Utils: { Crypto, Keyring, ss58Format },
   Message,
-  MessageBodyType,
   BalanceUtils,
 } = kilt
 
@@ -346,7 +345,7 @@ async function runAll() {
       content: {
         requestForAttestation: request,
       },
-      type: MessageBodyType.REQUEST_ATTESTATION,
+      type: 'request-attestation',
     },
     bob.uri,
     alice.uri


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

[TypeScript enums](https://www.typescriptlang.org/docs/handbook/enums.html) have some downsides:
* https://github.com/typescript-cheatsheets/react#enum-types
* https://fettblog.eu/tidy-typescript-avoid-enums/

Replacing enums with union types simplifies code and results in less type casting

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
