### PR TITLE
feat: use DID types directly

### DIFF
--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -10,7 +10,7 @@ import type {
   IDelegationHierarchyDetails,
   IRequestForAttestation,
   CompressedAttestation,
-  IDidDetails,
+  DidUri,
 } from '@kiltprotocol/types'
 import { DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
@@ -68,7 +68,7 @@ export function verifyDataStructure(input: IAttestation): void {
  */
 export function fromRequestAndDid(
   request: IRequestForAttestation,
-  attesterDid: IDidDetails['uri']
+  attesterDid: DidUri
 ): IAttestation {
   const attestation = {
     claimHash: request.rootHash,

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -20,19 +20,19 @@
 import { hexToBn } from '@polkadot/util'
 import type { HexString } from '@polkadot/util/types'
 import type {
-  IClaim,
-  IDidDetails,
-  ICType,
   CompressedClaim,
-  PartialClaim,
   CompressedPartialClaim,
+  DidUri,
+  IClaim,
+  ICType,
+  PartialClaim,
 } from '@kiltprotocol/types'
-import { DataUtils, Crypto, jsonabc, SDKErrors } from '@kiltprotocol/utils'
+import { Crypto, DataUtils, jsonabc, SDKErrors } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import {
-  verifyClaimAgainstSchema,
-  verifyClaimAgainstNestedSchemas,
   getIdForCTypeHash,
+  verifyClaimAgainstNestedSchemas,
+  verifyClaimAgainstSchema,
 } from '../ctype/index.js'
 
 const VC_VOCAB = 'https://www.w3.org/2018/credentials#'
@@ -264,7 +264,7 @@ export function fromNestedCTypeClaim(
   cTypeInput: ICType,
   nestedCType: Array<ICType['schema']>,
   claimContents: IClaim['contents'],
-  claimOwner: IDidDetails['uri']
+  claimOwner: DidUri
 ): IClaim {
   if (
     !verifyClaimAgainstNestedSchemas(
@@ -285,7 +285,7 @@ export function fromNestedCTypeClaim(
 }
 
 /**
- * Constructs a new Claim from the given [[ICType]], IClaim['contents'] and IDidDetails['uri'].
+ * Constructs a new Claim from the given [[ICType]], IClaim['contents'] and [[DidUri]].
  *
  * @param ctypeInput [[ICType]] for which the Claim will be built.
  * @param claimContents IClaim['contents'] to be used as the pure contents of the instantiated Claim.
@@ -297,7 +297,7 @@ export function fromNestedCTypeClaim(
 export function fromCTypeAndClaimContents(
   ctypeInput: ICType,
   claimContents: IClaim['contents'],
-  claimOwner: IDidDetails['uri']
+  claimOwner: DidUri
 ): IClaim {
   if (ctypeInput.schema) {
     if (!verifyAgainstCType(claimContents, ctypeInput.schema)) {

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -20,7 +20,6 @@ import type {
   IClaim,
   ICredential,
   ICType,
-  IDidDetails,
   IDidResolver,
   IRequestForAttestation,
   SignCallback,
@@ -48,7 +47,7 @@ jest.mock('../attestation/Attestation.chain')
 
 async function buildCredential(
   claimer: DidDetails,
-  attesterDid: IDidDetails['uri'],
+  attesterDid: DidUri,
   contents: IClaim['contents'],
   legitimations: ICredential[],
   sign: SignCallback

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -8,11 +8,7 @@
 import type { Option } from '@polkadot/types'
 import type { AccountId } from '@polkadot/types/interfaces'
 import { Crypto, DecoderUtils } from '@kiltprotocol/utils'
-import type {
-  ICType,
-  IDidDetails,
-  SubmittableExtrinsic,
-} from '@kiltprotocol/types'
+import type { DidUri, ICType, SubmittableExtrinsic } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { Utils as DidUtils } from '@kiltprotocol/did'
@@ -37,7 +33,7 @@ export async function getStoreTx(ctype: ICType): Promise<SubmittableExtrinsic> {
   return api.tx.ctype.add(preparedSchema)
 }
 
-function decode(encoded: Option<AccountId>): IDidDetails['uri'] | null {
+function decode(encoded: Option<AccountId>): DidUri | null {
   DecoderUtils.assertCodecIsType(encoded, ['Option<AccountId32>'])
   return encoded.isSome
     ? DidUtils.getKiltDidFromIdentifier(encoded.unwrap().toString(), 'full')
@@ -52,7 +48,7 @@ function decode(encoded: Option<AccountId>): IDidDetails['uri'] | null {
  */
 export async function getOwner(
   ctypeHash: ICType['hash']
-): Promise<IDidDetails['uri'] | null> {
+): Promise<DidUri | null> {
   const api = await BlockchainApiConnection.getConnectionOrConnect()
   const encoded = await api.query.ctype.ctypes<Option<AccountId>>(ctypeHash)
   return decode(encoded)

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -6,12 +6,12 @@
  */
 
 import {
+  DidUri,
   DidVerificationKey,
   IAttestation,
   ICType,
   IDelegationHierarchyDetails,
   IDelegationNode,
-  IDidDetails,
   SignCallback,
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
@@ -68,7 +68,7 @@ export class DelegationNode implements IDelegationNode {
   public readonly hierarchyId: IDelegationNode['hierarchyId']
   public readonly parentId?: IDelegationNode['parentId']
   private childrenIdentifiers: Array<IDelegationNode['id']> = []
-  public readonly account: IDidDetails['uri']
+  public readonly account: DidUri
   public readonly permissions: IDelegationNode['permissions']
   private hierarchyDetails?: IDelegationHierarchyDetails
   public readonly revoked: boolean
@@ -348,7 +348,7 @@ export class DelegationNode implements IDelegationNode {
    * @returns An object containing a `node` owned by the identity if it is delegating, plus the number of `steps` traversed. `steps` is 0 if the DID is owner of the current node.
    */
   public async findAncestorOwnedBy(
-    did: IDidDetails['uri']
+    did: DidUri
   ): Promise<{ steps: number; node: DelegationNode | null }> {
     if (this.account === did) {
       return {
@@ -393,9 +393,7 @@ export class DelegationNode implements IDelegationNode {
    * @param did The address of the identity used to revoke the delegation.
    * @returns Promise containing an unsigned SubmittableExtrinsic.
    */
-  public async getRevokeTx(
-    did: IDidDetails['uri']
-  ): Promise<SubmittableExtrinsic> {
+  public async getRevokeTx(did: DidUri): Promise<SubmittableExtrinsic> {
     const { steps, node } = await this.findAncestorOwnedBy(did)
     if (!node) {
       throw new SDKErrors.ERROR_UNAUTHORIZED(

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -5,11 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type {
-  IAttestation,
-  IDelegationNode,
-  IDidDetails,
-} from '@kiltprotocol/types'
+import type { DidUri, IAttestation, IDelegationNode } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import { isHex } from '@polkadot/util'
 import { DelegationNode } from './DelegationNode.js'
@@ -44,7 +40,7 @@ export function permissionsAsBitset(delegation: IDelegationNode): Uint8Array {
  * @throws [[SDKError]] If the `attester` is neither the owner nor in the delegation tree of `attestation`.
  */
 export async function countNodeDepth(
-  attester: IDidDetails['uri'],
+  attester: DidUri,
   attestation: IAttestation
 ): Promise<number> {
   let delegationTreeTraversalSteps = 0

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -22,9 +22,9 @@ import type {
   CompressedQuoteAttesterSigned,
   DidPublicKey,
   DidSignature,
+  DidUri,
   DidVerificationKey,
   ICostBreakdown,
-  IDidDetails,
   IDidResolver,
   IQuote,
   IQuoteAgreement,
@@ -168,7 +168,7 @@ export async function verifyAttesterSignedQuote(
 export async function createQuoteAgreement(
   attesterSignedQuote: IQuoteAttesterSigned,
   requestRootHash: IRequestForAttestation['rootHash'],
-  attesterIdentity: IDidDetails['uri'],
+  attesterIdentity: DidUri,
   claimerIdentity: DidDetails,
   sign: SignCallback,
   {

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -20,7 +20,7 @@ import type {
   CompressedQuote,
   CompressedQuoteAgreed,
   CompressedQuoteAttesterSigned,
-  DidPublicKey,
+  DidResourceUri,
   DidSignature,
   DidUri,
   DidVerificationKey,
@@ -298,13 +298,11 @@ export function decompressQuote(quote: CompressedQuote): IQuote {
   }
 }
 
-function compressSignature(comp: DidSignature): [string, DidPublicKey['uri']] {
+function compressSignature(comp: DidSignature): [string, DidResourceUri] {
   return [comp.signature, comp.keyUri]
 }
 
-function decompressSignature(
-  comp: [string, DidPublicKey['uri']]
-): DidSignature {
+function decompressSignature(comp: [string, DidResourceUri]): DidSignature {
   return { signature: comp[0], keyUri: comp[1] }
 }
 

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -19,7 +19,7 @@
 import type {
   CompressedCredential,
   CompressedRequestForAttestation,
-  DidPublicKey,
+  DidResourceUri,
   DidVerificationKey,
   Hash,
   IClaim,
@@ -133,7 +133,7 @@ export function makeSigningData(
 export async function addSignature(
   req4Att: IRequestForAttestation,
   sig: string | Uint8Array,
-  keyUri: DidPublicKey['uri'],
+  keyUri: DidResourceUri,
   {
     challenge,
   }: {

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -11,17 +11,17 @@ import { ApiPromise } from '@polkadot/api'
 import { u32 } from '@polkadot/types'
 
 import {
+  DidIdentifier,
   DidKey,
   DidPublicKey,
+  DidServiceEndpoint,
+  DidUri,
+  EncryptionAlgorithms,
   EncryptionKeyType,
   encryptionKeyTypes,
-  IDidDetails,
-  DidIdentifier,
   NewDidKey,
-  VerificationKeyType,
-  DidServiceEndpoint,
-  EncryptionAlgorithms,
   SigningAlgorithms,
+  VerificationKeyType,
   verificationKeyTypes,
 } from '@kiltprotocol/types'
 import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
@@ -67,7 +67,7 @@ export function getKiltDidFromIdentifier(
   didType: 'full' | 'light',
   version?: number,
   encodedDetails?: string
-): IDidDetails['uri'] {
+): DidUri {
   const typeString = didType === 'full' ? '' : `light:`
   let versionValue = version
   // If no version is specified, take the default one depending on the requested DID type.
@@ -81,7 +81,7 @@ export function getKiltDidFromIdentifier(
 }
 
 export type IDidParsingResult = {
-  did: IDidDetails['uri']
+  did: DidUri
   version: number
   type: 'light' | 'full'
   identifier: DidIdentifier
@@ -96,7 +96,7 @@ export type IDidParsingResult = {
  * @param didUri A KILT DID uri as a string.
  * @returns Object containing information extracted from the DID uri.
  */
-export function parseDidUri(didUri: IDidDetails['uri']): IDidParsingResult {
+export function parseDidUri(didUri: DidUri): IDidParsingResult {
   let matches = FULL_KILT_DID_REGEX.exec(didUri)?.groups
   if (matches && matches.identifier) {
     const version = matches.version
@@ -141,9 +141,7 @@ export function parseDidUri(didUri: IDidDetails['uri']): IDidParsingResult {
  * @param didUri A KILT DID uri as a string.
  * @returns The identifier contained within the DID uri.
  */
-export function getIdentifierFromKiltDid(
-  didUri: IDidDetails['uri']
-): DidIdentifier {
+export function getIdentifierFromKiltDid(didUri: DidUri): DidIdentifier {
   return parseDidUri(didUri).identifier
 }
 
@@ -154,10 +152,7 @@ export function getIdentifierFromKiltDid(
  * @param didB A second KILT DID uri as a string.
  * @returns Whether didA and didB refer to the same DID subject.
  */
-export function isSameSubject(
-  didA: IDidDetails['uri'],
-  didB: IDidDetails['uri']
-): boolean {
+export function isSameSubject(didA: DidUri, didB: DidUri): boolean {
   // eslint-disable-next-line prefer-const
   let { identifier: identifierA, type: typeA } = parseDidUri(didA)
   // eslint-disable-next-line prefer-const
@@ -271,13 +266,11 @@ export function isEncryptionKey(key: NewDidKey | DidKey): boolean {
 export function validateKiltDidUri(
   input: unknown,
   allowFragment = false
-): input is IDidDetails['uri'] {
+): input is DidUri {
   if (typeof input !== 'string') {
     throw TypeError(`DID string expected, got ${typeof input}`)
   }
-  const { identifier, type, fragment } = parseDidUri(
-    input as IDidDetails['uri']
-  )
+  const { identifier, type, fragment } = parseDidUri(input as DidUri)
   if (!allowFragment && fragment) {
     throw new SDKErrors.ERROR_INVALID_DID_FORMAT(input)
   }
@@ -452,7 +445,7 @@ export function checkServiceEndpointSizeConstraints(
  * @returns The full public key URI, which includes the subject's DID and the provided key ID.
  */
 export function assembleKeyUri(
-  did: IDidDetails['uri'],
+  did: DidUri,
   keyId: DidKey['id']
 ): DidPublicKey['uri'] {
   if (parseDidUri(did).fragment) {

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -13,7 +13,7 @@ import { u32 } from '@polkadot/types'
 import {
   DidIdentifier,
   DidKey,
-  DidPublicKey,
+  DidResourceUri,
   DidServiceEndpoint,
   DidUri,
   EncryptionAlgorithms,
@@ -447,7 +447,7 @@ export function checkServiceEndpointSizeConstraints(
 export function assembleKeyUri(
   did: DidUri,
   keyId: DidKey['id']
-): DidPublicKey['uri'] {
+): DidResourceUri {
   if (parseDidUri(did).fragment) {
     throw new SDKErrors.ERROR_DID_ERROR(
       `Cannot assemble key URI from a DID that already has a fragment: ${did}`

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
@@ -19,7 +19,7 @@ import type {
   DidServiceEndpoint,
   DidKey,
   SubmittableExtrinsic,
-  IDidDetails,
+  DidUri,
 } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 
@@ -55,7 +55,7 @@ export type FullDidUpdateCallback = (
  */
 export class FullDidUpdateBuilder extends FullDidBuilder {
   protected identifier: DidIdentifier
-  protected uri: IDidDetails['uri']
+  protected uri: DidUri
   protected batch: Extrinsic[] = []
 
   protected oldAuthenticationKey: DidVerificationKey

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -20,6 +20,7 @@ import {
   VerificationKeyType,
   VerificationKeyRelationship,
   EncryptionKeyRelationship,
+  DidUri,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 
@@ -39,7 +40,7 @@ type ServiceEndpointsInner = Map<
 >
 
 export abstract class DidDetails implements IDidDetails {
-  public readonly uri: IDidDetails['uri']
+  public readonly uri: DidUri
 
   // { key ID -> key details} - key ID does not include the DID subject
   protected publicKeys: PublicKeysInner

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -9,26 +9,26 @@ import { u8aToHex } from '@polkadot/util'
 
 import {
   DidEncryptionKey,
+  DidIdentifier,
   DidKey,
-  DidPublicKey,
+  DidResourceUri,
   DidServiceEndpoint,
   DidSignature,
-  DidVerificationKey,
-  IDidDetails,
-  DidIdentifier,
-  SignCallback,
-  VerificationKeyType,
-  VerificationKeyRelationship,
-  EncryptionKeyRelationship,
   DidUri,
+  DidVerificationKey,
+  EncryptionKeyRelationship,
+  IDidDetails,
+  SignCallback,
+  VerificationKeyRelationship,
+  VerificationKeyType,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 
 import type { DidConstructorDetails, MapKeysToRelationship } from '../types.js'
 import {
+  assembleKeyUri,
   getSigningAlgorithmForVerificationKeyType,
   isVerificationKey,
-  assembleKeyUri,
 } from '../Did.utils.js'
 
 import { checkDidCreationDetails } from './DidDetails.utils.js'
@@ -209,7 +209,7 @@ export abstract class DidDetails implements IDidDetails {
    *
    * @returns The full public key URI, which includes the subject's DID and the provided key ID.
    */
-  public assembleKeyUri(keyId: DidKey['id']): DidPublicKey['uri'] {
+  public assembleKeyUri(keyId: DidKey['id']): DidResourceUri {
     return assembleKeyUri(this.uri, keyId)
   }
 

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -10,8 +10,8 @@ import { BN } from '@polkadot/util'
 
 import type {
   DidIdentifier,
+  DidUri,
   DidVerificationKey,
-  IDidDetails,
   IIdentity,
   SignCallback,
   SubmittableExtrinsic,
@@ -78,7 +78,7 @@ export class FullDidDetails extends DidDetails {
    * @returns The reconstructed [[FullDidDetails]], or null if not DID with the provided identifier exists.
    */
   public static async fromChainInfo(
-    didUri: IDidDetails['uri']
+    didUri: DidUri
   ): Promise<FullDidDetails | null> {
     const { identifier, fragment, type } = parseDidUri(didUri)
     if (fragment) {

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -10,7 +10,6 @@ import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
 import type {
   DidIdentifier,
   DidUri,
-  IDidDetails,
   IIdentity,
   LightDidSupportedVerificationKeyType,
   SignCallback,
@@ -154,7 +153,7 @@ export class LightDidDetails extends DidDetails {
    * @returns The resulting [[LightDidDetails]].
    */
   public static fromUri(
-    uri: IDidDetails['uri'],
+    uri: DidUri,
     failIfFragmentPresent = true
   ): LightDidDetails {
     const { identifier, version, encodedDetails, fragment, type } =

--- a/packages/did/src/DidLinks/Web3Names.chain.ts
+++ b/packages/did/src/DidLinks/Web3Names.chain.ts
@@ -9,7 +9,7 @@ import type {
   SubmittableExtrinsic,
   DidIdentifier,
   Deposit,
-  IDidDetails,
+  DidUri,
 } from '@kiltprotocol/types'
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
 import { DecoderUtils, SDKErrors } from '@kiltprotocol/utils'
@@ -136,7 +136,7 @@ export async function queryDidIdentifierForWeb3Name(
  * @returns The registered web3name for this DID if any.
  */
 export async function queryWeb3NameForDid(
-  did: IDidDetails['uri']
+  did: DidUri
 ): Promise<Web3Name | null> {
   const details = DidUtils.parseDidUri(did)
   return queryWeb3NameForDidIdentifier(details.identifier)
@@ -150,7 +150,7 @@ export async function queryWeb3NameForDid(
  */
 export async function queryDidForWeb3Name(
   name: Web3Name
-): Promise<IDidDetails['uri'] | null> {
+): Promise<DidUri | null> {
   const identifier = await queryDidIdentifierForWeb3Name(name)
   if (identifier === null) {
     return null

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  DidPublicKey,
   DidPublicServiceEndpoint,
   DidResolvedDetails,
   DidResourceUri,
@@ -115,7 +114,7 @@ export async function resolveDoc(
  * @returns The details associated with the key.
  */
 export async function resolveKey(
-  didUri: DidPublicKey['uri']
+  didUri: DidResourceUri
 ): Promise<ResolvedDidKey | null> {
   const { did, identifier, fragment: keyId, type } = parseDidUri(didUri)
 

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -10,7 +10,7 @@ import {
   DidPublicServiceEndpoint,
   DidResolvedDetails,
   DidResourceUri,
-  IDidDetails,
+  DidUri,
   IDidResolver,
   ResolvedDidKey,
   ResolvedDidServiceEndpoint,
@@ -36,7 +36,7 @@ import { getKiltDidFromIdentifier, parseDidUri } from '../Did.utils.js'
  * @returns The details associated with the DID subject.
  */
 export async function resolveDoc(
-  did: IDidDetails['uri']
+  did: DidUri
 ): Promise<DidResolvedDetails | null> {
   const { identifier, type } = parseDidUri(did)
 
@@ -215,7 +215,7 @@ export async function resolveServiceEndpoint(
  * @returns The DID, key details or service details depending on the input URI. Null otherwise.
  */
 export async function resolve(
-  didUri: IDidDetails['uri']
+  didUri: DidUri
 ): Promise<
   DidResolvedDetails | ResolvedDidKey | ResolvedDidServiceEndpoint | null
 > {

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -18,7 +18,6 @@ import {
   DidResourceUri,
   DidServiceEndpoint,
   DidUri,
-  IDidDetails,
   ResolvedDidKey,
   ResolvedDidServiceEndpoint,
 } from '@kiltprotocol/types'
@@ -295,9 +294,7 @@ describe('When resolving a full DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(
-      fullDidWithAuthenticationKey
-    )
+    expect(details?.uri).toStrictEqual<DidUri>(fullDidWithAuthenticationKey)
     expect(details?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'auth',
@@ -319,7 +316,7 @@ describe('When resolving a full DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(fullDidWithAllKeys)
+    expect(details?.uri).toStrictEqual<DidUri>(fullDidWithAllKeys)
     expect(details?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'auth',
@@ -359,9 +356,7 @@ describe('When resolving a full DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(
-      fullDidWithServiceEndpoints
-    )
+    expect(details?.uri).toStrictEqual<DidUri>(fullDidWithServiceEndpoints)
     expect(details?.getEndpoints()).toStrictEqual<DidServiceEndpoint[]>([
       {
         id: 'id-1',
@@ -410,9 +405,7 @@ describe('When resolving a full DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(
-      fullDidWithAuthenticationKey
-    )
+    expect(details?.uri).toStrictEqual<DidUri>(fullDidWithAuthenticationKey)
   })
 })
 
@@ -435,7 +428,7 @@ describe('When resolving a light DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(
+    expect(details?.uri).toStrictEqual<DidUri>(
       lightDidWithAuthenticationKey.uri
     )
     expect(lightDidWithAuthenticationKey?.getKeys()).toStrictEqual<DidKey[]>([
@@ -469,7 +462,7 @@ describe('When resolving a light DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(lightDid.uri)
+    expect(details?.uri).toStrictEqual<DidUri>(lightDid.uri)
     expect(lightDid?.getKeys()).toStrictEqual<DidKey[]>([
       {
         id: 'authentication',
@@ -556,6 +549,6 @@ describe('When resolving a light DID', () => {
     expect(metadata).toStrictEqual<DidResolutionDocumentMetadata>({
       deactivated: false,
     })
-    expect(details?.uri).toStrictEqual<IDidDetails['uri']>(lightDid.uri)
+    expect(details?.uri).toStrictEqual<DidUri>(lightDid.uri)
   })
 })

--- a/packages/did/src/DidResolver/Resolver.spec.ts
+++ b/packages/did/src/DidResolver/Resolver.spec.ts
@@ -12,7 +12,6 @@ import Keyring from '@polkadot/keyring'
 import {
   DidIdentifier,
   DidKey,
-  DidPublicKey,
   DidResolutionDocumentMetadata,
   DidResolvedDetails,
   DidResourceUri,
@@ -208,7 +207,7 @@ describe('When resolving a key', () => {
 
   it('returns null if either the DID or the key do not exist', async () => {
     const deletedFullDid = getKiltDidFromIdentifier(deletedIdentifier, 'full')
-    let keyIdUri: DidPublicKey['uri'] = `${deletedFullDid}#enc`
+    let keyIdUri: DidResourceUri = `${deletedFullDid}#enc`
 
     expect(await DidResolver.resolveKey(keyIdUri)).toBeNull()
 

--- a/packages/did/src/types.ts
+++ b/packages/did/src/types.ts
@@ -6,10 +6,10 @@
  */
 
 import type {
+  DidIdentifier,
   DidKey,
   DidServiceEndpoint,
-  IDidDetails,
-  DidIdentifier,
+  DidUri,
   KeyRelationship,
   NewDidEncryptionKey,
   NewDidVerificationKey,
@@ -40,7 +40,7 @@ export type ServiceEndpoints = Record<
 export type DidKeySelectionCallback<T> = (keys: T[]) => Promise<T | null>
 
 export type DidConstructorDetails = {
-  uri: IDidDetails['uri']
+  uri: DidUri
   // Accepts a list of keys where the ID does not include the DID URI.
   keys: PublicKeys
   keyRelationships: MapKeysToRelationship

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -16,7 +16,6 @@ import {
   DidResourceUri,
   DidUri,
   ICredential,
-  IDidDetails,
   IDidResolver,
   IEncryptedMessage,
   IQuote,
@@ -55,9 +54,7 @@ let bobFullDid: FullDidDetails
 let bobSign: SignCallback
 const bobEncKey = makeEncryptionKeyTool('Bob//enc')
 
-const resolveDoc = async (
-  did: IDidDetails['uri']
-): Promise<DidResolvedDetails | null> => {
+const resolveDoc = async (did: DidUri): Promise<DidResolvedDetails | null> => {
   if (did.startsWith(aliceLightDidWithDetails.uri)) {
     return {
       details: aliceLightDidWithDetails,

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -11,7 +11,6 @@
 
 import {
   DidKey,
-  DidPublicKey,
   DidResolvedDetails,
   DidResourceUri,
   DidUri,
@@ -88,7 +87,7 @@ const resolveDoc = async (did: DidUri): Promise<DidResolvedDetails | null> => {
   return null
 }
 const resolveKey = async (
-  keyUri: DidPublicKey['uri']
+  keyUri: DidResourceUri
 ): Promise<ResolvedDidKey | null> => {
   const { fragment, did } = DidUtils.parseDidUri(keyUri)
   const { details } = (await resolveDoc(did as DidUri)) as DidResolvedDetails

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -9,7 +9,7 @@ import {
   CompressedMessageBody,
   DecryptCallback,
   DidEncryptionKey,
-  DidPublicKey,
+  DidResourceUri,
   EncryptCallback,
   EncryptionKeyType,
   ICType,
@@ -241,7 +241,7 @@ export class Message implements IMessage {
     senderKeyId: DidEncryptionKey['id'],
     senderDetails: DidDetails,
     encryptCallback: EncryptCallback,
-    receiverKeyUri: DidPublicKey['uri'],
+    receiverKeyUri: DidResourceUri,
     {
       resolver = DidResolver,
     }: {

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -35,7 +35,6 @@ import type {
   CompressedSubmitDelegationApproval,
   CompressedSubmitTerms,
   CompressedTerms,
-  DidPublicKey,
   DidResolvedDetails,
   DidResourceUri,
   DidUri,
@@ -252,7 +251,7 @@ describe('Messaging Utilities', () => {
     }
 
     const resolveKey = async (
-      keyUri: DidPublicKey['uri']
+      keyUri: DidResourceUri
     ): Promise<ResolvedDidKey | null> => {
       const { identifier, type, version, fragment, encodedDetails } =
         DidUtils.parseDidUri(keyUri)

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -44,7 +44,6 @@ import type {
   ICredential,
   ICType,
   IDelegationData,
-  IDidDetails,
   IDidResolver,
   IInformCreateDelegation,
   IInformDelegationCreation,
@@ -95,8 +94,8 @@ import { Message } from './Message'
 
 // TODO: Duplicated code, would be nice to have as a seperated test package with similar helpers
 async function buildCredential(
-  claimerDid: IDidDetails['uri'],
-  attesterDid: IDidDetails['uri'],
+  claimerDid: DidUri,
+  attesterDid: DidUri,
   contents: IClaim['contents'],
   legitimations: ICredential[]
 ): Promise<ICredential> {
@@ -231,7 +230,7 @@ describe('Messaging Utilities', () => {
     }
 
     const resolveDoc = async (
-      didUri: IDidDetails['uri']
+      didUri: DidUri
     ): Promise<DidResolvedDetails | null> => {
       if (didUri === identityAlice.uri) {
         return {

--- a/packages/types/src/Attestation.ts
+++ b/packages/types/src/Attestation.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { IDidDetails } from './DidDetails'
+import type { DidUri } from './DidDetails'
 import type { ICType } from './CType'
 import type { IDelegationNode } from './Delegation'
 import type { IRequestForAttestation } from './RequestForAttestation'
@@ -13,7 +13,7 @@ import type { IRequestForAttestation } from './RequestForAttestation'
 export interface IAttestation {
   claimHash: IRequestForAttestation['rootHash']
   cTypeHash: ICType['hash']
-  owner: IDidDetails['uri']
+  owner: DidUri
   delegationId: IDelegationNode['id'] | null
   revoked: boolean
 }

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -6,7 +6,7 @@
  */
 
 import type { HexString } from '@polkadot/util/types'
-import type { IDidDetails } from './DidDetails'
+import type { DidUri } from './DidDetails'
 
 export type InstanceType =
   | 'array'
@@ -31,7 +31,7 @@ export type CTypeSchemaWithoutId = Omit<ICTypeSchema, '$id'>
 
 export interface ICType {
   hash: HexString
-  owner: IDidDetails['uri'] | null
+  owner: DidUri | null
   schema: ICTypeSchema
 }
 

--- a/packages/types/src/Claim.ts
+++ b/packages/types/src/Claim.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { IDidDetails } from './DidDetails'
+import type { DidUri } from './DidDetails'
 import type { ICType } from './CType'
 
 export type IClaimContents = Record<
@@ -15,7 +15,7 @@ export type IClaimContents = Record<
 export interface IClaim {
   cTypeHash: ICType['hash']
   contents: IClaimContents
-  owner: IDidDetails['uri']
+  owner: DidUri
 }
 
 /**

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ICType } from './CType'
-import type { IDidDetails } from './DidDetails'
+import type { DidUri } from './DidDetails'
 
 /* eslint-disable no-bitwise */
 export const Permission = {
@@ -20,7 +20,7 @@ export interface IDelegationNode {
   hierarchyId: IDelegationNode['id']
   parentId?: IDelegationNode['id']
   childrenIds: Array<IDelegationNode['id']>
-  account: IDidDetails['uri']
+  account: DidUri
   permissions: PermissionType[]
   revoked: boolean
 }

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -52,7 +52,6 @@ export type VerificationKeyRelationship = Extract<
 export const verificationKeyTypes = ['sr25519', 'ed25519', 'ecdsa'] as const
 export type VerificationKeyType = typeof verificationKeyTypes[number]
 
-
 export type LightDidSupportedVerificationKeyType = Extract<
   VerificationKeyType,
   'ed25519' | 'sr25519'
@@ -61,8 +60,8 @@ export type LightDidSupportedVerificationKeyType = Extract<
 /**
  * Subset of key relationships which pertain to key agreement/encryption keys.
  */
-export type EncryptionKeyRelationship = Extract<KeyRelationship, 'keyAgreement
-'>
+export type EncryptionKeyRelationship = Extract<KeyRelationship, 'keyAgreement'>
+
 /**
  * Possible types for a DID encryption key.
  */

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -7,7 +7,7 @@
 
 import type { BN } from '@polkadot/util'
 
-import type { DidPublicKey } from './DidDocumentExporter'
+import type { DidResourceUri } from './DidDocumentExporter'
 import type { IIdentity } from './Identity'
 
 type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
@@ -52,6 +52,7 @@ export type VerificationKeyRelationship = Extract<
 export const verificationKeyTypes = ['sr25519', 'ed25519', 'ecdsa'] as const
 export type VerificationKeyType = typeof verificationKeyTypes[number]
 
+
 export type LightDidSupportedVerificationKeyType = Extract<
   VerificationKeyType,
   'ed25519' | 'sr25519'
@@ -60,7 +61,8 @@ export type LightDidSupportedVerificationKeyType = Extract<
 /**
  * Subset of key relationships which pertain to key agreement/encryption keys.
  */
-export type EncryptionKeyRelationship = Extract<KeyRelationship, 'keyAgreement'>
+export type EncryptionKeyRelationship = Extract<KeyRelationship, 'keyAgreement
+'>
 /**
  * Possible types for a DID encryption key.
  */
@@ -207,6 +209,6 @@ export interface IDidDetails {
  * A signature issued with a DID associated key, indicating which key was used to sign.
  */
 export type DidSignature = {
-  keyUri: DidPublicKey['uri']
+  keyUri: DidResourceUri
   signature: string
 }

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -88,10 +88,10 @@ export type DidPublicServiceEndpoint = {
 export type DidDocument = {
   id: DidUri
   verificationMethod: DidPublicKey[]
-  authentication: DidPublicKey['uri']
-  assertionMethod?: DidPublicKey['uri']
-  keyAgreement?: DidPublicKey['uri']
-  capabilityDelegation?: DidPublicKey['uri']
+  authentication: DidResourceUri
+  assertionMethod?: DidResourceUri
+  keyAgreement?: DidResourceUri
+  capabilityDelegation?: DidResourceUri
   service?: DidPublicServiceEndpoint[]
 }
 

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -53,7 +53,7 @@ export type DidPublicKey = {
   /**
    * The key controller, in the form of <did_subject>.
    */
-  controller: IDidDetails['uri']
+  controller: DidUri
   /**
    * The base58-encoded public component of the key.
    */
@@ -86,7 +86,7 @@ export type DidPublicServiceEndpoint = {
  * A DID Document according to the [W3C DID Core specification](https://www.w3.org/TR/did-core/).
  */
 export type DidDocument = {
-  id: IDidDetails['uri']
+  id: DidUri
   verificationMethod: DidPublicKey[]
   authentication: DidPublicKey['uri']
   assertionMethod?: DidPublicKey['uri']

--- a/packages/types/src/DidResolver.ts
+++ b/packages/types/src/DidResolver.ts
@@ -8,6 +8,7 @@
 import {
   DidPublicKey,
   DidPublicServiceEndpoint,
+  DidResourceUri,
 } from './DidDocumentExporter.js'
 import type { IDidDetails, DidKey, DidUri } from './DidDetails.js'
 
@@ -54,7 +55,7 @@ export interface IDidResolver {
    * @returns A promise of a [[DidResolvedDetails]] object if the didUri contains no fragment, [[ResolvedDidKey]] or [[ResolvedDidServiceEndpoint]] otherwise. Null if a resource cannot be resolved.
    */
   resolve: (
-    didUri: DidUri | DidPublicKey['uri'] | DidPublicServiceEndpoint['uri']
+    didUri: DidUri | DidResourceUri | DidPublicServiceEndpoint['uri']
   ) => Promise<
     DidResolvedDetails | ResolvedDidKey | ResolvedDidServiceEndpoint | null
   >
@@ -73,7 +74,7 @@ export interface IDidResolver {
    * @returns A promise of a [[ResolvedDidKey]] object representing the DID public key or null if
    * the DID or key URI cannot be resolved.
    */
-  resolveKey: (didUri: DidPublicKey['uri']) => Promise<ResolvedDidKey | null>
+  resolveKey: (didUri: DidResourceUri) => Promise<ResolvedDidKey | null>
   /**
    * Resolves a DID URI identifying a service endpoint associated with a DID.
    *

--- a/packages/types/src/DidResolver.ts
+++ b/packages/types/src/DidResolver.ts
@@ -9,7 +9,7 @@ import {
   DidPublicKey,
   DidPublicServiceEndpoint,
 } from './DidDocumentExporter.js'
-import type { IDidDetails, DidKey } from './DidDetails.js'
+import type { IDidDetails, DidKey, DidUri } from './DidDetails.js'
 
 /**
  * DID resolution metadata that includes a subset of the properties defined in the [W3C proposed standard](https://www.w3.org/TR/did-core/#did-resolution).
@@ -18,7 +18,7 @@ export type DidResolutionDocumentMetadata = {
   /**
    * If present, it indicates that the resolved by DID should be treated as if it were the DID as specified in this property.
    */
-  canonicalId?: IDidDetails['uri']
+  canonicalId?: DidUri
   /**
    * A boolean flag indicating whether the resolved DID has been deactivated.
    */
@@ -54,10 +54,7 @@ export interface IDidResolver {
    * @returns A promise of a [[DidResolvedDetails]] object if the didUri contains no fragment, [[ResolvedDidKey]] or [[ResolvedDidServiceEndpoint]] otherwise. Null if a resource cannot be resolved.
    */
   resolve: (
-    didUri:
-      | IDidDetails['uri']
-      | DidPublicKey['uri']
-      | DidPublicServiceEndpoint['uri']
+    didUri: DidUri | DidPublicKey['uri'] | DidPublicServiceEndpoint['uri']
   ) => Promise<
     DidResolvedDetails | ResolvedDidKey | ResolvedDidServiceEndpoint | null
   >
@@ -68,7 +65,7 @@ export interface IDidResolver {
    * @returns A promise of a [[DidResolvedDetails]] object representing the DID document or null if the DID
    * cannot be resolved.
    */
-  resolveDoc: (did: IDidDetails['uri']) => Promise<DidResolvedDetails | null>
+  resolveDoc: (did: DidUri) => Promise<DidResolvedDetails | null>
   /**
    * Resolves a DID URI identifying a public key associated with a DID.
    *

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AnyJson } from '@polkadot/types/types'
-import type { DidSignature, IDidDetails } from './DidDetails.js'
+import type { DidSignature, DidUri } from './DidDetails.js'
 import type { CompressedAttestation, IAttestation } from './Attestation.js'
 import type { CompressedCredential, ICredential } from './Credential.js'
 import type { IClaim, PartialClaim } from './Claim.js'
@@ -180,7 +180,7 @@ export interface IConfirmPayment extends IMessageBodyBase {
 export interface IRequestCredentialContent {
   cTypes: Array<{
     cTypeHash: ICType['hash']
-    trustedAttesters?: Array<IDidDetails['uri']>
+    trustedAttesters?: DidUri[]
     requiredProperties?: string[]
   }>
   challenge?: string
@@ -270,13 +270,7 @@ export type CompressedRejectedTerms = [
 export type CompressedRejectTerms = ['reject-terms', CompressedRejectedTerms]
 
 export type CompressedRequestCredentialContent = [
-  Array<
-    [
-      ICType['hash'],
-      Array<IDidDetails['uri']> | undefined,
-      string[] | undefined
-    ]
-  >,
+  Array<[ICType['hash'], DidUri[] | undefined, string[] | undefined]>,
   string?
 ]
 
@@ -369,8 +363,8 @@ export type CompressedMessageBody =
 export interface IMessage {
   body: MessageBody
   createdAt: number
-  sender: IDidDetails['uri']
-  receiver: IDidDetails['uri']
+  sender: DidUri
+  receiver: DidUri
   messageId?: string
   receivedAt?: number
   inReplyTo?: IMessage['messageId']

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -18,7 +18,7 @@ import type {
   IRequestForAttestation,
 } from './RequestForAttestation.js'
 import type { CompressedTerms, ITerms } from './Terms.js'
-import type { DidPublicKey, IClaimContents } from './index.js'
+import type { DidResourceUri, IClaimContents } from './index.js'
 
 export type MessageBodyType =
   | 'error'
@@ -385,8 +385,8 @@ export type IEncryptedMessageContents = Omit<IMessage, 'receivedAt'>
  * - `senderKeyUri` - The URI of the sender's encryption key.
  */
 export type IEncryptedMessage = Pick<IMessage, 'receivedAt'> & {
-  receiverKeyUri: DidPublicKey['uri']
-  senderKeyUri: DidPublicKey['uri']
+  receiverKeyUri: DidResourceUri
+  senderKeyUri: DidResourceUri
   ciphertext: string
   nonce: string
 }

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ICType } from './CType'
-import type { DidSignature, IDidDetails } from './DidDetails'
+import type { DidSignature, DidUri } from './DidDetails'
 import type { IRequestForAttestation } from './RequestForAttestation'
 
 export interface ICostBreakdown {
@@ -15,7 +15,7 @@ export interface ICostBreakdown {
   gross: number
 }
 export interface IQuote {
-  attesterDid: IDidDetails['uri']
+  attesterDid: DidUri
   cTypeHash: ICType['hash']
   cost: ICostBreakdown
   currency: string

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
@@ -15,7 +15,10 @@ import jsonld from 'jsonld'
 
 import { base58Encode, randomAsHex } from '@polkadot/util-crypto'
 
-import { DidPublicKey, DidUri } from '@kiltprotocol/types'
+import {
+  DidResourceUri,
+  DidUri,
+} from '@kiltprotocol/types'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import { Crypto } from '@kiltprotocol/utils'
 
@@ -23,9 +26,9 @@ import { KiltSignatureSuite as Suite } from './KiltSignatureSuite'
 import credential from '../examples/example-vc.json'
 import { documentLoader as kiltDocumentLoader } from '../documentLoader'
 import type {
-  VerifiableCredential,
-  SelfSignedProof,
   IPublicKeyRecord,
+  SelfSignedProof,
+  VerifiableCredential,
 } from '../../types'
 import { KILT_SELF_SIGNED_PROOF_TYPE } from '../../constants'
 
@@ -48,7 +51,7 @@ beforeAll(async () => {
     if (uri.startsWith('did:kilt:')) {
       const { identifier, fragment, did } = DidUtils.parseDidUri(uri as DidUri)
       const key: IPublicKeyRecord = {
-        uri: uri as DidPublicKey['uri'],
+        uri: uri as DidResourceUri,
         publicKeyBase58: base58Encode(Crypto.decodeAddress(identifier)),
         controller: did,
         type: 'Ed25519VerificationKey2018',

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.spec.ts
@@ -15,10 +15,7 @@ import jsonld from 'jsonld'
 
 import { base58Encode, randomAsHex } from '@polkadot/util-crypto'
 
-import {
-  DidResourceUri,
-  DidUri,
-} from '@kiltprotocol/types'
+import { DidResourceUri, DidUri } from '@kiltprotocol/types'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import { Crypto } from '@kiltprotocol/utils'
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

The DID is a foundational feature of the KILT protocol, so I think it’s fair to treat the types `DidUri` and `DidResourceUri` as foundational types that can be used directly in most places, excluding maybe those where indirection provides helpful hints.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
