### PR TITLE
feat!: idiomatic consistent errors

### DIFF
--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.spec.ts
@@ -30,7 +30,7 @@ it('rejects promise on timeout', async () => {
     timeout: 500,
   })
   subscription('something else')
-  await expect(promise).rejects.toThrow(SDKErrors.ERROR_TIMEOUT)
+  await expect(promise).rejects.toThrow(SDKErrors.TimeoutError)
 })
 
 it('resolves the promise', async () => {

--- a/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
+++ b/packages/chain-helpers/src/blockchain/SubscriptionPromise.ts
@@ -47,7 +47,7 @@ export function makeSubscriptionPromise<SubscriptionType>(
         }
   if (timeout)
     setTimeout(() => {
-      reject(new SDKErrors.ERROR_TIMEOUT())
+      reject(new SDKErrors.TimeoutError())
     }, timeout)
   return { promise, subscription }
 }

--- a/packages/config/src/ConfigService.spec.ts
+++ b/packages/config/src/ConfigService.spec.ts
@@ -45,7 +45,7 @@ describe('Configuration Service', () => {
   it('has configuration Object with default values', () => {
     expect(ConfigService.get('logLevel')).toEqual(LogLevel.Error)
     expect(() => ConfigService.get('address')).toThrowError(
-      SDKErrors.ERROR_WS_ADDRESS_NOT_SET
+      SDKErrors.WsAddressNotSetError
     )
   })
   describe('set function for host address, logLevel and any custom configuration prop', () => {
@@ -70,11 +70,11 @@ describe('Configuration Service', () => {
     it('throws if address not set', () => {
       ConfigService.set({ address: '' })
       expect(() => ConfigService.get('address')).toThrowError(
-        SDKErrors.ERROR_WS_ADDRESS_NOT_SET
+        SDKErrors.WsAddressNotSetError
       )
       ConfigService.set({ address: undefined })
       expect(() => ConfigService.get('address')).toThrowError(
-        SDKErrors.ERROR_WS_ADDRESS_NOT_SET
+        SDKErrors.WsAddressNotSetError
       )
     })
     it('returns logLevel property', () => {

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -59,7 +59,7 @@ let configuration: configOpts = {
 
 function checkAddress(): void {
   if (!configuration.address) {
-    throw new SDKErrors.ERROR_WS_ADDRESS_NOT_SET()
+    throw new SDKErrors.WsAddressNotSetError()
   }
 }
 

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -79,18 +79,18 @@ async function addDelegation(
   hierarchyId: IDelegationNode['id'],
   parentId: DelegationNode['id'],
   delegator: FullDidDetails,
-  delegee: FullDidDetails,
+  delegate: FullDidDetails,
   delegatorSign: SignCallback,
-  delegeeSign: SignCallback,
+  delegateSign: SignCallback,
   permissions: PermissionType[] = [Permission.ATTEST, Permission.DELEGATE]
 ): Promise<DelegationNode> {
   const delegationNode = DelegationNode.newNode({
     hierarchyId,
     parentId,
-    account: delegee.uri,
+    account: delegate.uri,
     permissions,
   })
-  const signature = await delegationNode.delegeeSign(delegee, delegeeSign)
+  const signature = await delegationNode.delegateSign(delegate, delegateSign)
   const storeTx = await delegationNode.getStoreTx(signature)
   const authorizedStoreTx = await delegator.authorizeExtrinsic(
     storeTx,
@@ -227,18 +227,18 @@ describe('and attestation rights have been delegated', () => {
 describe('revocation', () => {
   let delegator: FullDidDetails
   let delegatorSign: SignCallback
-  let firstDelegee: FullDidDetails
-  let firstDelegeeSign: SignCallback
-  let secondDelegee: FullDidDetails
-  let secondDelegeeSign: SignCallback
+  let firstDelegate: FullDidDetails
+  let firstDelegateSign: SignCallback
+  let secondDelegate: FullDidDetails
+  let secondDelegateSign: SignCallback
 
   beforeAll(() => {
     delegator = root
     delegatorSign = rootKey.sign
-    firstDelegee = attester
-    firstDelegeeSign = attesterKey.sign
-    secondDelegee = claimer
-    secondDelegeeSign = claimerKey.sign
+    firstDelegate = attester
+    firstDelegateSign = attesterKey.sign
+    secondDelegate = claimer
+    secondDelegateSign = claimerKey.sign
   })
 
   it('delegator can revoke but not remove delegation', async () => {
@@ -251,9 +251,9 @@ describe('revocation', () => {
       rootNode.id,
       rootNode.id,
       delegator,
-      firstDelegee,
+      firstDelegate,
       delegatorSign,
-      firstDelegeeSign
+      firstDelegateSign
     )
 
     // Test revocation
@@ -287,7 +287,7 @@ describe('revocation', () => {
     expect(await DelegationNode.query(delegationA.id)).not.toBeNull()
   }, 60_000)
 
-  it('delegee cannot revoke root but can revoke own delegation', async () => {
+  it('delegate cannot revoke root but can revoke own delegation', async () => {
     const delegationRoot = await writeHierarchy(
       delegator,
       driversLicenseCType.hash,
@@ -297,14 +297,14 @@ describe('revocation', () => {
       delegationRoot.id,
       delegationRoot.id,
       delegator,
-      firstDelegee,
+      firstDelegate,
       delegatorSign,
-      firstDelegeeSign
+      firstDelegateSign
     )
     const revokeTx = await getRevokeTx(delegationRoot.id, 1, 1)
-    const authorizedRevokeTx = await firstDelegee.authorizeExtrinsic(
+    const authorizedRevokeTx = await firstDelegate.authorizeExtrinsic(
       revokeTx,
-      firstDelegeeSign,
+      firstDelegateSign,
       paymentAccount.address
     )
     await expect(
@@ -315,10 +315,10 @@ describe('revocation', () => {
     })
     expect(await delegationRoot.verify()).toBe(true)
 
-    const revokeTx2 = await delegationA.getRevokeTx(firstDelegee.uri)
-    const authorizedRevokeTx2 = await firstDelegee.authorizeExtrinsic(
+    const revokeTx2 = await delegationA.getRevokeTx(firstDelegate.uri)
+    const authorizedRevokeTx2 = await firstDelegate.authorizeExtrinsic(
       revokeTx2,
-      firstDelegeeSign,
+      firstDelegateSign,
       paymentAccount.address
     )
     await submitExtrinsic(authorizedRevokeTx2, paymentAccount)
@@ -335,17 +335,17 @@ describe('revocation', () => {
       delegationRoot.id,
       delegationRoot.id,
       delegator,
-      firstDelegee,
+      firstDelegate,
       delegatorSign,
-      firstDelegeeSign
+      firstDelegateSign
     )
     const delegationB = await addDelegation(
       delegationRoot.id,
       delegationA.id,
-      firstDelegee,
-      secondDelegee,
-      firstDelegeeSign,
-      secondDelegeeSign
+      firstDelegate,
+      secondDelegate,
+      firstDelegateSign,
+      secondDelegateSign
     )
     delegationRoot = await delegationRoot.getLatestState()
     const revokeTx = await delegationRoot.getRevokeTx(delegator.uri)

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1178,11 +1178,12 @@ describe('Runtime constraints', () => {
             identifier: encodeAddress(testAuthKey.publicKey),
             keyAgreementKeys: newKeyAgreementKeys,
           },
+
           paymentAccount.address,
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"The number of key agreement keys in the creation operation is greater than the maximum allowed, which is 10."'
+        `"The number of key agreement keys in the creation operation is greater than the maximum allowed, which is 10"`
       )
     }, 30_000)
 
@@ -1217,11 +1218,12 @@ describe('Runtime constraints', () => {
             identifier: encodeAddress(testAuthKey.publicKey),
             serviceEndpoints: newServiceEndpoints,
           },
+
           paymentAccount.address,
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"Cannot store more than 25 service endpoints per DID."'
+        `"Cannot store more than 25 service endpoints per DID"`
       )
     }, 30_000)
 
@@ -1261,7 +1263,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service ID 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
+        `"The service ID \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
       )
     }, 30_000)
 
@@ -1295,7 +1297,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has too many types (2). Max number of types allowed per service is 1."`
+        `"The service with ID \\"id-1\\" has too many types (2). Max number of types allowed per service is 1."`
       )
     }, 30_000)
 
@@ -1329,7 +1331,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has too many URLs (2). Max number of URLs allowed per service is 1."`
+        `"The service with ID \\"id-1\\" has too many URLs (2). Max number of URLs allowed per service is 1."`
       )
     }, 30_000)
 
@@ -1369,7 +1371,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has the type 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
+        `"The service with ID \\"id-1\\" has the type \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
       )
     }, 30_000)
 
@@ -1413,7 +1415,7 @@ describe('Runtime constraints', () => {
           sign
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has the URL 'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' that is too long (202 bytes). Max number of bytes allowed for a service URL is 200."`
+        `"The service with ID \\"id-1\\" has the URL \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (202 bytes). Max number of bytes allowed for a service URL is 200."`
       )
     }, 30_000)
   })
@@ -1434,7 +1436,7 @@ describe('Runtime constraints', () => {
           urls: ['x:url-a'],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service ID 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
+        `"The service ID \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
       )
     }, 30_000)
 
@@ -1451,7 +1453,7 @@ describe('Runtime constraints', () => {
       await expect(
         DidChain.getAddEndpointExtrinsic(newEndpoint)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has too many types (2). Max number of types allowed per service is 1."`
+        `"The service with ID \\"id-1\\" has too many types (2). Max number of types allowed per service is 1."`
       )
     }, 30_000)
 
@@ -1468,7 +1470,7 @@ describe('Runtime constraints', () => {
       await expect(
         DidChain.getAddEndpointExtrinsic(newEndpoint)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has too many URLs (2). Max number of URLs allowed per service is 1."`
+        `"The service with ID \\"id-1\\" has too many URLs (2). Max number of URLs allowed per service is 1."`
       )
     }, 30_000)
 
@@ -1487,7 +1489,7 @@ describe('Runtime constraints', () => {
           urls: ['x:url-1'],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has the type 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
+        `"The service with ID \\"id-1\\" has the type \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
       )
     }, 30_000)
 
@@ -1510,7 +1512,7 @@ describe('Runtime constraints', () => {
           ],
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID 'id-1' has the URL 'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' that is too long (201 bytes). Max number of bytes allowed for a service URL is 200."`
+        `"The service with ID \\"id-1\\" has the URL \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (201 bytes). Max number of bytes allowed for a service URL is 200."`
       )
     }, 30_000)
   })

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -58,10 +58,10 @@ describe('When there is an Web3NameCreator and a payer', () => {
     )
 
     if (paymentAccount === otherPaymentAccount) {
-      throw new Error('The payment accounts are the same.')
+      throw new Error('The payment accounts are the same')
     }
     if (w3nCreator === otherWeb3NameCreator) {
-      throw new Error('The web3name creators are the same.')
+      throw new Error('The web3name creators are the same')
     }
   }, 60_000)
 
@@ -198,7 +198,7 @@ describe('Runtime constraints', () => {
     await expect(
       Web3Names.getClaimTx('aa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3."'
+      `"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"`
     )
   }, 30_000)
 
@@ -209,7 +209,7 @@ describe('Runtime constraints', () => {
     await expect(
       Web3Names.getClaimTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32."'
+      `"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"`
     )
   }, 30_000)
 
@@ -220,7 +220,7 @@ describe('Runtime constraints', () => {
     await expect(
       Web3Names.getReclaimDepositTx('aa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3."'
+      `"The provided name \\"aa\\" is shorter than the minimum number of characters allowed, which is 3"`
     )
   }, 30_000)
 
@@ -231,7 +231,7 @@ describe('Runtime constraints', () => {
     await expect(
       Web3Names.getReclaimDepositTx('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32."'
+      `"The provided name \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is longer than the maximum number of characters allowed, which is 32"`
     )
   }, 30_000)
 })

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -53,7 +53,7 @@ export async function getStoreTx(
           : undefined
       )
     default:
-      throw new SDKErrors.ERROR_CODEC_MISMATCH(
+      throw new SDKErrors.CodecMismatchError(
         'Failed to encode call: unknown authorization type'
       )
   }
@@ -96,7 +96,7 @@ function decode(
     } else if ('delegationId' in chainAttestation) {
       delegationId = chainAttestation.delegationId.unwrapOr(undefined)?.toHex()
     } else {
-      throw new SDKErrors.ERROR_CODEC_MISMATCH(
+      throw new SDKErrors.CodecMismatchError(
         'Failed to decode Attestation: unknown Codec type'
       )
     }
@@ -174,7 +174,7 @@ export async function getRevokeTx(
           : undefined
       )
     default:
-      throw new SDKErrors.ERROR_CODEC_MISMATCH(
+      throw new SDKErrors.CodecMismatchError(
         'Failed to encode call: unknown authorization type'
       )
   }
@@ -209,7 +209,7 @@ export async function getRemoveTx(
           : undefined
       )
     default:
-      throw new SDKErrors.ERROR_CODEC_MISMATCH(
+      throw new SDKErrors.CodecMismatchError(
         'Failed to encode call: unknown authorization type'
       )
   }

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -239,34 +239,34 @@ describe('Attestation', () => {
     } as IAttestation
 
     expect(() => Attestation.verifyDataStructure(noClaimHash)).toThrowError(
-      SDKErrors.ERROR_CLAIM_HASH_NOT_PROVIDED
+      SDKErrors.ClaimHashMissingError
     )
 
     expect(() => Attestation.verifyDataStructure(noCTypeHash)).toThrowError(
-      SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED
+      SDKErrors.CTypeHashMissingError
     )
 
     expect(() => Attestation.verifyDataStructure(malformedOwner)).toThrowError(
-      SDKErrors.ERROR_OWNER_NOT_PROVIDED
+      SDKErrors.OwnerMissingError
     )
 
     expect(() => Attestation.verifyDataStructure(noRevocationBit)).toThrowError(
-      SDKErrors.ERROR_REVOCATION_BIT_MISSING
+      SDKErrors.RevokedTypeError
     )
 
     expect(() => Attestation.verifyDataStructure(everything)).not.toThrow()
 
     expect(() =>
       Attestation.verifyDataStructure(malformedClaimHash)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
 
     expect(() =>
       Attestation.verifyDataStructure(malformedCTypeHash)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
 
     expect(() =>
       Attestation.verifyDataStructure(malformedAddress)
-    ).toThrowError(SDKErrors.ERROR_INVALID_DID_FORMAT)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
   })
   it('Typeguard should return true on complete Attestations', () => {
     const attestation = Attestation.fromRequestAndDid(

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -33,29 +33,33 @@ import { query } from './Attestation.chain.js'
  * Throws on invalid input.
  *
  * @param input The potentially only partial [[IAttestation]].
- * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]], [[ERROR_CLAIM_HASH_NOT_PROVIDED]] or [[ERROR_OWNER_NOT_PROVIDED]] when input's cTypeHash, claimHash or owner respectively do not exist.
- * @throws [[ERROR_DELEGATION_ID_TYPE]] when the input's delegationId is not of type 'string' or 'null'.
- * @throws [[ERROR_REVOCATION_BIT_MISSING]] when input.revoked is not of type 'boolean'.
+ * @throws [[CTypeHashMissingError]], [[ClaimHashMissingError]] or [[OwnerMissingError]] when input's cTypeHash, claimHash or owner respectively do not exist.
+ * @throws [[DelegationIdTypeError]] when the input's delegationId is not of type 'string' or 'null'.
+ * @throws [[RevokedTypeError]] when input.revoked is not of type 'boolean'.
  *
  */
 export function verifyDataStructure(input: IAttestation): void {
   if (!input.cTypeHash) {
-    throw new SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED()
-  } else DataUtils.validateHash(input.cTypeHash, 'CType')
+    throw new SDKErrors.CTypeHashMissingError()
+  }
+  DataUtils.validateHash(input.cTypeHash, 'CType')
 
   if (!input.claimHash) {
-    throw new SDKErrors.ERROR_CLAIM_HASH_NOT_PROVIDED()
-  } else DataUtils.validateHash(input.claimHash, 'Claim')
+    throw new SDKErrors.ClaimHashMissingError()
+  }
+  DataUtils.validateHash(input.claimHash, 'Claim')
 
   if (typeof input.delegationId !== 'string' && !input.delegationId === null) {
-    throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
+    throw new SDKErrors.DelegationIdTypeError()
   }
+
   if (!input.owner) {
-    throw new SDKErrors.ERROR_OWNER_NOT_PROVIDED()
-  } else DidUtils.validateKiltDidUri(input.owner)
+    throw new SDKErrors.OwnerMissingError()
+  }
+  DidUtils.validateKiltDidUri(input.owner)
 
   if (typeof input.revoked !== 'boolean') {
-    throw new SDKErrors.ERROR_REVOCATION_BIT_MISSING()
+    throw new SDKErrors.RevokedTypeError()
   }
 }
 
@@ -170,13 +174,13 @@ export function compress(attestation: IAttestation): CompressedAttestation {
  * Decompresses an [[Attestation]] from storage and/or message into an object.
  *
  * @param attestation A compressed [[Attestation]] array that is decompressed back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when the attestation is not an array or its length is not equal to 5.
+ * @throws [[DecompressionArrayError]] when the attestation is not an array or its length is not equal to 5.
  *
  * @returns An object that has the same properties as an [[Attestation]].
  */
 export function decompress(attestation: CompressedAttestation): IAttestation {
   if (!Array.isArray(attestation) || attestation.length !== 5) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('Attestation')
+    throw new SDKErrors.DecompressionArrayError('Attestation')
   }
   const decompressedAttestation = {
     claimHash: attestation[0],

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -33,10 +33,6 @@ import { query } from './Attestation.chain.js'
  * Throws on invalid input.
  *
  * @param input The potentially only partial [[IAttestation]].
- * @throws [[CTypeHashMissingError]], [[ClaimHashMissingError]] or [[OwnerMissingError]] when input's cTypeHash, claimHash or owner respectively do not exist.
- * @throws [[DelegationIdTypeError]] when the input's delegationId is not of type 'string' or 'null'.
- * @throws [[RevokedTypeError]] when input.revoked is not of type 'boolean'.
- *
  */
 export function verifyDataStructure(input: IAttestation): void {
   if (!input.cTypeHash) {
@@ -174,8 +170,6 @@ export function compress(attestation: IAttestation): CompressedAttestation {
  * Decompresses an [[Attestation]] from storage and/or message into an object.
  *
  * @param attestation A compressed [[Attestation]] array that is decompressed back into an object.
- * @throws [[DecompressionArrayError]] when the attestation is not an array or its length is not equal to 5.
- *
  * @returns An object that has the same properties as an [[Attestation]].
  */
 export function decompress(attestation: CompressedAttestation): IAttestation {

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -81,7 +81,7 @@ export const TRANSACTION_FEE = convertToTxUnit(new BN(125), -9)
 export function balanceNumberToString(input: BalanceNumber): string {
   if (typeof input === 'string') {
     if (!input.match(/^-?\d*\.?\d+$/)) {
-      throw new Error('not a string representation of number')
+      throw new Error('Not a string representation of number')
     }
     return input
   }
@@ -92,7 +92,7 @@ export function balanceNumberToString(input: BalanceNumber): string {
   ) {
     return input.toString()
   }
-  throw new Error('could not convert to String')
+  throw new Error('Could not convert to String')
 }
 
 /**
@@ -121,7 +121,7 @@ export function toFemtoKilt(
     : stringRepresentation.split('.')
   if (fraction && fraction.length > unitVal + 15) {
     throw new Error(
-      `Too many decimal places: input with unit ${unit} and value ${stringRepresentation} exceeds the ${
+      `Too many decimal places: input with unit "${unit}" and value "${stringRepresentation}" exceeds the ${
         unitVal + 15
       } possible decimal places by ${fraction.length - unitVal + 15}`
     )

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -75,8 +75,6 @@ export const TRANSACTION_FEE = convertToTxUnit(new BN(125), -9)
  *
  * @param input [[BalanceNumber]] to convert.
  * @returns String representation of the given [[BalanceNumber]].
- * @throws On invalid number representation if given a string.
- * @throws On malformed input.
  */
 export function balanceNumberToString(input: BalanceNumber): string {
   if (typeof input === 'string') {
@@ -101,7 +99,6 @@ export function balanceNumberToString(input: BalanceNumber): string {
  * @param input [[BalanceNumber]] to convert.
  * @param unit Metric prefix of the given [[BalanceNumber]].
  * @returns Exact BN representation in femtoKilt, to use in transactions and calculations.
- * @throws Unknown metricPrefix, or if the input has too many decimal places for its unit.
  */
 export function toFemtoKilt(
   input: BalanceNumber,

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -263,15 +263,15 @@ describe('Claim', () => {
     expect(() => Claim.verifyDataStructure(everything)).not.toThrow()
 
     expect(() => Claim.verifyDataStructure(noCTypeHash)).toThrowError(
-      SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED
+      SDKErrors.CTypeHashMissingError
     )
 
     expect(() => Claim.verifyDataStructure(malformedCTypeHash)).toThrowError(
-      SDKErrors.ERROR_HASH_MALFORMED
+      SDKErrors.HashMalformedError
     )
 
     expect(() => Claim.verifyDataStructure(malformedAddress)).toThrowError(
-      SDKErrors.ERROR_ADDRESS_INVALID
+      SDKErrors.AddressInvalidError
     )
   })
 })

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -44,7 +44,6 @@ const VC_VOCAB = 'https://www.w3.org/2018/credentials#'
  * @param claim A (partial) [[IClaim]] from to build a JSON-LD representation from. The `cTypeHash` property is required.
  * @param expanded Return an expanded instead of a compacted representation. While property transformation is done explicitly in the expanded format, it is otherwise done implicitly via adding JSON-LD's reserved `@context` properties while leaving [[IClaim]][contents] property keys untouched.
  * @returns An object which can be serialized into valid JSON-LD representing an [[IClaim]]'s ['contents'].
- * @throws [[CTypeHashMissingError]] in case the claim's ['cTypeHash'] property is undefined.
  */
 function jsonLDcontents(
   claim: PartialClaim,
@@ -75,7 +74,6 @@ function jsonLDcontents(
  * @param claim A (partial) [[IClaim]] from to build a JSON-LD representation from. The `cTypeHash` property is required.
  * @param expanded Return an expanded instead of a compacted representation. While property transformation is done explicitly in the expanded format, it is otherwise done implicitly via adding JSON-LD's reserved `@context` properties while leaving [[IClaim]][contents] property keys untouched.
  * @returns An object which can be serialized into valid JSON-LD representing an [[IClaim]].
- * @throws [[CTypeHashMissingError]] in case the claim's ['cTypeHash'] property is undefined.
  */
 export function toJsonLD(
   claim: PartialClaim,
@@ -110,7 +108,6 @@ function makeStatementsJsonLD(claim: PartialClaim): string[] {
  * @param options.nonceGenerator Nonce generator as defined by [[hashStatements]] to be used if no `nonces` are given. Default produces random UUIDs (v4).
  * @param options.hasher The hasher to be used. Required but defaults to 256 bit blake2 over `${nonce}${statement}`.
  * @returns An array of salted `hashes` and a `nonceMap` where keys correspond to unsalted statement hashes.
- * @throws [[ClaimNonceMapMalformedError]] if the nonceMap or the nonceGenerator was non-exhaustive for any statement.
  */
 export function hashClaimContents(
   claim: PartialClaim,
@@ -199,9 +196,6 @@ export function verifyDisclosedAttributes(
  * Throws on invalid input.
  *
  * @param input The potentially only partial IClaim.
- * @throws [[CTypeHashMissingError]] when input's cTypeHash do not exist.
- * @throws [[ClaimContentsMalformedError]] when any of the input's contents[key] is not of type 'number', 'boolean' or 'string'.
- *
  */
 export function verifyDataStructure(input: IClaim | PartialClaim): void {
   if (!input.cTypeHash) {
@@ -236,7 +230,6 @@ function verifyAgainstCType(
  *
  * @param claimInput IClaim to verify.
  * @param cTypeSchema ICType['schema'] to verify claimInput's contents.
- * @throws [[ClaimUnverifiableError]] when claimInput's contents could not be verified with the provided cTypeSchema.
  */
 export function verify(
   claimInput: IClaim,
@@ -289,8 +282,6 @@ export function fromNestedCTypeClaim(
  * @param ctypeInput [[ICType]] for which the Claim will be built.
  * @param claimContents IClaim['contents'] to be used as the pure contents of the instantiated Claim.
  * @param claimOwner The DID to be used as the Claim owner.
- * @throws [[ClaimUnverifiableError]] when claimInput's contents could not be verified with the schema of the provided ctypeInput.
- *
  * @returns A Claim object.
  */
 export function fromCTypeAndClaimContents(
@@ -366,7 +357,6 @@ export function compress(
  * Decompresses an [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedClaim]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] if `claim` is not an Array or it's length is unequal 3.
  * @returns An [[IClaim]] object that has the same properties compressed representation.
  */
 export function decompress(claim: CompressedClaim): IClaim
@@ -374,7 +364,6 @@ export function decompress(claim: CompressedClaim): IClaim
  * Decompresses a partial [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedPartialClaim]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] if `claim` is not an Array or it's length is unequal 3.
  * @returns A [[PartialClaim]] object that has the same properties compressed representation.
  */
 export function decompress(claim: CompressedPartialClaim): PartialClaim
@@ -382,7 +371,6 @@ export function decompress(claim: CompressedPartialClaim): PartialClaim
  * Decompresses compressed representation of a (partial) [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedClaim]] or [[CompressedPartialClaim]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] if `claim` is not an Array or it's length is unequal 3.
  * @returns An [[IClaim]] or [[PartialClaim]] object that has the same properties compressed representation.
  */
 export function decompress(

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -44,14 +44,14 @@ const VC_VOCAB = 'https://www.w3.org/2018/credentials#'
  * @param claim A (partial) [[IClaim]] from to build a JSON-LD representation from. The `cTypeHash` property is required.
  * @param expanded Return an expanded instead of a compacted representation. While property transformation is done explicitly in the expanded format, it is otherwise done implicitly via adding JSON-LD's reserved `@context` properties while leaving [[IClaim]][contents] property keys untouched.
  * @returns An object which can be serialized into valid JSON-LD representing an [[IClaim]]'s ['contents'].
- * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] in case the claim's ['cTypeHash'] property is undefined.
+ * @throws [[CTypeHashMissingError]] in case the claim's ['cTypeHash'] property is undefined.
  */
 function jsonLDcontents(
   claim: PartialClaim,
   expanded = true
 ): Record<string, unknown> {
   const { cTypeHash, contents, owner } = claim
-  if (!cTypeHash) throw new SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED()
+  if (!cTypeHash) throw new SDKErrors.CTypeHashMissingError()
   const vocabulary = `${getIdForCTypeHash(cTypeHash)}#`
   const result: Record<string, unknown> = {}
   if (owner) result['@id'] = owner
@@ -75,7 +75,7 @@ function jsonLDcontents(
  * @param claim A (partial) [[IClaim]] from to build a JSON-LD representation from. The `cTypeHash` property is required.
  * @param expanded Return an expanded instead of a compacted representation. While property transformation is done explicitly in the expanded format, it is otherwise done implicitly via adding JSON-LD's reserved `@context` properties while leaving [[IClaim]][contents] property keys untouched.
  * @returns An object which can be serialized into valid JSON-LD representing an [[IClaim]].
- * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] in case the claim's ['cTypeHash'] property is undefined.
+ * @throws [[CTypeHashMissingError]] in case the claim's ['cTypeHash'] property is undefined.
  */
 export function toJsonLD(
   claim: PartialClaim,
@@ -110,7 +110,7 @@ function makeStatementsJsonLD(claim: PartialClaim): string[] {
  * @param options.nonceGenerator Nonce generator as defined by [[hashStatements]] to be used if no `nonces` are given. Default produces random UUIDs (v4).
  * @param options.hasher The hasher to be used. Required but defaults to 256 bit blake2 over `${nonce}${statement}`.
  * @returns An array of salted `hashes` and a `nonceMap` where keys correspond to unsalted statement hashes.
- * @throws [[ERROR_CLAIM_NONCE_MAP_MALFORMED]] if the nonceMap or the nonceGenerator was non-exhaustive for any statement.
+ * @throws [[ClaimNonceMapMalformedError]] if the nonceMap or the nonceGenerator was non-exhaustive for any statement.
  */
 export function hashClaimContents(
   claim: PartialClaim,
@@ -136,7 +136,7 @@ export function hashClaimContents(
   const nonceMap = {}
   processed.forEach(({ digest, nonce, statement }) => {
     // throw if we can't map a digest to a nonce - this should not happen if the nonce map is complete and the credential has not been tampered with
-    if (!nonce) throw new SDKErrors.ERROR_CLAIM_NONCE_MAP_MALFORMED(statement)
+    if (!nonce) throw new SDKErrors.ClaimNonceMapMalformedError(statement)
     nonceMap[digest] = nonce
   }, {})
   return { hashes, nonceMap }
@@ -178,15 +178,13 @@ export function verifyDisclosedAttributes(
     (status, { saltedHash, statement, digest, nonce }) => {
       // check if the statement digest was contained in the proof and mapped it to a nonce
       if (!digestsInProof.includes(digest) || !nonce) {
-        status.errors.push(
-          new SDKErrors.ERROR_NO_PROOF_FOR_STATEMENT(statement)
-        )
+        status.errors.push(new SDKErrors.NoProofForStatementError(statement))
         return { ...status, verified: false }
       }
       // check if the hash is whitelisted in the proof
       if (!proof.hashes.includes(saltedHash)) {
         status.errors.push(
-          new SDKErrors.ERROR_INVALID_PROOF_FOR_STATEMENT(statement)
+          new SDKErrors.InvalidProofForStatementError(statement)
         )
         return { ...status, verified: false }
       }
@@ -201,13 +199,13 @@ export function verifyDisclosedAttributes(
  * Throws on invalid input.
  *
  * @param input The potentially only partial IClaim.
- * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] when input's cTypeHash do not exist.
- * @throws [[ERROR_CLAIM_CONTENTS_MALFORMED]] when any of the input's contents[key] is not of type 'number', 'boolean' or 'string'.
+ * @throws [[CTypeHashMissingError]] when input's cTypeHash do not exist.
+ * @throws [[ClaimContentsMalformedError]] when any of the input's contents[key] is not of type 'number', 'boolean' or 'string'.
  *
  */
 export function verifyDataStructure(input: IClaim | PartialClaim): void {
   if (!input.cTypeHash) {
-    throw new SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED()
+    throw new SDKErrors.CTypeHashMissingError()
   }
   if (input.owner) {
     DidUtils.validateKiltDidUri(input.owner)
@@ -219,7 +217,7 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
         typeof key !== 'string' ||
         !['string', 'number', 'boolean', 'object'].includes(typeof value)
       ) {
-        throw new SDKErrors.ERROR_CLAIM_CONTENTS_MALFORMED()
+        throw new SDKErrors.ClaimContentsMalformedError()
       }
     })
   }
@@ -232,19 +230,20 @@ function verifyAgainstCType(
 ): boolean {
   return verifyClaimAgainstSchema(claimContents, cTypeSchema)
 }
+
 /**
  * Verifies the data structure and schema of a Claim.
  *
  * @param claimInput IClaim to verify.
  * @param cTypeSchema ICType['schema'] to verify claimInput's contents.
- * @throws [[ERROR_CLAIM_UNVERIFIABLE]] when claimInput's contents could not be verified with the provided cTypeSchema.
+ * @throws [[ClaimUnverifiableError]] when claimInput's contents could not be verified with the provided cTypeSchema.
  */
 export function verify(
   claimInput: IClaim,
   cTypeSchema: ICType['schema']
 ): void {
   if (!verifyAgainstCType(claimInput.contents, cTypeSchema)) {
-    throw new SDKErrors.ERROR_CLAIM_UNVERIFIABLE()
+    throw new SDKErrors.ClaimUnverifiableError()
   }
 
   verifyDataStructure(claimInput)
@@ -273,7 +272,7 @@ export function fromNestedCTypeClaim(
       claimContents
     )
   ) {
-    throw new SDKErrors.ERROR_NESTED_CLAIM_UNVERIFIABLE()
+    throw new SDKErrors.NestedClaimUnverifiableError()
   }
   const claim = {
     cTypeHash: cTypeInput.hash,
@@ -290,7 +289,7 @@ export function fromNestedCTypeClaim(
  * @param ctypeInput [[ICType]] for which the Claim will be built.
  * @param claimContents IClaim['contents'] to be used as the pure contents of the instantiated Claim.
  * @param claimOwner The DID to be used as the Claim owner.
- * @throws [[ERROR_CLAIM_UNVERIFIABLE]] when claimInput's contents could not be verified with the schema of the provided ctypeInput.
+ * @throws [[ClaimUnverifiableError]] when claimInput's contents could not be verified with the schema of the provided ctypeInput.
  *
  * @returns A Claim object.
  */
@@ -301,7 +300,7 @@ export function fromCTypeAndClaimContents(
 ): IClaim {
   if (ctypeInput.schema) {
     if (!verifyAgainstCType(claimContents, ctypeInput.schema)) {
-      throw new SDKErrors.ERROR_CLAIM_UNVERIFIABLE()
+      throw new SDKErrors.ClaimUnverifiableError()
     }
   }
   const claim = {
@@ -367,7 +366,7 @@ export function compress(
  * Decompresses an [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedClaim]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] if `claim` is not an Array or it's length is unequal 3.
+ * @throws [[DecompressionArrayError]] if `claim` is not an Array or it's length is unequal 3.
  * @returns An [[IClaim]] object that has the same properties compressed representation.
  */
 export function decompress(claim: CompressedClaim): IClaim
@@ -375,7 +374,7 @@ export function decompress(claim: CompressedClaim): IClaim
  * Decompresses a partial [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedPartialClaim]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] if `claim` is not an Array or it's length is unequal 3.
+ * @throws [[DecompressionArrayError]] if `claim` is not an Array or it's length is unequal 3.
  * @returns A [[PartialClaim]] object that has the same properties compressed representation.
  */
 export function decompress(claim: CompressedPartialClaim): PartialClaim
@@ -383,14 +382,14 @@ export function decompress(claim: CompressedPartialClaim): PartialClaim
  * Decompresses compressed representation of a (partial) [[IClaim]] from storage and/or message.
  *
  * @param claim A [[CompressedClaim]] or [[CompressedPartialClaim]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] if `claim` is not an Array or it's length is unequal 3.
+ * @throws [[DecompressionArrayError]] if `claim` is not an Array or it's length is unequal 3.
  * @returns An [[IClaim]] or [[PartialClaim]] object that has the same properties compressed representation.
  */
 export function decompress(
   claim: CompressedClaim | CompressedPartialClaim
 ): IClaim | PartialClaim {
   if (!Array.isArray(claim) || claim.length !== 3) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('Claim')
+    throw new SDKErrors.DecompressionArrayError('Claim')
   }
   const decompressedClaim = {
     cTypeHash: claim[0],

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -58,17 +58,17 @@ export function verifyDataIntegrity(credential: ICredential): boolean {
  * Throws on invalid input.
  *
  * @param input The potentially only partial ICredential.
- * @throws [[ERROR_ATTESTATION_NOT_PROVIDED]] or [[ERROR_RFA_NOT_PROVIDED]] when input's attestation and request respectively do not exist.
+ * @throws [[AttestationMissingError]] or [[RequestForAttestationMissingError]] when input's attestation and request respectively do not exist.
  *
  */
 export function verifyDataStructure(input: ICredential): void {
   if (input.attestation) {
     Attestation.verifyDataStructure(input.attestation)
-  } else throw new SDKErrors.ERROR_ATTESTATION_NOT_PROVIDED()
+  } else throw new SDKErrors.AttestationMissingError()
 
   if (input.request) {
     RequestForAttestation.verifyDataStructure(input.request)
-  } else throw new SDKErrors.ERROR_RFA_NOT_PROVIDED()
+  } else throw new SDKErrors.RequestForAttestationMissingError()
 }
 
 /**
@@ -161,14 +161,14 @@ export async function verify(
  * Verifies the data of each element of the given Array of ICredentials.
  *
  * @param legitimations Array of ICredentials to validate.
- * @throws [[ERROR_LEGITIMATIONS_UNVERIFIABLE]] when one of the ICredentials data is unable to be verified.
+ * @throws [[LegitimationsUnverifiableError]] when one of the ICredentials data is unable to be verified.
  *
  * @returns Boolean whether each element of the given Array of ICredentials is verifiable.
  */
 export function validateLegitimations(legitimations: ICredential[]): boolean {
   legitimations.forEach((legitimation) => {
     if (!verifyDataIntegrity(legitimation)) {
-      throw new SDKErrors.ERROR_LEGITIMATIONS_UNVERIFIABLE()
+      throw new SDKErrors.LegitimationsUnverifiableError()
     }
   })
   return true
@@ -246,7 +246,7 @@ export async function createPresentation({
   const selectedKeyId = (await keySelection(keys))?.id
 
   if (!selectedKeyId) {
-    throw new SDKErrors.ERROR_UNSUPPORTED_KEY('authentication')
+    throw new SDKErrors.UnsupportedKeyError('authentication')
   }
 
   await RequestForAttestation.signWithDidKey(
@@ -281,12 +281,12 @@ export function compress(credential: ICredential): CompressedCredential {
  * Decompresses a [[Credential]] array from storage and/or message into an object.
  *
  * @param credential The [[CompressedCredential]] that should get decompressed.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when credential is not an Array or it's length is unequal 2.
+ * @throws [[DecompressionArrayError]] when credential is not an Array or it's length is unequal 2.
  * @returns A new [[Credential]] object.
  */
 export function decompress(credential: CompressedCredential): ICredential {
   if (!Array.isArray(credential) || credential.length !== 2) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('Credential')
+    throw new SDKErrors.DecompressionArrayError('Credential')
   }
   const decompressedCredential = {
     request: RequestForAttestation.decompress(credential[0]),

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -202,7 +202,7 @@ export function getAttributes(credential: ICredential): Set<string> {
  * @param presentationOptions.challenge Challenge which will be part of the presentation signature.
  * @param presentationOptions.selectedAttributes All properties of the claim which have been requested by the verifier and therefore must be publicly presented.
  * If not specified, all attributes are shown. If set to an empty array, we hide all attributes inside the claim for the presentation.
- * @param presentationOptions.keySelection The logic to select the right key to sign for the delegee. It defaults to picking the first key from the set of valid keys.
+ * @param presentationOptions.keySelection The logic to select the right key to sign for the delegate. It defaults to picking the first key from the set of valid keys.
  * @returns A deep copy of the Credential with all but `publicAttributes` removed.
  */
 export async function createPresentation({

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -58,8 +58,6 @@ export function verifyDataIntegrity(credential: ICredential): boolean {
  * Throws on invalid input.
  *
  * @param input The potentially only partial ICredential.
- * @throws [[AttestationMissingError]] or [[RequestForAttestationMissingError]] when input's attestation and request respectively do not exist.
- *
  */
 export function verifyDataStructure(input: ICredential): void {
   if (input.attestation) {
@@ -161,8 +159,6 @@ export async function verify(
  * Verifies the data of each element of the given Array of ICredentials.
  *
  * @param legitimations Array of ICredentials to validate.
- * @throws [[LegitimationsUnverifiableError]] when one of the ICredentials data is unable to be verified.
- *
  * @returns Boolean whether each element of the given Array of ICredentials is verifiable.
  */
 export function validateLegitimations(legitimations: ICredential[]): boolean {
@@ -281,7 +277,6 @@ export function compress(credential: ICredential): CompressedCredential {
  * Decompresses a [[Credential]] array from storage and/or message into an object.
  *
  * @param credential The [[CompressedCredential]] that should get decompressed.
- * @throws [[DecompressionArrayError]] when credential is not an Array or it's length is unequal 2.
  * @returns A new [[Credential]] object.
  */
 export function decompress(credential: CompressedCredential): ICredential {

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -70,7 +70,7 @@ describe('CType', () => {
     // @ts-expect-error
     delete faultyMetadata.metadata.properties
     expect(() => CType.verifyCTypeMetadata(metadata)).toThrow(
-      SDKErrors.ERROR_OBJECT_MALFORMED
+      SDKErrors.ObjectUnverifiableError
     )
   })
 })

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -130,23 +130,25 @@ describe('CType', () => {
       },
     }
     expect(() => CType.verifyDataStructure(wrongHashCtype)).toThrowError(
-      SDKErrors.ERROR_HASH_MALFORMED
+      SDKErrors.HashMalformedError
     )
     expect(() => CType.verifyDataStructure(faultySchemaCtype)).toThrowError(
-      SDKErrors.ERROR_OBJECT_MALFORMED
+      SDKErrors.ObjectUnverifiableError
     )
     expect(() =>
       CType.verifyDataStructure(invalidAddressCtype)
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Not a valid KILT did: did:kilt:Dp6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N"`
+      `"Not a valid KILT DID \\"did:kilt:Dp6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N\\""`
     )
     expect(() =>
       CType.verifyDataStructure(faultyAddressTypeCType)
-    ).toThrowErrorMatchingInlineSnapshot(`"Not a valid KILT did: 4262626426"`)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Not a valid KILT DID \\"4262626426\\""`
+    )
     expect(() =>
       CType.verifyDataStructure(wrongSchemaIdCType)
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Provided $id \\"kilt:ctype:0xd5302762c62114f6455e0b373cccce20631c2a717004a98f8953e738e17c5d3c\\" and schema $id \\"kilt:ctype:0xd5301762c62114f6455e0b373cccce20631c2a717004a98f8953e738e17c5d3c\\" are not matching"`
+      `"Provided $id \\"kilt:ctype:0xd5302762c62114f6455e0b373cccce20631c2a717004a98f8953e738e17c5d3c\\" does not match schema $id \\"kilt:ctype:0xd5301762c62114f6455e0b373cccce20631c2a717004a98f8953e738e17c5d3c\\""`
     )
   })
 
@@ -300,7 +302,7 @@ describe('CType verification', () => {
     ).toBeFalsy()
     expect(() => {
       CType.verifyClaimAgainstSchema(badClaim, ctypeInput)
-    }).toThrow(SDKErrors.ERROR_OBJECT_MALFORMED)
+    }).toThrow(SDKErrors.ObjectUnverifiableError)
   })
   it('verifies ctypes', () => {
     expect(

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -123,7 +123,7 @@ export function verifyObjectAgainstSchema(
  * @param claimContents IClaim['contents'] to be verified against the schema.
  * @param schema ICType['schema'] to be verified against the [CTypeModel].
  * @param messages An array, which will be filled by schema errors.
- * @throws [[ERROR_OBJECT_MALFORMED]] when schema does not correspond to the CTypeModel.
+ * @throws [[ObjectUnverifiableError]] when schema does not correspond to the CTypeModel.
  *
  * @returns Boolean whether both claimContents and schema could be verified.
  */
@@ -133,7 +133,7 @@ export function verifyClaimAgainstSchema(
   messages?: string[]
 ): boolean {
   if (!verifyObjectAgainstSchema(schema, CTypeModel)) {
-    throw new SDKErrors.ERROR_OBJECT_MALFORMED()
+    throw new SDKErrors.ObjectUnverifiableError()
   }
   return verifyObjectAgainstSchema(claimContents, schema, messages)
 }
@@ -164,26 +164,26 @@ export async function verifyOwner(ctype: ICType): Promise<boolean> {
  * Throws on invalid input.
  *
  * @param input The potentially only partial ICType.
- * @throws [[ERROR_OBJECT_MALFORMED]] when input does not correspond to either it's schema, or the CTypeWrapperModel.
- * @throws [[ERROR_HASH_MALFORMED]] when the input's hash does not match the hash calculated from ICType's schema.
- * @throws [[ERROR_CTYPE_OWNER_TYPE]] when the input's owner is not of type string or null.
+ * @throws [[ObjectUnverifiableError]] when input does not correspond to either it's schema, or the CTypeWrapperModel.
+ * @throws [[HashMalformedError]] when the input's hash does not match the hash calculated from ICType's schema.
+ * @throws [[CTypeOwnerTypeError]] when the input's owner is not a DID or null.
  *
  */
 export function verifyDataStructure(input: ICType): void {
   if (!verifyObjectAgainstSchema(input, CTypeWrapperModel)) {
-    throw new SDKErrors.ERROR_OBJECT_MALFORMED()
+    throw new SDKErrors.ObjectUnverifiableError()
   }
   if (!input.schema || getHashForSchema(input.schema) !== input.hash) {
-    throw new SDKErrors.ERROR_HASH_MALFORMED(input.hash, 'CType')
+    throw new SDKErrors.HashMalformedError(input.hash, 'CType')
   }
   if (getIdForSchema(input.schema) !== input.schema.$id) {
-    throw new SDKErrors.ERROR_CTYPE_ID_NOT_MATCHING(
+    throw new SDKErrors.CTypeIdMismatchError(
       getIdForSchema(input.schema),
       input.schema.$id
     )
   }
   if (!(input.owner === null || DidUtils.validateKiltDidUri(input.owner))) {
-    throw new SDKErrors.ERROR_CTYPE_OWNER_TYPE()
+    throw new SDKErrors.CTypeOwnerTypeError()
   }
 }
 
@@ -221,11 +221,11 @@ export function verifyClaimAgainstNestedSchemas(
  * Checks a CTypeMetadata object.
  *
  * @param metadata [[ICTypeMetadata]] that is to be instantiated.
- * @throws [[ERROR_OBJECT_MALFORMED]] when metadata is not verifiable with the MetadataModel.
+ * @throws [[ObjectUnverifiableError]] when metadata is not verifiable with the MetadataModel.
  */
 export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
   if (!verifyObjectAgainstSchema(metadata, MetadataModel)) {
-    throw new SDKErrors.ERROR_OBJECT_MALFORMED()
+    throw new SDKErrors.ObjectUnverifiableError()
   }
 }
 
@@ -275,7 +275,7 @@ export function isICType(input: unknown): input is ICType {
  * Compresses a [[CType]] schema for storage and/or messaging.
  *
  * @param cTypeSchema A [[CType]] schema object that will be sorted and stripped for messaging or storage.
- * @throws [[ERROR_COMPRESS_OBJECT]] when any of the four required properties of the cTypeSchema are missing.
+ * @throws [[CompressObjectError]] when any of the four required properties of the cTypeSchema are missing.
  *
  * @returns An ordered array of a [[CType]] schema.
  */
@@ -289,7 +289,7 @@ export function compressSchema(
     !cTypeSchema.properties ||
     !cTypeSchema.type
   ) {
-    throw new SDKErrors.ERROR_COMPRESS_OBJECT(cTypeSchema, 'cTypeSchema')
+    throw new SDKErrors.CompressObjectError(cTypeSchema, 'cTypeSchema')
   }
   const sortedCTypeSchema = jsonabc.sortObj(cTypeSchema)
   return [
@@ -305,7 +305,7 @@ export function compressSchema(
  * Decompresses a schema of a [[CType]] from storage and/or message.
  *
  * @param cTypeSchema A compressed [[CType]] schema array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when either the cTypeSchema is not an Array or it's length is not equal to the defined length of 4.
+ * @throws [[DecompressionArrayError]] when either the cTypeSchema is not an Array or it's length is not equal to the defined length of 4.
  *
  * @returns An object that has the same properties as a [[CType]] schema.
  */
@@ -313,7 +313,7 @@ export function decompressSchema(
   cTypeSchema: CompressedCTypeSchema
 ): ICType['schema'] {
   if (!Array.isArray(cTypeSchema) || cTypeSchema.length !== 5) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('cTypeSchema')
+    throw new SDKErrors.DecompressionArrayError('cTypeSchema')
   }
   return {
     $id: cTypeSchema[0],
@@ -340,13 +340,13 @@ export function compress(cType: ICType): CompressedCType {
  * Decompresses a [[CType]] from storage and/or message.
  *
  * @param cType A compressed [[CType]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when either the cType is not an Array or it's length is not equal to the defined length of 3.
+ * @throws [[DecompressionArrayError]] when either the cType is not an Array or it's length is not equal to the defined length of 3.
  *
  * @returns An object that has the same properties as a [[CType]].
  */
 export function decompress(cType: CompressedCType): ICType {
   if (!Array.isArray(cType) || cType.length !== 3) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('CType')
+    throw new SDKErrors.DecompressionArrayError('CType')
   }
   const decompressedCType = {
     hash: cType[0],

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -123,8 +123,6 @@ export function verifyObjectAgainstSchema(
  * @param claimContents IClaim['contents'] to be verified against the schema.
  * @param schema ICType['schema'] to be verified against the [CTypeModel].
  * @param messages An array, which will be filled by schema errors.
- * @throws [[ObjectUnverifiableError]] when schema does not correspond to the CTypeModel.
- *
  * @returns Boolean whether both claimContents and schema could be verified.
  */
 export function verifyClaimAgainstSchema(
@@ -164,10 +162,6 @@ export async function verifyOwner(ctype: ICType): Promise<boolean> {
  * Throws on invalid input.
  *
  * @param input The potentially only partial ICType.
- * @throws [[ObjectUnverifiableError]] when input does not correspond to either it's schema, or the CTypeWrapperModel.
- * @throws [[HashMalformedError]] when the input's hash does not match the hash calculated from ICType's schema.
- * @throws [[CTypeOwnerTypeError]] when the input's owner is not a DID or null.
- *
  */
 export function verifyDataStructure(input: ICType): void {
   if (!verifyObjectAgainstSchema(input, CTypeWrapperModel)) {
@@ -221,7 +215,6 @@ export function verifyClaimAgainstNestedSchemas(
  * Checks a CTypeMetadata object.
  *
  * @param metadata [[ICTypeMetadata]] that is to be instantiated.
- * @throws [[ObjectUnverifiableError]] when metadata is not verifiable with the MetadataModel.
  */
 export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
   if (!verifyObjectAgainstSchema(metadata, MetadataModel)) {
@@ -275,8 +268,6 @@ export function isICType(input: unknown): input is ICType {
  * Compresses a [[CType]] schema for storage and/or messaging.
  *
  * @param cTypeSchema A [[CType]] schema object that will be sorted and stripped for messaging or storage.
- * @throws [[CompressObjectError]] when any of the four required properties of the cTypeSchema are missing.
- *
  * @returns An ordered array of a [[CType]] schema.
  */
 export function compressSchema(
@@ -305,8 +296,6 @@ export function compressSchema(
  * Decompresses a schema of a [[CType]] from storage and/or message.
  *
  * @param cTypeSchema A compressed [[CType]] schema array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when either the cTypeSchema is not an Array or it's length is not equal to the defined length of 4.
- *
  * @returns An object that has the same properties as a [[CType]] schema.
  */
 export function decompressSchema(
@@ -340,8 +329,6 @@ export function compress(cType: ICType): CompressedCType {
  * Decompresses a [[CType]] from storage and/or message.
  *
  * @param cType A compressed [[CType]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when either the cType is not an Array or it's length is not equal to the defined length of 3.
- *
  * @returns An object that has the same properties as a [[CType]].
  */
 export function decompress(cType: CompressedCType): ICType {

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ICType, IClaim, IClaimContents } from '@kiltprotocol/types'
+import { SDKErrors } from '@kiltprotocol/utils'
 import * as CType from './CType'
 import * as Claim from '../claim'
 
@@ -168,9 +169,7 @@ describe('Nested CTypes', () => {
         claimContents,
         didAlice
       )
-    ).toThrowError(
-      new Error('Nested claim data does not validate against CType')
-    )
+    ).toThrowError(SDKErrors.NestedClaimUnverifiableError)
     expect(
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType.schema,
@@ -198,8 +197,6 @@ describe('Nested CTypes', () => {
         claimDeepContents,
         didAlice
       )
-    ).toThrowError(
-      new Error('Nested claim data does not validate against CType')
-    )
+    ).toThrowError(SDKErrors.NestedClaimUnverifiableError)
   })
 })

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -52,7 +52,7 @@ export async function getStoreAsRootTx(
  * Generate the extrinsic to store a given delegation node under a given delegation hierarchy.
  *
  * @param delegation The delegation node to store under the hierarchy specified as part of the node.
- * @param signature The DID signature of the delegee owner of the new delegation node.
+ * @param signature The DID signature of the delegate owner of the new delegation node.
  * @returns The SubmittableExtrinsic for the `addDelegation` call.
  */
 export async function getStoreAsDelegationTx(

--- a/packages/core/src/delegation/DelegationNode.chain.ts
+++ b/packages/core/src/delegation/DelegationNode.chain.ts
@@ -40,7 +40,7 @@ export async function getStoreAsRootTx(
   const api = await BlockchainApiConnection.getConnectionOrConnect()
 
   if (!delegation.isRoot()) {
-    throw new SDKErrors.ERROR_INVALID_ROOT_NODE()
+    throw new SDKErrors.InvalidRootNodeError()
   }
   return api.tx.delegation.createHierarchy(
     delegation.hierarchyId,
@@ -62,7 +62,7 @@ export async function getStoreAsDelegationTx(
   const api = await BlockchainApiConnection.getConnectionOrConnect()
 
   if (delegation.isRoot()) {
-    throw new SDKErrors.ERROR_INVALID_DELEGATION_NODE()
+    throw new SDKErrors.InvalidDelegationNodeError()
   }
 
   return api.tx.delegation.addDelegation(
@@ -165,7 +165,7 @@ export async function getChildren(
     delegationNode.childrenIds.map(async (childId: IDelegationNode['id']) => {
       const childNode = await query(childId)
       if (!childNode) {
-        throw new SDKErrors.ERROR_DELEGATION_ID_MISSING()
+        throw new SDKErrors.DelegationIdMissingError()
       }
       return childNode
     })
@@ -205,7 +205,7 @@ export async function getAttestationHashes(
     DecoderUtils.assertCodecIsType(claimHashes, ['Option<Vec<H256>>'])
     return claimHashes.unwrapOrDefault().map((hash) => hash.toHex())
   }
-  throw new SDKErrors.ERROR_CODEC_MISMATCH(
+  throw new SDKErrors.CodecMismatchError(
     'Failed to query delegated attestations: Unknown pallet storage'
   )
 }

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -512,19 +512,19 @@ describe('DelegationNode', () => {
       } as IDelegationNode
 
       expect(() => errorCheck(malformedPermissionsDelegationNode)).toThrowError(
-        SDKErrors.ERROR_UNAUTHORIZED
+        SDKErrors.UnauthorizedError
       )
 
       expect(() => errorCheck(missingRootIdDelegationNode)).toThrowError(
-        SDKErrors.ERROR_DELEGATION_ID_MISSING
+        SDKErrors.DelegationIdMissingError
       )
 
       expect(() => errorCheck(malformedRootIdDelegationNode)).toThrowError(
-        SDKErrors.ERROR_DELEGATION_ID_TYPE
+        SDKErrors.DelegationIdTypeError
       )
 
       expect(() => errorCheck(malformedParentIdDelegationNode)).toThrowError(
-        SDKErrors.ERROR_DELEGATION_ID_TYPE
+        SDKErrors.DelegationIdTypeError
       )
     })
   })

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -173,14 +173,14 @@ export class DelegationNode implements IDelegationNode {
   /**
    * Fetches the details of the hierarchy this delegation node belongs to.
    *
-   * @throws [[ERROR_HIERARCHY_QUERY]] when the hierarchy details could not be queried.
+   * @throws [[HierarchyQueryError]] when the hierarchy details could not be queried.
    * @returns Promise containing the [[IDelegationHierarchyDetails]] of this delegation node.
    */
   public async getHierarchyDetails(): Promise<IDelegationHierarchyDetails> {
     if (!this.hierarchyDetails) {
       const hierarchyDetails = await queryDetails(this.hierarchyId)
       if (!hierarchyDetails) {
-        throw new SDKErrors.ERROR_HIERARCHY_QUERY(this.hierarchyId)
+        throw new SDKErrors.HierarchyQueryError(this.hierarchyId)
       }
       this.hierarchyDetails = hierarchyDetails
       return hierarchyDetails
@@ -283,8 +283,8 @@ export class DelegationNode implements IDelegationNode {
       delegeeDid.getVerificationKeys('authentication')
     )
     if (!authenticationKey) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Delegee ${delegeeDid.uri} does not have any authentication key.`
+      throw new SDKErrors.DidError(
+        `Delegee "${delegeeDid.uri}" does not have any authentication key`
       )
     }
     const delegeeSignature = await delegeeDid.signPayload(
@@ -303,7 +303,7 @@ export class DelegationNode implements IDelegationNode {
   public async getLatestState(): Promise<DelegationNode> {
     const newNodeState = await query(this.id)
     if (!newNodeState) {
-      throw new SDKErrors.ERROR_DELEGATION_ID_MISSING()
+      throw new SDKErrors.DelegationIdMissingError()
     }
     return newNodeState
   }
@@ -321,7 +321,7 @@ export class DelegationNode implements IDelegationNode {
       return getStoreAsRootTx(this)
     }
     if (!signature) {
-      throw new SDKErrors.ERROR_DELEGATION_SIGNATURE_MISSING()
+      throw new SDKErrors.DelegationSignatureMissingError()
     }
     return getStoreAsDelegationTx(this, signature)
   }
@@ -396,8 +396,8 @@ export class DelegationNode implements IDelegationNode {
   public async getRevokeTx(did: DidUri): Promise<SubmittableExtrinsic> {
     const { steps, node } = await this.findAncestorOwnedBy(did)
     if (!node) {
-      throw new SDKErrors.ERROR_UNAUTHORIZED(
-        `The DID ${did} is not among the delegators and may not revoke this node`
+      throw new SDKErrors.UnauthorizedError(
+        `The DID "${did}" is not among the delegators and may not revoke this node`
       )
     }
     const childCount = await this.subtreeNodeCount()

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -261,16 +261,16 @@ export class DelegationNode implements IDelegationNode {
   /**
    * Signs the delegation hash from the delegations' property values.
    *
-   * This is required to anchor the delegation node on chain in order to enforce the delegee's consent.
+   * This is required to anchor the delegation node on chain in order to enforce the delegate's consent.
    *
-   * @param delegeeDid The DID of the delegee.
-   * @param sign The callback to sign the delegation creation details for the delegee.
+   * @param delegateDid The DID of the delegate.
+   * @param sign The callback to sign the delegation creation details for the delegate.
    * @param options The additional signing options.
-   * @param options.keySelection The logic to select the right key to sign for the delegee. It defaults to picking the first key from the set of valid keys.
+   * @param options.keySelection The logic to select the right key to sign for the delegate. It defaults to picking the first key from the set of valid keys.
    * @returns The DID signature over the delegation **as a hex string**.
    */
-  public async delegeeSign(
-    delegeeDid: DidDetails,
+  public async delegateSign(
+    delegateDid: DidDetails,
     sign: SignCallback,
     {
       keySelection = DidUtils.defaultKeySelectionCallback,
@@ -279,19 +279,19 @@ export class DelegationNode implements IDelegationNode {
     } = {}
   ): Promise<DidChain.SignatureEnum> {
     const authenticationKey = await keySelection(
-      delegeeDid.getVerificationKeys('authentication')
+      delegateDid.getVerificationKeys('authentication')
     )
     if (!authenticationKey) {
       throw new SDKErrors.DidError(
-        `Delegee "${delegeeDid.uri}" does not have any authentication key`
+        `Delegate "${delegateDid.uri}" does not have any authentication key`
       )
     }
-    const delegeeSignature = await delegeeDid.signPayload(
+    const delegateSignature = await delegateDid.signPayload(
       this.generateHash(),
       sign,
       authenticationKey.id
     )
-    return DidChain.encodeDidSignature(authenticationKey, delegeeSignature)
+    return DidChain.encodeDidSignature(authenticationKey, delegateSignature)
   }
 
   /**

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -173,7 +173,6 @@ export class DelegationNode implements IDelegationNode {
   /**
    * Fetches the details of the hierarchy this delegation node belongs to.
    *
-   * @throws [[HierarchyQueryError]] when the hierarchy details could not be queried.
    * @returns Promise containing the [[IDelegationHierarchyDetails]] of this delegation node.
    */
   public async getHierarchyDetails(): Promise<IDelegationHierarchyDetails> {

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -320,7 +320,7 @@ export class DelegationNode implements IDelegationNode {
       return getStoreAsRootTx(this)
     }
     if (!signature) {
-      throw new SDKErrors.DelegationSignatureMissingError()
+      throw new SDKErrors.DelegateSignatureMissingError()
     }
     return getStoreAsDelegationTx(this, signature)
   }

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -54,14 +54,14 @@ export async function countNodeDepth(
       const { steps, node } = await delegationNode.findAncestorOwnedBy(attester)
       delegationTreeTraversalSteps += steps
       if (node === null) {
-        throw new SDKErrors.ERROR_UNAUTHORIZED(
-          'Attester is not authorized to revoke this attestation. (attester not in delegation tree)'
+        throw new SDKErrors.UnauthorizedError(
+          'Attester is not authorized to revoke this attestation. (Attester not in delegation tree)'
         )
       }
     }
   } else if (attestation.owner !== attester) {
-    throw new SDKErrors.ERROR_UNAUTHORIZED(
-      'Attester is not authorized to revoke this attestation. (not the owner, no delegations)'
+    throw new SDKErrors.UnauthorizedError(
+      'Attester is not authorized to revoke this attestation. (Not the owner, no delegations)'
     )
   }
 
@@ -78,23 +78,17 @@ export function errorCheck(delegationNodeInput: IDelegationNode): void {
   const { permissions, hierarchyId: rootId, parentId } = delegationNodeInput
 
   if (permissions.length === 0 || permissions.length > 3) {
-    throw new SDKErrors.ERROR_UNAUTHORIZED(
+    throw new SDKErrors.UnauthorizedError(
       'Must have at least one permission and no more then two'
     )
   }
 
   if (!rootId) {
-    throw new SDKErrors.ERROR_DELEGATION_ID_MISSING()
-  } else if (typeof rootId !== 'string') {
-    throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
-  } else if (!isHex(rootId)) {
-    throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
+    throw new SDKErrors.DelegationIdMissingError()
+  } else if (typeof rootId !== 'string' || !isHex(rootId)) {
+    throw new SDKErrors.DelegationIdTypeError()
   }
-  if (parentId) {
-    if (typeof parentId !== 'string') {
-      throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
-    } else if (!isHex(parentId)) {
-      throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
-    }
+  if (parentId && (typeof parentId !== 'string' || !isHex(parentId))) {
+    throw new SDKErrors.DelegationIdTypeError()
   }
 }

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -37,7 +37,6 @@ export function permissionsAsBitset(delegation: IDelegationNode): Uint8Array {
  * @param attester Identity to be located in the delegation tree.
  * @param attestation Attestation whose delegation tree to search.
  * @returns 0 if `attester` is the owner of `attestation`, the number of delegation nodes traversed otherwise.
- * @throws [[SDKError]] If the `attester` is neither the owner nor in the delegation tree of `attestation`.
  */
 export async function countNodeDepth(
   attester: DidUri,
@@ -72,7 +71,6 @@ export async function countNodeDepth(
  * Checks for errors on delegation node data.
  *
  * @param delegationNodeInput Delegation node data.
- * @throws [[SDKError]] in case of errors.
  */
 export function errorCheck(delegationNodeInput: IDelegationNode): void {
   const { permissions, hierarchyId: rootId, parentId } = delegationNodeInput

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -123,7 +123,6 @@ export async function createAttesterSignedQuote(
  * @param quote The object which to be verified.
  * @param options Optional settings.
  * @param options.resolver DidResolver used in the process of verifying the attester signature.
- * @throws [[QuoteUnverifiableError]] when the quote can not be validated with the QuoteSchema.
  */
 export async function verifyAttesterSignedQuote(
   quote: IQuoteAttesterSigned,
@@ -222,8 +221,6 @@ export async function createQuoteAgreement(
  * Compresses the cost from a [[Quote]] object.
  *
  * @param cost A cost object that will be sorted and stripped into a [[Quote]].
- * @throws [[CompressObjectError]] when cost is missing any property defined in [[ICostBreakdown]].
- *
  * @returns An ordered array of a cost.
  */
 export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
@@ -237,8 +234,6 @@ export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
  * Decompresses the cost from storage and/or message.
  *
  * @param cost A compressed cost array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when cost is not an Array and its length does not equal the defined length of 3.
- *
  * @returns An object that has the same properties as a cost.
  */
 export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
@@ -252,8 +247,6 @@ export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
  * Compresses a [[Quote]] for storage and/or messaging.
  *
  * @param quote An [[Quote]] object that will be sorted and stripped for messaging or storage.
- * @throws [[CompressObjectError]] when quote is missing any property defined in [[IQuote]].
- *
  * @returns An ordered array of an [[Quote]].
  */
 export function compressQuote(quote: IQuote): CompressedQuote {
@@ -281,7 +274,6 @@ export function compressQuote(quote: IQuote): CompressedQuote {
  * Decompresses an [[Quote]] from storage and/or message.
  *
  * @param quote A compressed [[Quote]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when quote is not an Array and its length does not equal the defined length of 6.
  * @returns An object that has the same properties as an [[Quote]].
  */
 export function decompressQuote(quote: CompressedQuote): IQuote {
@@ -310,8 +302,6 @@ function decompressSignature(comp: [string, DidResourceUri]): DidSignature {
  * Compresses an attester signed [[Quote]] for storage and/or messaging.
  *
  * @param attesterSignedQuote An attester signed [[Quote]] object that will be sorted and stripped for messaging or storage.
- * @throws [[CompressObjectError]] when attesterSignedQuote is missing any property defined in [[IQuoteAttesterSigned]].
- *
  * @returns An ordered array of an attester signed [[Quote]].
  */
 export function compressAttesterSignedQuote(
@@ -356,8 +346,6 @@ export function compressAttesterSignedQuote(
  * Decompresses an attester signed [[Quote]] from storage and/or message.
  *
  * @param attesterSignedQuote A compressed attester signed [[Quote]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when attesterSignedQuote is not an Array and its length does not equal the defined length of 7.
- *
  * @returns An object that has the same properties as an attester signed [[Quote]].
  */
 export function decompressAttesterSignedQuote(
@@ -381,8 +369,6 @@ export function decompressAttesterSignedQuote(
  * Compresses a [[Quote]] Agreement for storage and/or messaging.
  *
  * @param quoteAgreement A [[Quote]] Agreement object that will be sorted and stripped for messaging or storage.
- * @throws [[CompressObjectError]] when quoteAgreement is missing any property defined in [[IQuoteAgreement]].
- *
  * @returns An ordered array of a [[Quote]] Agreement.
  */
 export function compressQuoteAgreement(
@@ -416,8 +402,6 @@ export function compressQuoteAgreement(
  * Decompresses a [[Quote]] Agreement from storage and/or message.
  *
  * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when quoteAgreement is not an Array and its length does not equal the defined length of 9.
- *
  * @returns An object that has the same properties as a [[Quote]] Agreement.
  */
 export function decompressQuoteAgreement(

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -92,15 +92,15 @@ export async function createAttesterSignedQuote(
   } = {}
 ): Promise<IQuoteAttesterSigned> {
   if (!validateQuoteSchema(QuoteSchema, quoteInput)) {
-    throw new SDKErrors.ERROR_QUOTE_MALFORMED()
+    throw new SDKErrors.QuoteUnverifiableError()
   }
 
   const authenticationKey = await keySelection(
     attesterIdentity.getVerificationKeys('authentication')
   )
   if (!authenticationKey) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `The attester ${attesterIdentity.uri} does not have a valid authentication key.`
+    throw new SDKErrors.DidError(
+      `The attester "${attesterIdentity.uri}" does not have a valid authentication key`
     )
   }
   const signature = await attesterIdentity.signPayload(
@@ -123,7 +123,7 @@ export async function createAttesterSignedQuote(
  * @param quote The object which to be verified.
  * @param options Optional settings.
  * @param options.resolver DidResolver used in the process of verifying the attester signature.
- * @throws [[ERROR_QUOTE_MALFORMED]] when the quote can not be validated with the QuoteSchema.
+ * @throws [[QuoteUnverifiableError]] when the quote can not be validated with the QuoteSchema.
  */
 export async function verifyAttesterSignedQuote(
   quote: IQuoteAttesterSigned,
@@ -143,12 +143,12 @@ export async function verifyAttesterSignedQuote(
 
   if (!result.verified) {
     // TODO: should throw a "signature not verifiable" error, with the reason attached.
-    throw new SDKErrors.ERROR_QUOTE_MALFORMED()
+    throw new SDKErrors.QuoteUnverifiableError()
   }
 
   const messages: string[] = []
   if (!validateQuoteSchema(QuoteSchema, basicQuote, messages)) {
-    throw new SDKErrors.ERROR_QUOTE_MALFORMED()
+    throw new SDKErrors.QuoteUnverifiableError()
   }
 }
 
@@ -182,7 +182,7 @@ export async function createQuoteAgreement(
   const { attesterSignature, ...basicQuote } = attesterSignedQuote
 
   if (attesterIdentity !== attesterSignedQuote.attesterDid)
-    throw new SDKErrors.ERROR_DID_IDENTIFIER_MISMATCH(
+    throw new SDKErrors.DidIdentifierMismatchError(
       attesterIdentity,
       attesterSignedQuote.attesterDid
     )
@@ -198,8 +198,8 @@ export async function createQuoteAgreement(
     claimerIdentity.getVerificationKeys('authentication')
   )
   if (!claimerAuthenticationKey) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `Claimer DID ${claimerIdentity.uri} does not have an authentication key.`
+    throw new SDKErrors.DidError(
+      `Claimer DID "${claimerIdentity.uri}" does not have an authentication key`
     )
   }
 
@@ -222,13 +222,13 @@ export async function createQuoteAgreement(
  * Compresses the cost from a [[Quote]] object.
  *
  * @param cost A cost object that will be sorted and stripped into a [[Quote]].
- * @throws [[ERROR_COMPRESS_OBJECT]] when cost is missing any property defined in [[ICostBreakdown]].
+ * @throws [[CompressObjectError]] when cost is missing any property defined in [[ICostBreakdown]].
  *
  * @returns An ordered array of a cost.
  */
 export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
   if (!cost.gross || !cost.net || !cost.tax) {
-    throw new SDKErrors.ERROR_COMPRESS_OBJECT(cost, 'Cost Breakdown')
+    throw new SDKErrors.CompressObjectError(cost, 'Cost Breakdown')
   }
   return [cost.gross, cost.net, cost.tax]
 }
@@ -237,13 +237,13 @@ export function compressCost(cost: ICostBreakdown): CompressedCostBreakdown {
  * Decompresses the cost from storage and/or message.
  *
  * @param cost A compressed cost array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when cost is not an Array and its length does not equal the defined length of 3.
+ * @throws [[DecompressionArrayError]] when cost is not an Array and its length does not equal the defined length of 3.
  *
  * @returns An object that has the same properties as a cost.
  */
 export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
   if (!Array.isArray(cost) || cost.length !== 3) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('Cost Breakdown')
+    throw new SDKErrors.DecompressionArrayError('Cost Breakdown')
   }
   return { gross: cost[0], net: cost[1], tax: cost[2] }
 }
@@ -252,7 +252,7 @@ export function decompressCost(cost: CompressedCostBreakdown): ICostBreakdown {
  * Compresses a [[Quote]] for storage and/or messaging.
  *
  * @param quote An [[Quote]] object that will be sorted and stripped for messaging or storage.
- * @throws [[ERROR_COMPRESS_OBJECT]] when quote is missing any property defined in [[IQuote]].
+ * @throws [[CompressObjectError]] when quote is missing any property defined in [[IQuote]].
  *
  * @returns An ordered array of an [[Quote]].
  */
@@ -265,7 +265,7 @@ export function compressQuote(quote: IQuote): CompressedQuote {
     !quote.termsAndConditions ||
     !quote.timeframe
   ) {
-    throw new SDKErrors.ERROR_COMPRESS_OBJECT(quote, 'Quote')
+    throw new SDKErrors.CompressObjectError(quote, 'Quote')
   }
   return [
     quote.attesterDid,
@@ -281,12 +281,12 @@ export function compressQuote(quote: IQuote): CompressedQuote {
  * Decompresses an [[Quote]] from storage and/or message.
  *
  * @param quote A compressed [[Quote]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when quote is not an Array and its length does not equal the defined length of 6.
+ * @throws [[DecompressionArrayError]] when quote is not an Array and its length does not equal the defined length of 6.
  * @returns An object that has the same properties as an [[Quote]].
  */
 export function decompressQuote(quote: CompressedQuote): IQuote {
   if (!Array.isArray(quote) || quote.length !== 6) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY()
+    throw new SDKErrors.DecompressionArrayError()
   }
   return {
     attesterDid: quote[0],
@@ -310,7 +310,7 @@ function decompressSignature(comp: [string, DidResourceUri]): DidSignature {
  * Compresses an attester signed [[Quote]] for storage and/or messaging.
  *
  * @param attesterSignedQuote An attester signed [[Quote]] object that will be sorted and stripped for messaging or storage.
- * @throws [[ERROR_COMPRESS_OBJECT]] when attesterSignedQuote is missing any property defined in [[IQuoteAttesterSigned]].
+ * @throws [[CompressObjectError]] when attesterSignedQuote is missing any property defined in [[IQuoteAttesterSigned]].
  *
  * @returns An ordered array of an attester signed [[Quote]].
  */
@@ -336,7 +336,7 @@ export function compressAttesterSignedQuote(
     !attesterSignature.signature ||
     !attesterSignature.keyUri
   ) {
-    throw new SDKErrors.ERROR_COMPRESS_OBJECT(
+    throw new SDKErrors.CompressObjectError(
       attesterSignedQuote,
       'Attester Signed Quote'
     )
@@ -356,7 +356,7 @@ export function compressAttesterSignedQuote(
  * Decompresses an attester signed [[Quote]] from storage and/or message.
  *
  * @param attesterSignedQuote A compressed attester signed [[Quote]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when attesterSignedQuote is not an Array and its length does not equal the defined length of 7.
+ * @throws [[DecompressionArrayError]] when attesterSignedQuote is not an Array and its length does not equal the defined length of 7.
  *
  * @returns An object that has the same properties as an attester signed [[Quote]].
  */
@@ -364,7 +364,7 @@ export function decompressAttesterSignedQuote(
   attesterSignedQuote: CompressedQuoteAttesterSigned
 ): IQuoteAttesterSigned {
   if (!Array.isArray(attesterSignedQuote) || attesterSignedQuote.length !== 7) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY()
+    throw new SDKErrors.DecompressionArrayError()
   }
   return {
     attesterDid: attesterSignedQuote[0],
@@ -381,7 +381,7 @@ export function decompressAttesterSignedQuote(
  * Compresses a [[Quote]] Agreement for storage and/or messaging.
  *
  * @param quoteAgreement A [[Quote]] Agreement object that will be sorted and stripped for messaging or storage.
- * @throws [[ERROR_COMPRESS_OBJECT]] when quoteAgreement is missing any property defined in [[IQuoteAgreement]].
+ * @throws [[CompressObjectError]] when quoteAgreement is missing any property defined in [[IQuoteAgreement]].
  *
  * @returns An ordered array of a [[Quote]] Agreement.
  */
@@ -397,7 +397,7 @@ export function compressQuoteAgreement(
     !quoteAgreement.timeframe ||
     !quoteAgreement.attesterSignature
   ) {
-    throw new SDKErrors.ERROR_COMPRESS_OBJECT(quoteAgreement, 'Quote Agreement')
+    throw new SDKErrors.CompressObjectError(quoteAgreement, 'Quote Agreement')
   }
   return [
     quoteAgreement.attesterDid,
@@ -416,7 +416,7 @@ export function compressQuoteAgreement(
  * Decompresses a [[Quote]] Agreement from storage and/or message.
  *
  * @param quoteAgreement A compressed [[Quote]] Agreement array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when quoteAgreement is not an Array and its length does not equal the defined length of 9.
+ * @throws [[DecompressionArrayError]] when quoteAgreement is not an Array and its length does not equal the defined length of 9.
  *
  * @returns An object that has the same properties as a [[Quote]] Agreement.
  */
@@ -424,7 +424,7 @@ export function decompressQuoteAgreement(
   quoteAgreement: CompressedQuoteAgreed
 ): IQuoteAgreement {
   if (!Array.isArray(quoteAgreement) || quoteAgreement.length !== 9) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY()
+    throw new SDKErrors.DecompressionArrayError()
   }
   return {
     attesterDid: quoteAgreement[0],

--- a/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.spec.ts
@@ -121,7 +121,7 @@ describe('RequestForAttestation', () => {
     delete request.claimNonceMap[Object.keys(request.claimNonceMap)[0]]
     expect(() =>
       RequestForAttestation.verifyDataIntegrity(request)
-    ).toThrowError(SDKErrors.ERROR_NO_PROOF_FOR_STATEMENT)
+    ).toThrowError(SDKErrors.NoProofForStatementError)
   })
 
   it('throws on wrong hash in claim hash tree', async () => {
@@ -372,21 +372,21 @@ describe('RequestForAttestation', () => {
       RequestForAttestation.calculateRootHash(builtRequestMalformedHashes)
     expect(() =>
       RequestForAttestation.verifyDataStructure(builtRequestNoLegitimations)
-    ).toThrowError(SDKErrors.ERROR_LEGITIMATIONS_NOT_PROVIDED)
+    ).toThrowError(SDKErrors.LegitimationsMissingError)
     expect(() =>
       RequestForAttestation.verifyDataIntegrity(builtRequestMalformedRootHash)
-    ).toThrowError(SDKErrors.ERROR_ROOT_HASH_UNVERIFIABLE)
+    ).toThrowError(SDKErrors.RootHashUnverifiableError)
     expect(() =>
       RequestForAttestation.verifyDataIntegrity(
         builtRequestIncompleteClaimHashTree
       )
-    ).toThrowError(SDKErrors.ERROR_NO_PROOF_FOR_STATEMENT)
+    ).toThrowError(SDKErrors.NoProofForStatementError)
     expect(() =>
       RequestForAttestation.verifyDataStructure(builtRequestMalformedSignature)
-    ).toThrowError(SDKErrors.ERROR_SIGNATURE_DATA_TYPE)
+    ).toThrowError(SDKErrors.SignatureMalformedError)
     expect(() =>
       RequestForAttestation.verifyDataIntegrity(builtRequestMalformedHashes)
-    ).toThrowError(SDKErrors.ERROR_NO_PROOF_FOR_STATEMENT)
+    ).toThrowError(SDKErrors.NoProofForStatementError)
     expect(() =>
       RequestForAttestation.verifyDataStructure(builtRequest)
     ).not.toThrow()

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -88,7 +88,6 @@ export function calculateRootHash(
  *
  * @param req4Att - The RequestForAttestation object to remove properties from.
  * @param properties - Properties to remove from the [[Claim]] object.
- * @throws [[ClaimNonceMapMalformedError]] when a property which should be deleted wasn't found.
  */
 export function removeClaimProperties(
   req4Att: IRequestForAttestation,
@@ -189,8 +188,6 @@ export function verifyRootHash(input: IRequestForAttestation): boolean {
  *
  * @param input - The [[RequestForAttestation]] for which to verify data.
  * @returns Whether the data is valid.
- * @throws [[ClaimNonceMapMalformedError]] when any key of the claim contents could not be found in the claimHashTree.
- * @throws [[RootHashUnverifiableError]] when the rootHash is not verifiable.
  */
 export function verifyDataIntegrity(input: IRequestForAttestation): boolean {
   // check claim hash
@@ -218,9 +215,6 @@ export function verifyDataIntegrity(input: IRequestForAttestation): boolean {
  * Throws on invalid input.
  *
  * @param input - A potentially only partial [[IRequestForAttestation]].
- * @throws [[ClaimMissingError]], [[LegitimationsMissingError]], [[ClaimNonceMapMissingError]] or [[DelegationIdTypeError]] when either the input's claim, legitimations, claimHashTree or DelegationId are not provided or of the wrong type, respectively.
- * @throws [[ClaimNonceMapMalformedError]] when any of the input's claimHashTree's keys missing their hash.
- *
  */
 export function verifyDataStructure(input: IRequestForAttestation): void {
   if (!input.claim) {
@@ -289,7 +283,6 @@ export function verifyAgainstCType(
  * @param verificationOpts Additional options to retrieve the details from the identifiers inside the request for attestation.
  * @param verificationOpts.resolver - The resolver used to resolve the claimer's identity. Defaults to [[DidResolver]].
  * @param verificationOpts.challenge - The expected value of the challenge. Verification will fail in case of a mismatch.
- * @throws [[IdentityMismatchError]] if the DidDetails do not match the claim owner or if the light DID is used after it has been upgraded.
  * @returns Whether the signature is correct.
  */
 export async function verifySignature(
@@ -369,7 +362,6 @@ type VerifyOptions = {
  * @param options.ctype - Ctype which the included claim should be checked against.
  * @param options.challenge -  The expected value of the challenge. Verification will fail in case of a mismatch.
  * @param options.resolver - The resolver used to resolve the claimer's identity. Defaults to [[DidResolver]].
- * @throws - If a check fails.
  */
 export async function verify(
   requestForAttestation: IRequestForAttestation,
@@ -460,8 +452,6 @@ export function compress(
  * Decompresses a [[RequestForAttestation]] from storage and/or message.
  *
  * @param reqForAtt A compressed [[RequestForAttestation]] array that is reverted back into an object.
- * @throws [[DecompressionArrayError]] when reqForAtt is not an Array and its length is not equal to the defined length of 8.
- *
  * @returns An object that has the same properties as a [[RequestForAttestation]].
  */
 export function decompress(

--- a/packages/core/src/requestforattestation/RequestForAttestation.ts
+++ b/packages/core/src/requestforattestation/RequestForAttestation.ts
@@ -88,7 +88,7 @@ export function calculateRootHash(
  *
  * @param req4Att - The RequestForAttestation object to remove properties from.
  * @param properties - Properties to remove from the [[Claim]] object.
- * @throws [[ERROR_CLAIM_HASHTREE_MISMATCH]] when a property which should be deleted wasn't found.
+ * @throws [[ClaimNonceMapMalformedError]] when a property which should be deleted wasn't found.
  */
 export function removeClaimProperties(
   req4Att: IRequestForAttestation,
@@ -189,13 +189,13 @@ export function verifyRootHash(input: IRequestForAttestation): boolean {
  *
  * @param input - The [[RequestForAttestation]] for which to verify data.
  * @returns Whether the data is valid.
- * @throws [[ERROR_CLAIM_NONCE_MAP_MALFORMED]] when any key of the claim contents could not be found in the claimHashTree.
- * @throws [[ERROR_ROOT_HASH_UNVERIFIABLE]] when the rootHash is not verifiable.
+ * @throws [[ClaimNonceMapMalformedError]] when any key of the claim contents could not be found in the claimHashTree.
+ * @throws [[RootHashUnverifiableError]] when the rootHash is not verifiable.
  */
 export function verifyDataIntegrity(input: IRequestForAttestation): boolean {
   // check claim hash
   if (!verifyRootHash(input)) {
-    throw new SDKErrors.ERROR_ROOT_HASH_UNVERIFIABLE()
+    throw new SDKErrors.RootHashUnverifiableError()
   }
 
   // verify properties against selective disclosure proof
@@ -205,9 +205,7 @@ export function verifyDataIntegrity(input: IRequestForAttestation): boolean {
   })
   // TODO: how do we want to deal with multiple errors during claim verification?
   if (!verificationResult.verified)
-    throw (
-      verificationResult.errors[0] || new SDKErrors.ERROR_CLAIM_UNVERIFIABLE()
-    )
+    throw verificationResult.errors[0] || new SDKErrors.ClaimUnverifiableError()
 
   // check legitimations
   Credential.validateLegitimations(input.legitimations)
@@ -220,25 +218,25 @@ export function verifyDataIntegrity(input: IRequestForAttestation): boolean {
  * Throws on invalid input.
  *
  * @param input - A potentially only partial [[IRequestForAttestation]].
- * @throws [[ERROR_CLAIM_NOT_PROVIDED]], [[ERROR_LEGITIMATIONS_NOT_PROVIDED]], [[ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED]] or [[ERROR_DELEGATION_ID_TYPE]] when either the input's claim, legitimations, claimHashTree or DelegationId are not provided or of the wrong type, respectively.
- * @throws [[ERROR_CLAIM_NONCE_MAP_MALFORMED]] when any of the input's claimHashTree's keys missing their hash.
+ * @throws [[ClaimMissingError]], [[LegitimationsMissingError]], [[ClaimNonceMapMissingError]] or [[DelegationIdTypeError]] when either the input's claim, legitimations, claimHashTree or DelegationId are not provided or of the wrong type, respectively.
+ * @throws [[ClaimNonceMapMalformedError]] when any of the input's claimHashTree's keys missing their hash.
  *
  */
 export function verifyDataStructure(input: IRequestForAttestation): void {
   if (!input.claim) {
-    throw new SDKErrors.ERROR_CLAIM_NOT_PROVIDED()
+    throw new SDKErrors.ClaimMissingError()
   } else {
     Claim.verifyDataStructure(input.claim)
   }
   if (!input.claim.owner) {
-    throw new SDKErrors.ERROR_OWNER_NOT_PROVIDED()
+    throw new SDKErrors.OwnerMissingError()
   }
   if (!input.legitimations && !Array.isArray(input.legitimations)) {
-    throw new SDKErrors.ERROR_LEGITIMATIONS_NOT_PROVIDED()
+    throw new SDKErrors.LegitimationsMissingError()
   }
 
   if (!input.claimNonceMap) {
-    throw new SDKErrors.ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED()
+    throw new SDKErrors.ClaimNonceMapMissingError()
   }
   if (
     typeof input.claimNonceMap !== 'object' ||
@@ -250,10 +248,10 @@ export function verifyDataStructure(input: IRequestForAttestation): void {
         !nonce
     )
   ) {
-    throw new SDKErrors.ERROR_CLAIM_NONCE_MAP_MALFORMED()
+    throw new SDKErrors.ClaimNonceMapMalformedError()
   }
   if (typeof input.delegationId !== 'string' && !input.delegationId === null) {
-    throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
+    throw new SDKErrors.DelegationIdTypeError()
   }
   if (input.claimerSignature) isDidSignature(input.claimerSignature)
 }
@@ -291,7 +289,7 @@ export function verifyAgainstCType(
  * @param verificationOpts Additional options to retrieve the details from the identifiers inside the request for attestation.
  * @param verificationOpts.resolver - The resolver used to resolve the claimer's identity. Defaults to [[DidResolver]].
  * @param verificationOpts.challenge - The expected value of the challenge. Verification will fail in case of a mismatch.
- * @throws [[ERROR_IDENTITY_MISMATCH]] if the DidDetails do not match the claim owner or if the light DID is used after it has been upgraded.
+ * @throws [[IdentityMismatchError]] if the DidDetails do not match the claim owner or if the light DID is used after it has been upgraded.
  * @returns Whether the signature is correct.
  */
 export async function verifySignature(
@@ -382,7 +380,7 @@ export async function verify(
 
   if (ctype) {
     const isSchemaValid = verifyAgainstCType(requestForAttestation, ctype)
-    if (!isSchemaValid) throw new SDKErrors.ERROR_CREDENTIAL_UNVERIFIABLE()
+    if (!isSchemaValid) throw new SDKErrors.CredentialUnverifiableError()
   }
 
   if (challenge) {
@@ -390,7 +388,7 @@ export async function verify(
       challenge,
       resolver,
     })
-    if (!isSignatureCorrect) throw new SDKErrors.ERROR_SIGNATURE_UNVERIFIABLE()
+    if (!isSignatureCorrect) throw new SDKErrors.SignatureUnverifiableError()
   }
 }
 
@@ -462,7 +460,7 @@ export function compress(
  * Decompresses a [[RequestForAttestation]] from storage and/or message.
  *
  * @param reqForAtt A compressed [[RequestForAttestation]] array that is reverted back into an object.
- * @throws [[ERROR_DECOMPRESSION_ARRAY]] when reqForAtt is not an Array and its length is not equal to the defined length of 8.
+ * @throws [[DecompressionArrayError]] when reqForAtt is not an Array and its length is not equal to the defined length of 8.
  *
  * @returns An object that has the same properties as a [[RequestForAttestation]].
  */
@@ -470,7 +468,7 @@ export function decompress(
   reqForAtt: CompressedRequestForAttestation
 ): IRequestForAttestation {
   if (!Array.isArray(reqForAtt) || reqForAtt.length !== 7) {
-    throw new SDKErrors.ERROR_DECOMPRESSION_ARRAY('Request for Attestation')
+    throw new SDKErrors.DecompressionArrayError('Request for Attestation')
   }
   const decompressedRequestForAttestation = {
     claim: Claim.decompress(reqForAtt[0]),

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -200,8 +200,8 @@ function decodeDidPublicKeyDetails(
   const key = keyDetails.key.value
   const keyType = chainTypeToDidKeyType[key.type]
   if (!keyType) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `Unsupported key type "${key.type}" found on chain.`
+    throw new SDKErrors.DidError(
+      `Unsupported key type "${key.type}" found on chain`
     )
   }
   return {
@@ -465,8 +465,8 @@ export async function generateCreateTxFromCreationDetails(
   ).toNumber()
 
   if (keyAgreementKeys.length > maxKeyAgreementKeys) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `The number of key agreement keys in the creation operation is greater than the maximum allowed, which is ${maxKeyAgreementKeys}.`
+    throw new SDKErrors.DidError(
+      `The number of key agreement keys in the creation operation is greater than the maximum allowed, which is ${maxKeyAgreementKeys}`
     )
   }
 
@@ -486,8 +486,8 @@ export async function generateCreateTxFromCreationDetails(
   ).toNumber()
 
   if (serviceEndpoints.length > maxNumberOfServicesPerDid) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `Cannot store more than ${maxNumberOfServicesPerDid} service endpoints per DID.`
+    throw new SDKErrors.DidError(
+      `Cannot store more than ${maxNumberOfServicesPerDid} service endpoints per DID`
     )
   }
 
@@ -543,8 +543,8 @@ export async function generateCreateTxFromDidDetails(
 ): Promise<SubmittableExtrinsic> {
   const { authenticationKey } = did
   if (!authenticationKey) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `The provided DID does not have an authentication key to sign the creation operation.`
+    throw new SDKErrors.DidError(
+      `The provided DID does not have an authentication key to sign the creation operation`
     )
   }
 
@@ -607,8 +607,8 @@ export async function getSetKeyExtrinsic(
     case 'assertionMethod':
       return api.tx.did.setAttestationKey(keyAsEnum)
     default:
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `setting a key is only allowed for the following key types: ${[
+      throw new SDKErrors.DidError(
+        `Setting a key is only allowed for the following key types: ${[
           'authentication',
           'capabilityDelegation',
           'assertionMethod',
@@ -636,14 +636,14 @@ export async function getRemoveKeyExtrinsic(
       return api.tx.did.removeAttestationKey()
     case 'keyAgreement':
       if (!keyId) {
-        throw new SDKErrors.ERROR_DID_ERROR(
-          `When removing a ${'keyAgreement'} key it is required to specify the id of the key to be removed.`
+        throw new SDKErrors.DidError(
+          'When removing a keyAgreement key it is required to specify the id of the key to be removed'
         )
       }
       return api.tx.did.removeKeyAgreementKey(keyId)
     default:
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `key removal is only allowed for the following key types: ${[
+      throw new SDKErrors.DidError(
+        `Key removal is only allowed for the following key types: ${[
           'keyAgreement',
           'capabilityDelegation',
           'assertionMethod',
@@ -668,8 +668,8 @@ export async function getAddKeyExtrinsic(
   if (keyRelationship === 'keyAgreement') {
     return api.tx.did.addKeyAgreementKey(keyAsEnum)
   }
-  throw new SDKErrors.ERROR_DID_ERROR(
-    `adding to the key set is only allowed for the following key types:  ${[
+  throw new SDKErrors.DidError(
+    `Adding to the key set is only allowed for the following key types: ${[
       'keyAgreement',
     ]}`
   )
@@ -712,7 +712,7 @@ export async function getRemoveEndpointExtrinsic(
     api.consts.did.maxServiceIdLength as u32
   ).toNumber()
   if (endpointId.length > maxServiceIdLength) {
-    throw new SDKErrors.ERROR_DID_ERROR(
+    throw new SDKErrors.DidError(
       `The service ID "${endpointId}" has is too long. Max number of characters allowed for a service ID is ${maxServiceIdLength}.`
     )
   }
@@ -816,7 +816,7 @@ export function encodeDidSignature(
   signature: Pick<DidSignature, 'signature'>
 ): SignatureEnum {
   if (!verificationKeyTypes.some((kt) => kt === key.type)) {
-    throw new SDKErrors.ERROR_DID_ERROR(
+    throw new SDKErrors.DidError(
       `encodedDidSignature requires a verification key. A key of type "${key.type}" was used instead.`
     )
   }

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -356,7 +356,7 @@ describe('type guard', () => {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     signature = {
       // @ts-expect-error
@@ -364,7 +364,7 @@ describe('type guard', () => {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     signature = {
       // @ts-expect-error
@@ -372,7 +372,7 @@ describe('type guard', () => {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     signature = {
       // @ts-expect-error
@@ -380,7 +380,7 @@ describe('type guard', () => {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     signature = {
       // @ts-expect-error
@@ -388,7 +388,7 @@ describe('type guard', () => {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
   })
 
@@ -398,16 +398,16 @@ describe('type guard', () => {
       signature: '',
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     signature.signature = randomAsHex(32).substring(2)
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     // @ts-expect-error
     signature.signature = randomAsU8a(32)
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
   })
 
@@ -418,7 +418,7 @@ describe('type guard', () => {
       signature: undefined,
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     signature = {
       // @ts-expect-error
@@ -426,31 +426,31 @@ describe('type guard', () => {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     // @ts-expect-error
     signature = {
       signature: randomAsHex(32),
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     // @ts-expect-error
     signature = {
       keyUri: `did:kilt:${keypair.address}#mykey`,
     }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     // @ts-expect-error
     signature = {}
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     // @ts-expect-error
     signature = { keyUri: null, signature: null }
     expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
   })
 })

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -172,8 +172,10 @@ export function isDidSignature(input: unknown): input is DidSignature {
       throw new SDKErrors.SignatureMalformedError()
     }
     return true
-  } catch {
+  } catch (cause) {
     // TODO: type guards shouldn't throw
-    throw new SDKErrors.SignatureMalformedError()
+    throw new SDKErrors.SignatureMalformedError(undefined, {
+      cause: cause as Error,
+    })
   }
 }

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -160,7 +160,6 @@ export async function verifyDidSignature({
  *
  * @param input Arbitrary input.
  * @returns True if validation of form has passed.
- * @throws [[SDKError]] if validation fails.
  */
 export function isDidSignature(input: unknown): input is DidSignature {
   const signature = input as DidSignature

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -45,7 +45,7 @@ function verifyDidSignatureFromDetails({
   if (!key) {
     return {
       verified: false,
-      reason: `No key with ID ${keyId} for the DID ${details.uri}`,
+      reason: `No key with ID "${keyId}" for the DID ${details.uri}`,
     }
   }
   // Check whether the provided key ID is within the keys for a given verification relationship, if provided.
@@ -58,7 +58,7 @@ function verifyDidSignatureFromDetails({
   ) {
     return {
       verified: false,
-      reason: `No key with ID ${keyId} for the verification method ${expectedVerificationMethod}`,
+      reason: `No key with ID "${keyId}" for the verification method "${expectedVerificationMethod}"`,
     }
   }
   const isSignatureValid = Crypto.verify(
@@ -112,7 +112,7 @@ export async function verifyDidSignature({
   } catch {
     return {
       verified: false,
-      reason: `Signature key ID ${signature.keyUri} invalid.`,
+      reason: `Signature key ID "${signature.keyUri}" invalid`,
     }
   }
   const resolutionDetails = await resolver.resolveDoc(signature.keyUri)
@@ -120,21 +120,21 @@ export async function verifyDidSignature({
   if (!resolutionDetails) {
     return {
       verified: false,
-      reason: `No result for provided key ID ${signature.keyUri}`,
+      reason: `No result for provided key ID "${signature.keyUri}"`,
     }
   }
   // Verification also fails if the DID has been deleted.
   if (resolutionDetails.metadata.deactivated) {
     return {
       verified: false,
-      reason: 'DID for provided key is deactivated.',
+      reason: 'DID for provided key is deactivated',
     }
   }
   // Verification also fails if the signer is a migrated light DID.
   if (resolutionDetails.metadata.canonicalId) {
     return {
       verified: false,
-      reason: 'DID for provided key has been migrated and not usable anymore.',
+      reason: 'DID for provided key has been migrated and not usable anymore',
     }
   }
   // Otherwise, the details used are either the migrated full DID details or the light DID details.
@@ -169,11 +169,11 @@ export function isDidSignature(input: unknown): input is DidSignature {
       !isHex(signature.signature) ||
       !validateKiltDidUri(signature.keyUri, true)
     ) {
-      throw new SDKErrors.ERROR_SIGNATURE_DATA_TYPE()
+      throw new SDKErrors.SignatureMalformedError()
     }
     return true
-  } catch (e) {
+  } catch {
     // TODO: type guards shouldn't throw
-    throw new SDKErrors.ERROR_SIGNATURE_DATA_TYPE()
+    throw new SDKErrors.SignatureMalformedError()
   }
 }

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -261,7 +261,6 @@ export function isEncryptionKey(key: NewDidKey | DidKey): boolean {
  * @param input Arbitrary input.
  * @param allowFragment Whether the uri is allowed to have a fragment (following '#').
  * @returns True if validation has passed.
- * @throws [[SDKError]] if validation fails.
  */
 export function validateKiltDidUri(
   input: unknown,

--- a/packages/did/src/DidBatcher/DidBatchBuilder.ts
+++ b/packages/did/src/DidBatcher/DidBatchBuilder.ts
@@ -162,8 +162,8 @@ export class DidBatchBuilder {
     const batchesLength = this.batches.length
 
     if (!batchesLength) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Cannot build a batch with no transactions.'
+      throw new SDKErrors.DidBuilderError(
+        'Cannot build a batch with no transactions'
       )
     }
 

--- a/packages/did/src/DidBatcher/DidBatchBuilder.utils.ts
+++ b/packages/did/src/DidBatcher/DidBatchBuilder.utils.ts
@@ -24,21 +24,21 @@ export function checkExtrinsicInput(
   const { section, method } = ext.method
   // Cannot batch DID extrinsics
   if (section === 'did') {
-    throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-      'DidBatchBuilder.addExtrinsic() cannot be used to queue DID extrinsics. Please use FullDidBuilder and its subclasses for those.'
+    throw new SDKErrors.DidBuilderError(
+      'DidBatchBuilder.addExtrinsic() cannot be used to queue DID extrinsics. Please use FullDidBuilder and its subclasses for those'
     )
   }
 
   const extrinsicKeyRelationship = getKeyRelationshipForExtrinsic(ext)
   if (extrinsicKeyRelationship === 'paymentAccount') {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      'DidBatchBuilder.addExtrinsic() cannot be used to queue extrinsics that do not require a DID signature.'
+    throw new SDKErrors.DidError(
+      'DidBatchBuilder.addExtrinsic() cannot be used to queue extrinsics that do not require a DID signature'
     )
   }
 
   if (did.getVerificationKeys(extrinsicKeyRelationship).length === 0) {
-    throw new SDKErrors.ERROR_DID_ERROR(
-      `DidBatchBuilder.addExtrinsic() cannot be used with the provided extrinsic "${section}:${method}" because the DID ${did.uri} does not have a valid key to sign the operation.`
+    throw new SDKErrors.DidError(
+      `DidBatchBuilder.addExtrinsic() cannot be used with the provided extrinsic "${section}:${method}" because the DID "${did.uri}" does not have a valid key to sign the operation`
     )
   }
 

--- a/packages/did/src/DidBatcher/FullDidBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidBuilder.ts
@@ -59,8 +59,8 @@ export abstract class FullDidBuilder {
 
   protected checkBuilderConsumption(): void {
     if (this.consumed) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'DID builder has already been consumed.'
+      throw new SDKErrors.DidBuilderError(
+        'DID builder has already been consumed'
       )
     }
   }
@@ -84,8 +84,8 @@ export abstract class FullDidBuilder {
     const newKeyId = deriveChainKeyId(this.apiObject, key)
     // Check if a key with the same ID has already been added.
     if (this.newKeyAgreementKeys.has(newKeyId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Key agreement key with ID ${newKeyId} has already been marked for addition. Failing since this may lead to unexpected behaviour.`
+      throw new SDKErrors.DidBuilderError(
+        `Key agreement key with ID "${newKeyId}" has already been marked for addition. Failing since this may lead to unexpected behaviour.`
       )
     }
     // Otherwise we can safely mark the key for addition.
@@ -110,8 +110,8 @@ export abstract class FullDidBuilder {
     this.checkBuilderConsumption()
     // Check if another attestation key was already marked for addition.
     if (this.newAssertionKey.action === 'update') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Another assertion key was already been marked for addition. Failing since this may lead to unexpected behaviour.'
+      throw new SDKErrors.DidBuilderError(
+        'Another assertion key was already been marked for addition. Failing since this may lead to unexpected behaviour'
       )
     }
     this.newAssertionKey = {
@@ -135,8 +135,8 @@ export abstract class FullDidBuilder {
     this.checkBuilderConsumption()
     // Check if another delegation key was already marked for addition.
     if (this.newDelegationKey.action === 'update') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Another delegation key was already been marked for addition. Failing since this may lead to unexpected behaviour.'
+      throw new SDKErrors.DidBuilderError(
+        'Another delegation key was already been marked for addition. Failing since this may lead to unexpected behaviour'
       )
     }
     this.newDelegationKey = {
@@ -161,8 +161,8 @@ export abstract class FullDidBuilder {
     const { id, ...details } = service
     // Check if the service has already been added.
     if (this.newServiceEndpoints.has(id)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Service endpoint with ID ${id} has already been marked for addition. Failing since this may lead to unexpected behaviour.`
+      throw new SDKErrors.DidBuilderError(
+        `Service endpoint with ID "${id}" has already been marked for addition. Failing since this may lead to unexpected behaviour.`
       )
     }
     // Check syntax & size constraints
@@ -173,10 +173,10 @@ export abstract class FullDidBuilder {
     )
     if (!(syntaxOk && sizeOk)) {
       const errors = [...(syntaxErrors || []), ...(sizeErrors || [])]
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Service endpoint with ID ${
+      throw new SDKErrors.DidBuilderError(
+        `Service endpoint with ID "${
           service.id
-        } violates size and/or content constraints:${errors.reduce(
+        }" violates size and/or content constraints: ${errors.reduce(
           (str, e, i) => `${str}\n  ${i + 1}. ${e.message}`,
           ''
         )}`

--- a/packages/did/src/DidBatcher/FullDidBuilder.utils.ts
+++ b/packages/did/src/DidBatcher/FullDidBuilder.utils.ts
@@ -11,7 +11,7 @@
 import { ApiPromise } from '@polkadot/api'
 
 import type { DidKey, NewDidKey } from '@kiltprotocol/types'
-import { Crypto } from '@kiltprotocol/utils'
+import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 
 import { ChainDidPublicKey, formatPublicKey } from '../Did.chain.js'
 import { isEncryptionKey, isVerificationKey } from '../Did.utils.js'
@@ -27,7 +27,7 @@ function encodeToChainKey(api: ApiPromise, key: NewDidKey): ChainDidPublicKey {
   } else if (isEncryptionKey(key)) {
     keyClass = 'PublicEncryptionKey'
   } else {
-    throw TypeError('Unsupported key type.')
+    throw new SDKErrors.DidBuilderError('Unsupported key type')
   }
   return new (api.registry.getOrThrow<ChainDidPublicKey>(
     'DidDidDetailsDidPublicKey'

--- a/packages/did/src/DidBatcher/FullDidCreationBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidCreationBuilder.ts
@@ -39,9 +39,7 @@ function encodeVerificationKeyToAddress({
       return encodeAddress(pk, ss58Format)
     }
     default:
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Unsupported key type ${type}.`
-      )
+      throw new SDKErrors.DidBuilderError(`Unsupported key type "${type}"`)
   }
 }
 
@@ -109,6 +107,7 @@ export class FullDidCreationBuilder extends FullDidBuilder {
    *
    * @returns The [[FullDidDetails]] as returned by the provided callback.
    */
+
   /* istanbul ignore next */
   public async buildAndSubmit(
     sign: SignCallback,
@@ -125,8 +124,8 @@ export class FullDidCreationBuilder extends FullDidBuilder {
       getKiltDidFromIdentifier(encodedAddress, 'full')
     )
     if (!fetchedDidDetails) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Something went wrong during the creation.'
+      throw new SDKErrors.DidBuilderError(
+        'Something went wrong during the creation'
       )
     }
     return fetchedDidDetails

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.spec.ts
@@ -448,11 +448,11 @@ describe('FullDidUpdateBuilder', () => {
 
         expect(() => builder.addServiceEndpoint(newInvalidServiceEndpoint))
           .toThrowErrorMatchingInlineSnapshot(`
-          "Service endpoint with ID id-new violates size and/or content constraints:
-            1. A service URL must be a URI according to RFC#3986, which 'type-new' (service id 'id-new') is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.
-            2. The service with ID 'id-new' has too many types (2). Max number of types allowed per service is 1.
-            3. The service with ID 'id-new' has too many URLs (2). Max number of URLs allowed per service is 1.
-            4. The service with ID 'id-new' has the type 'Ξέρω-ότι-η-θάλασσα-είναι-μπλε' that is too long (53 bytes). Max number of bytes allowed for a service type is 50."
+          "Service endpoint with ID \\"id-new\\" violates size and/or content constraints: 
+            1. A service URL must be a URI according to RFC#3986, which \\"type-new\\" (service id \\"id-new\\") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.
+            2. The service with ID \\"id-new\\" has too many types (2). Max number of types allowed per service is 1.
+            3. The service with ID \\"id-new\\" has too many URLs (2). Max number of URLs allowed per service is 1.
+            4. The service with ID \\"id-new\\" has the type \\"Ξέρω-ότι-η-θάλασσα-είναι-μπλε\\" that is too long (53 bytes). Max number of bytes allowed for a service type is 50."
         `)
       })
 

--- a/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
+++ b/packages/did/src/DidBatcher/FullDidUpdateBuilder.ts
@@ -127,8 +127,8 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     this.checkBuilderConsumption()
     // Check that no other authentication key has already been set.
     if (this.newAuthenticationKey) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'A new authentication key has already been marked for addition.'
+      throw new SDKErrors.DidBuilderError(
+        'A new authentication key has already been marked for addition'
       )
     }
 
@@ -158,14 +158,14 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     const newKeyId = deriveChainKeyId(this.apiObject, key)
     // 1. Check if the key is already present in the DID.
     if (this.oldKeyAgreementKeys.has(newKeyId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Key agreement key with ID ${newKeyId} already present under the full DID.`
+      throw new SDKErrors.DidBuilderError(
+        `Key agreement key with ID "${newKeyId}" already present under the full DID`
       )
     }
     // 2. Check if the key has already been marked for deletion.
     if (this.keyAgreementKeysToDelete.has(newKeyId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Key agreement key with ID ${newKeyId} has already been marked for deletion and cannot be re-added in the same operation.`
+      throw new SDKErrors.DidBuilderError(
+        `Key agreement key with ID "${newKeyId}" has already been marked for deletion and cannot be re-added in the same operation`
       )
     }
     const extrinsic = this.apiObject.tx.did.addKeyAgreementKey(
@@ -194,20 +194,20 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     this.checkBuilderConsumption()
     // 1. Check that the key exists in the DID.
     if (!this.oldKeyAgreementKeys.has(keyId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Key agreement key with ID ${keyId} not present under the full DID.`
+      throw new SDKErrors.DidBuilderError(
+        `Key agreement key with ID "${keyId}" not present under the full DID`
       )
     }
     // 2. Check if the key has already been marked for addition.
     if (this.newKeyAgreementKeys.has(keyId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Key agreement key with ID ${keyId} has already been marked for addition and cannot be deleted in the same operation.`
+      throw new SDKErrors.DidBuilderError(
+        `Key agreement key with ID "${keyId}" has already been marked for addition and cannot be deleted in the same operation`
       )
     }
     // 3. Check if the key has already been marked for deletion.
     if (this.keyAgreementKeysToDelete.has(keyId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Key agreement key with ID ${keyId} has already been marked for deletion. Failing since this may lead to unexpected behaviour.`
+      throw new SDKErrors.DidBuilderError(
+        `Key agreement key with ID "${keyId}" has already been marked for deletion. Failing since this may lead to unexpected behaviour.`
       )
     }
     const extrinsic = this.apiObject.tx.did.removeKeyAgreementKey(keyId)
@@ -249,8 +249,8 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
   public setAttestationKey(key: NewDidVerificationKey): this {
     // Check that the attestation key has not already been marked for deletion.
     if (this.newAssertionKey.action === 'delete') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'The assertion key has already been marked for deletion.'
+      throw new SDKErrors.DidBuilderError(
+        'The assertion key has already been marked for deletion'
       )
     }
     const extrinsic = this.apiObject.tx.did.setAttestationKey(
@@ -278,20 +278,20 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     this.checkBuilderConsumption()
     // 1. Check that the DID has an attestation key.
     if (!this.oldAssertionKey) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'The DID does not have an attestation key to remove.'
+      throw new SDKErrors.DidBuilderError(
+        'The DID does not have an attestation key to remove'
       )
     }
     // 2. Check if another attestation key was already marked for addition.
     if (this.newAssertionKey.action === 'update') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'A new assertion key has already been marked for addition.'
+      throw new SDKErrors.DidBuilderError(
+        'A new assertion key has already been marked for addition'
       )
     }
     // 3. Check that the old key has not already been marked for deletion.
     if (this.newAssertionKey.action === 'delete') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Another assertion key was already been marked for deletion. Failing since this may lead to unexpected behaviour.'
+      throw new SDKErrors.DidBuilderError(
+        'Another assertion key was already been marked for deletion. Failing since this may lead to unexpected behaviour'
       )
     }
 
@@ -317,8 +317,8 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
   public setDelegationKey(key: NewDidVerificationKey): this {
     // Check that the delegation key has not already been marked for deletion.
     if (this.newDelegationKey.action === 'delete') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'The delegation key has already been marked for deletion.'
+      throw new SDKErrors.DidBuilderError(
+        'The delegation key has already been marked for deletion'
       )
     }
     const extrinsic = this.apiObject.tx.did.setDelegationKey(
@@ -346,18 +346,20 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     this.checkBuilderConsumption()
     // 1. Check that the DID has a delegation key.
     if (!this.oldDelegationKey) {
-      throw new Error('The DID does not have a delegation key to remove.')
+      throw new SDKErrors.DidBuilderError(
+        'The DID does not have a delegation key to remove'
+      )
     }
     // 2. Check that a new key has not already been marked for addition.
     if (this.newDelegationKey.action === 'update') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'A new delegation key has already been marked for addition.'
+      throw new SDKErrors.DidBuilderError(
+        'A new delegation key has already been marked for addition'
       )
     }
     // 3. Check that the old key has not already been marked for deletion.
     if (this.newDelegationKey.action === 'delete') {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Another delegation key was already been marked for deletion. Failing since this may lead to unexpected behaviour.'
+      throw new SDKErrors.DidBuilderError(
+        'Another delegation key was already been marked for deletion. Failing since this may lead to unexpected behaviour'
       )
     }
     const extrinsic = this.apiObject.tx.did.removeDelegationKey()
@@ -383,8 +385,8 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
   public addServiceEndpoint(service: DidServiceEndpoint): this {
     // Check if the service is already present in the DID.
     if (this.oldServiceEndpoints.has(service.id)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Service endpoint with ID ${service.id} already present under the DID.`
+      throw new SDKErrors.DidBuilderError(
+        `Service endpoint with ID "${service.id}" already present under the DID`
       )
     }
 
@@ -415,14 +417,14 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     this.checkBuilderConsumption()
     // 1. Check that the service exists in the DID.
     if (!this.oldServiceEndpoints.has(serviceId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Service endpoint with ID ${serviceId} not present under the full DID.`
+      throw new SDKErrors.DidBuilderError(
+        `Service endpoint with ID "${serviceId}" not present under the full DID`
       )
     }
     // 2. Check if the service has already been marked for deletion.
     if (this.serviceEndpointsToDelete.has(serviceId)) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        `Service endpoint with ID ${serviceId} has already been marked for deletion. Failing since this may lead to unexpected behaviour.`
+      throw new SDKErrors.DidBuilderError(
+        `Service endpoint with ID "${serviceId}" has already been marked for deletion. Failing since this may lead to unexpected behaviour.`
       )
     }
     const extrinsic = this.apiObject.tx.did.removeServiceEndpoint(serviceId)
@@ -460,6 +462,7 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
    *
    * @returns The [[FullDidDetails]] as returned by the provided callback.
    */
+
   /* istanbul ignore next */
   public async buildAndSubmit(
     sign: SignCallback,
@@ -471,8 +474,8 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
     await callback(extrinsic)
     const fetchedDidDetails = await FullDidDetails.fromChainInfo(this.uri)
     if (!fetchedDidDetails) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Something went wrong during the creation.'
+      throw new SDKErrors.DidBuilderError(
+        'Something went wrong during the creation'
       )
     }
     return fetchedDidDetails
@@ -501,8 +504,8 @@ export class FullDidUpdateBuilder extends FullDidBuilder {
       : this.apiObject.tx.utility.batch
 
     if (!this.batch.length) {
-      throw new SDKErrors.ERROR_DID_BUILDER_ERROR(
-        'Builder was empty, hence it cannot be consumed.'
+      throw new SDKErrors.DidBuilderError(
+        'Builder was empty, hence it cannot be consumed'
       )
     }
 

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -80,8 +80,8 @@ export abstract class DidDetails implements IDidDetails {
   public get authenticationKey(): DidVerificationKey {
     const firstAuthenticationKey = this.getVerificationKeys('authentication')[0]
     if (!firstAuthenticationKey) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        'Unexpected error. Any DID should always have at least one authentication key.'
+      throw new SDKErrors.DidError(
+        'Unexpected error. Any DID should always have at least one authentication key'
       )
     }
     return firstAuthenticationKey
@@ -229,16 +229,16 @@ export abstract class DidDetails implements IDidDetails {
   ): Promise<DidSignature> {
     const key = this.getKey(keyId)
     if (!key || !isVerificationKey(key)) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Failed to find verification key with ID ${keyId} on DID (${this.uri})`
+      throw new SDKErrors.DidError(
+        `Failed to find verification key with ID "${keyId}" on DID "${this.uri}"`
       )
     }
     const alg = getSigningAlgorithmForVerificationKeyType(
       key.type as VerificationKeyType
     )
     if (!alg) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `No algorithm found for key type ${key.type}`
+      throw new SDKErrors.DidError(
+        `No algorithm found for key type "${key.type}"`
       )
     }
     const { data: signature } = await sign({

--- a/packages/did/src/DidDetails/DidDetails.utils.ts
+++ b/packages/did/src/DidDetails/DidDetails.utils.ts
@@ -21,15 +21,15 @@ export function checkDidCreationDetails({
 }: DidConstructorDetails): void {
   validateKiltDidUri(uri, false)
   if (keyRelationships.authentication?.size !== 1) {
-    throw Error(
-      `One and only one ${'authentication'} key is required on any instance of DidDetails`
+    throw new SDKErrors.DidError(
+      'One and only one authentication key is required on any instance of DidDetails'
     )
   }
   const allowedKeyRelationships = new Set([...allKeyRelationships, 'none'])
   Object.keys(keyRelationships).forEach((keyRel) => {
     if (!allowedKeyRelationships.has(keyRel)) {
-      throw Error(
-        `key relationship ${keyRel} is not recognized. Allowed: ${allKeyRelationships}`
+      throw new SDKErrors.DidError(
+        `Key relationship "${keyRel}" is not recognized. Allowed: ${allKeyRelationships}`
       )
     }
   })
@@ -41,6 +41,6 @@ export function checkDidCreationDetails({
 
   allIds.forEach((id) => {
     if (!providedIds.has(id))
-      throw new SDKErrors.ERROR_DID_ERROR(`No key with id ${id} in "keys"`)
+      throw new SDKErrors.DidError(`No key with id "${id}" in "keys"`)
   })
 }

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -82,13 +82,13 @@ export class FullDidDetails extends DidDetails {
   ): Promise<FullDidDetails | null> {
     const { identifier, fragment, type } = parseDidUri(didUri)
     if (fragment) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `DID URI cannot contain fragment: ${didUri}`
+      throw new SDKErrors.DidError(
+        `DID URI cannot contain fragment: "${didUri}"`
       )
     }
     if (type !== 'full') {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `DID URI does not refer to a full DID: ${didUri}`
+      throw new SDKErrors.DidError(
+        `DID URI "${didUri}" does not refer to a full DID`
       )
     }
     const didRec = await queryDetails(identifier)
@@ -186,8 +186,8 @@ export class FullDidDetails extends DidDetails {
   ): Promise<SubmittableExtrinsic> {
     const signingKey = await keySelection(this.getKeysForExtrinsic(extrinsic))
     if (!signingKey) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `The details for did ${this.uri} do not contain the required keys for this operation`
+      throw new SDKErrors.DidError(
+        `The details for DID "${this.uri}" do not contain the required keys for this operation`
       )
     }
     return generateDidAuthenticatedTx({

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -160,21 +160,21 @@ export class LightDidDetails extends DidDetails {
       parseDidUri(uri)
 
     if (type !== 'light') {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Cannot build a light DID from the provided URI ${uri} because it does not refer to a light DID.`
+      throw new SDKErrors.DidError(
+        `Cannot build a light DID from the provided URI "${uri}" because it does not refer to a light DID`
       )
     }
     if (fragment && failIfFragmentPresent) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Cannot build a light DID from the provided URI ${uri} because it has a fragment.`
+      throw new SDKErrors.DidError(
+        `Cannot build a light DID from the provided URI "${uri}" because it has a fragment`
       )
     }
     const authKeyTypeEncoding = identifier.substring(0, 2)
     const decodedAuthKeyType =
       getVerificationKeyTypeForEncoding(authKeyTypeEncoding)
     if (!decodedAuthKeyType) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Authentication key encoding "${authKeyTypeEncoding}" does not match any supported key type.`
+      throw new SDKErrors.DidError(
+        `Authentication key encoding "${authKeyTypeEncoding}" does not match any supported key type`
       )
     }
     const authenticationKey: NewLightDidAuthenticationKey = {
@@ -245,9 +245,7 @@ export class LightDidDetails extends DidDetails {
       getKiltDidFromIdentifier(this.identifier, 'full')
     )
     if (!fullDidDetails) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        'Something went wrong during the migration.'
-      )
+      throw new SDKErrors.DidError('Something went wrong during the migration')
     }
     return fullDidDetails
   }

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -87,13 +87,13 @@ export function checkLightDidCreationDetails(
     details.authenticationKey.type
   )
   if (!authenticationKeyTypeEncoding) {
-    throw SDKErrors.ERROR_UNSUPPORTED_KEY
+    throw new SDKErrors.UnsupportedKeyError(details.authenticationKey.type)
   }
 
   if (details.encryptionKey?.type) {
     if (!supportedEncryptionKeyTypes.has(details.encryptionKey.type)) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Encryption key type ${details.encryptionKey.type} is not supported.`
+      throw new SDKErrors.DidError(
+        `Encryption key type "${details.encryptionKey.type}" is not supported`
       )
     }
   }
@@ -109,8 +109,8 @@ export function checkLightDidCreationDetails(
   details.serviceEndpoints?.forEach((service) => {
     // A service ID cannot have a reserved ID that is used for key IDs.
     if (service.id === 'authentication' || service.id === 'encryption') {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Cannot specify a service ID with the name ${service.id} as it is a reserved keyword.`
+      throw new SDKErrors.DidError(
+        `Cannot specify a service ID with the name "${service.id}" as it is a reserved keyword`
       )
     }
     const [, errors] = checkServiceEndpointSyntax(service)
@@ -168,7 +168,7 @@ export function decodeAndDeserializeAdditionalLightDidDetails(
   const decoded = base58Decode(rawInput, true)
   const serializationFlag = decoded[0]
   if (serializationFlag !== 0x0) {
-    throw new SDKErrors.ERROR_DID_ERROR('Serialization algorithm not supported')
+    throw new SDKErrors.DidError('Serialization algorithm not supported')
   }
   const withoutFlag = decoded.slice(1)
   const deserialized: SerializableStructure = cborDecode(withoutFlag)

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
@@ -121,8 +121,8 @@ export function exportToDidDocument(
     case 'application/ld+json':
       return exportToJsonLdDidDocument(details)
     default:
-      throw new SDKErrors.ERROR_DID_EXPORTER_ERROR(
-        `${mimeType} not supported by any of the available exporters.`
+      throw new SDKErrors.DidExporterError(
+        `The MIME type "${mimeType}" not supported by any of the available exporters`
       )
   }
 }

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -6,7 +6,7 @@
  */
 
 import { BlockchainApiConnection } from '@kiltprotocol/chain-helpers'
-import { ss58Format } from '@kiltprotocol/utils'
+import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
 import {
   Deposit,
   DidIdentifier,
@@ -249,7 +249,9 @@ function getMultiSignatureTypeFromKeypairType(
     case 'ecdsa':
       return 'Ecdsa'
     default:
-      throw new Error(`Unsupported signature algorithm '${keypairType}'`)
+      throw new SDKErrors.DidError(
+        `Unsupported signature algorithm "${keypairType}"`
+      )
   }
 }
 

--- a/packages/did/src/DidLinks/Web3Names.chain.ts
+++ b/packages/did/src/DidLinks/Web3Names.chain.ts
@@ -45,13 +45,13 @@ function checkWeb3NameInputConstraints(
   ]
 
   if (web3Name.length < minLength) {
-    throw new SDKErrors.ERROR_WEB3_NAME_ERROR(
-      `The provided name "${web3Name}" is shorter than the minimum number of characters allowed, which is ${minLength}.`
+    throw new SDKErrors.Web3NameError(
+      `The provided name "${web3Name}" is shorter than the minimum number of characters allowed, which is ${minLength}`
     )
   }
   if (web3Name.length > maxLength) {
-    throw new SDKErrors.ERROR_WEB3_NAME_ERROR(
-      `The provided name "${web3Name}" is longer than the maximum number of characters allowed, which is ${maxLength}.`
+    throw new SDKErrors.Web3NameError(
+      `The provided name "${web3Name}" is longer than the maximum number of characters allowed, which is ${maxLength}`
     )
   }
 }

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -67,8 +67,10 @@ export async function resolveDoc(
       let details: LightDidDetails
       try {
         details = LightDidDetails.fromUri(did, false)
-      } catch {
-        throw new SDKErrors.InvalidDidFormatError(did)
+      } catch (cause) {
+        throw new SDKErrors.InvalidDidFormatError(did, {
+          cause: cause as Error,
+        })
       }
 
       const fullDidDetails = await queryDetails(details.identifier)

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -68,7 +68,7 @@ export async function resolveDoc(
       try {
         details = LightDidDetails.fromUri(did, false)
       } catch {
-        throw new SDKErrors.ERROR_INVALID_DID_FORMAT(did)
+        throw new SDKErrors.InvalidDidFormatError(did)
       }
 
       const fullDidDetails = await queryDetails(details.identifier)
@@ -103,7 +103,7 @@ export async function resolveDoc(
       }
     }
     default:
-      throw new SDKErrors.ERROR_UNSUPPORTED_DID(did)
+      throw new SDKErrors.UnsupportedDidError(did)
   }
 }
 
@@ -120,7 +120,7 @@ export async function resolveKey(
 
   // A fragment (keyId) IS expected to resolve a key.
   if (!keyId) {
-    throw new SDKErrors.ERROR_INVALID_DID_FORMAT(didUri)
+    throw new SDKErrors.InvalidDidFormatError(didUri)
   }
 
   switch (type) {
@@ -141,7 +141,7 @@ export async function resolveKey(
     case 'light': {
       const resolvedDetails = await resolveDoc(didUri)
       if (!resolvedDetails) {
-        throw new SDKErrors.ERROR_INVALID_DID_FORMAT(didUri)
+        throw new SDKErrors.InvalidDidFormatError(didUri)
       }
       const key = resolvedDetails.details?.getKey(keyId)
       if (!key) {
@@ -155,7 +155,7 @@ export async function resolveKey(
       }
     }
     default:
-      throw new SDKErrors.ERROR_UNSUPPORTED_DID(didUri)
+      throw new SDKErrors.UnsupportedDidError(didUri)
   }
 }
 
@@ -172,7 +172,7 @@ export async function resolveServiceEndpoint(
 
   // A fragment (serviceId) IS expected to resolve a service endpoint.
   if (!serviceId) {
-    throw new SDKErrors.ERROR_INVALID_DID_FORMAT(serviceUri)
+    throw new SDKErrors.InvalidDidFormatError(serviceUri)
   }
 
   switch (type) {
@@ -190,7 +190,7 @@ export async function resolveServiceEndpoint(
     case 'light': {
       const resolvedDetails = await resolveDoc(did)
       if (!resolvedDetails) {
-        throw new SDKErrors.ERROR_INVALID_DID_FORMAT(serviceUri)
+        throw new SDKErrors.InvalidDidFormatError(serviceUri)
       }
       const serviceEndpoint = resolvedDetails.details?.getEndpoint(serviceId)
       if (!serviceEndpoint) {
@@ -203,7 +203,7 @@ export async function resolveServiceEndpoint(
       }
     }
     default:
-      throw new SDKErrors.ERROR_UNSUPPORTED_DID(did)
+      throw new SDKErrors.UnsupportedDidError(did)
   }
 }
 

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -192,7 +192,7 @@ describe('Messaging', () => {
           resolver: mockResolver,
         }
       )
-    ).rejects.toThrowError(SDKErrors.ERROR_DECODING_MESSAGE)
+    ).rejects.toThrowError(SDKErrors.DecodingMessageError)
 
     const encryptedWrongBody = await aliceEncKey.encrypt({
       alg: 'x25519-xsalsa20-poly1305',
@@ -217,7 +217,7 @@ describe('Messaging', () => {
           resolver: mockResolver,
         }
       )
-    ).rejects.toThrowError(SDKErrors.ERROR_PARSING_MESSAGE)
+    ).rejects.toThrowError(SDKErrors.ParsingMessageError)
   })
 
   it('verifies the message with sender is the owner (as full DID)', async () => {
@@ -283,7 +283,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(requestAttestationBody, bobFullDid.uri, aliceFullDid.uri)
       )
-    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH)
+    ).toThrowError(SDKErrors.IdentityMismatchError)
 
     const attestation = {
       delegationId: null,
@@ -320,7 +320,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(submitAttestationBody, aliceFullDid.uri, bobFullDid.uri)
       )
-    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH)
+    ).toThrowError(SDKErrors.IdentityMismatchError)
 
     const credential: ICredential = {
       request: content,
@@ -352,7 +352,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(submitClaimsForCTypeBody, bobFullDid.uri, aliceFullDid.uri)
       )
-    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH)
+    ).toThrowError(SDKErrors.IdentityMismatchError)
   })
 
   it('verifies the message with sender is the owner (as light DID)', async () => {
@@ -483,7 +483,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(requestAttestationBody, bobLightDid.uri, aliceLightDid.uri)
       )
-    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH)
+    ).toThrowError(SDKErrors.IdentityMismatchError)
 
     const attestation = {
       delegationId: null,
@@ -556,7 +556,7 @@ describe('Messaging', () => {
       Message.ensureOwnerIsSender(
         new Message(submitAttestationBody, aliceLightDid.uri, bobLightDid.uri)
       )
-    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH)
+    ).toThrowError(SDKErrors.IdentityMismatchError)
 
     const credential: ICredential = {
       request: content,
@@ -627,6 +627,6 @@ describe('Messaging', () => {
           aliceLightDid.uri
         )
       )
-    ).toThrowError(SDKErrors.ERROR_IDENTITY_MISMATCH)
+    ).toThrowError(SDKErrors.IdentityMismatchError)
   })
 })

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -37,7 +37,6 @@ export class Message implements IMessage {
    * @param message The [[Message]] object which needs to be decrypted.
    * @param message.body The body of the [[Message]] which depends on the [[BodyType]].
    * @param message.sender The sender's DID taken from the [[IMessage]].
-   * @throws [[IdentityMismatchError]] when the sender is not the same subject as the owner of the content embedded in the message, e.g. A request for attestation or an attestation.
    */
   public static ensureOwnerIsSender({ body, sender }: IMessage): void {
     switch (body.type) {
@@ -91,9 +90,6 @@ export class Message implements IMessage {
    * @param receiverDetails The DID details of the receiver.
    * @param decryptionOptions Options to perform the decryption operation.
    * @param decryptionOptions.resolver The DID resolver to use.
-   *
-   * @throws [[DecodingMessageError]] when encrypted message couldn't be decrypted.
-   * @throws [[ParsingMessageError]] when the decoded message could not be parsed.
    * @returns The original [[Message]].
    */
   public static async decrypt(
@@ -325,7 +321,6 @@ export class Message implements IMessage {
    *
    * @param requiredProperties The list of required properties that need to be verified against a [[CType]].
    * @param cType A [[CType]] used to verify the properties.
-   * @throws [[CTypeHashMissingError]] when the properties do not match the provide [[CType]].
    */
   public static verifyRequiredCTypeProperties(
     requiredProperties: string[],

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -148,8 +148,10 @@ export class Message implements IMessage {
           nonce: hexToU8a(nonce),
         })
       ).data
-    } catch {
-      throw new SDKErrors.DecodingMessageError()
+    } catch (cause) {
+      throw new SDKErrors.DecodingMessageError(undefined, {
+        cause: cause as Error,
+      })
     }
 
     const decoded = u8aToString(data)
@@ -188,8 +190,10 @@ export class Message implements IMessage {
       Message.ensureOwnerIsSender(decrypted)
 
       return decrypted
-    } catch (error) {
-      throw new SDKErrors.ParsingMessageError()
+    } catch (cause) {
+      throw new SDKErrors.ParsingMessageError(undefined, {
+        cause: cause as Error,
+      })
     }
   }
 

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -37,7 +37,7 @@ export class Message implements IMessage {
    * @param message The [[Message]] object which needs to be decrypted.
    * @param message.body The body of the [[Message]] which depends on the [[BodyType]].
    * @param message.sender The sender's DID taken from the [[IMessage]].
-   * @throws [[ERROR_IDENTITY_MISMATCH]] when the sender is not the same subject as the owner of the content embedded in the message, e.g. A request for attestation or an attestation.
+   * @throws [[IdentityMismatchError]] when the sender is not the same subject as the owner of the content embedded in the message, e.g. A request for attestation or an attestation.
    */
   public static ensureOwnerIsSender({ body, sender }: IMessage): void {
     switch (body.type) {
@@ -50,7 +50,7 @@ export class Message implements IMessage {
               sender
             )
           ) {
-            throw new SDKErrors.ERROR_IDENTITY_MISMATCH('Claim', 'Sender')
+            throw new SDKErrors.IdentityMismatchError('Claim', 'Sender')
           }
         }
         break
@@ -63,7 +63,7 @@ export class Message implements IMessage {
               sender
             )
           ) {
-            throw new SDKErrors.ERROR_IDENTITY_MISMATCH('Attestation', 'Sender')
+            throw new SDKErrors.IdentityMismatchError('Attestation', 'Sender')
           }
         }
         break
@@ -72,7 +72,7 @@ export class Message implements IMessage {
           const submitClaimsForCtype = body
           submitClaimsForCtype.content.forEach((claim) => {
             if (!DidUtils.isSameSubject(claim.request.claim.owner, sender)) {
-              throw new SDKErrors.ERROR_IDENTITY_MISMATCH('Claims', 'Sender')
+              throw new SDKErrors.IdentityMismatchError('Claims', 'Sender')
             }
           })
         }
@@ -92,8 +92,8 @@ export class Message implements IMessage {
    * @param decryptionOptions Options to perform the decryption operation.
    * @param decryptionOptions.resolver The DID resolver to use.
    *
-   * @throws [[ERROR_DECODING_MESSAGE]] when encrypted message couldn't be decrypted.
-   * @throws [[ERROR_PARSING_MESSAGE]] when the decoded message could not be parsed.
+   * @throws [[DecodingMessageError]] when encrypted message couldn't be decrypted.
+   * @throws [[ParsingMessageError]] when the decoded message could not be parsed.
    * @returns The original [[Message]].
    */
   public static async decrypt(
@@ -111,20 +111,20 @@ export class Message implements IMessage {
 
     const senderKeyDetails = await resolver.resolveKey(senderKeyUri)
     if (!senderKeyDetails) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Could not resolve sender encryption key ${senderKeyUri}`
+      throw new SDKErrors.DidError(
+        `Could not resolve sender encryption key "${senderKeyUri}"`
       )
     }
     const { fragment } = DidUtils.parseDidUri(receiverKeyUri)
     if (!fragment) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `No fragment for the receiver key ID ${receiverKeyUri}`
+      throw new SDKErrors.DidError(
+        `No fragment for the receiver key ID "${receiverKeyUri}"`
       )
     }
     const receiverKeyDetails = receiverDetails.getKey(fragment)
     if (!receiverKeyDetails || !DidUtils.isEncryptionKey(receiverKeyDetails)) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Could not resolve receiver encryption key ${receiverKeyUri}`
+      throw new SDKErrors.DidError(
+        `Could not resolve receiver encryption key "${receiverKeyUri}"`
       )
     }
     const receiverKeyAlgType =
@@ -132,8 +132,8 @@ export class Message implements IMessage {
         receiverKeyDetails.type as EncryptionKeyType
       )
     if (receiverKeyAlgType !== 'x25519-xsalsa20-poly1305') {
-      throw new SDKErrors.ERROR_ENCRYPTION_ERROR(
-        'Only the "x25519-xsalsa20-poly1305" encryption algorithm currently supported.'
+      throw new SDKErrors.EncryptionError(
+        'Only the "x25519-xsalsa20-poly1305" encryption algorithm currently supported'
       )
     }
 
@@ -149,7 +149,7 @@ export class Message implements IMessage {
         })
       ).data
     } catch {
-      throw new SDKErrors.ERROR_DECODING_MESSAGE()
+      throw new SDKErrors.DecodingMessageError()
     }
 
     const decoded = u8aToString(data)
@@ -176,7 +176,7 @@ export class Message implements IMessage {
       }
 
       if (sender !== senderKeyDetails.controller) {
-        throw new SDKErrors.ERROR_IDENTITY_MISMATCH('Encryption key', 'Sender')
+        throw new SDKErrors.IdentityMismatchError('Encryption key', 'Sender')
       }
 
       // checks the message body
@@ -189,7 +189,7 @@ export class Message implements IMessage {
 
       return decrypted
     } catch (error) {
-      throw new SDKErrors.ERROR_PARSING_MESSAGE()
+      throw new SDKErrors.ParsingMessageError()
     }
   }
 
@@ -250,23 +250,21 @@ export class Message implements IMessage {
   ): Promise<IEncryptedMessage> {
     const receiverKey = await resolver.resolveKey(receiverKeyUri)
     if (!receiverKey) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Cannot resolve key ${receiverKeyUri}`
-      )
+      throw new SDKErrors.DidError(`Cannot resolve key "${receiverKeyUri}"`)
     }
     if (this.receiver !== receiverKey.controller) {
-      throw new SDKErrors.ERROR_IDENTITY_MISMATCH(
+      throw new SDKErrors.IdentityMismatchError(
         'receiver public key',
         'receiver'
       )
     }
     if (this.sender !== senderDetails.uri) {
-      throw new SDKErrors.ERROR_IDENTITY_MISMATCH('sender public key', 'sender')
+      throw new SDKErrors.IdentityMismatchError('sender public key', 'sender')
     }
     const senderKey = senderDetails.getKey(senderKeyId)
     if (!senderKey || !DidUtils.isEncryptionKey(senderKey)) {
-      throw new SDKErrors.ERROR_DID_ERROR(
-        `Cannot find key with ID ${senderKeyId} for the sender DID.`
+      throw new SDKErrors.DidError(
+        `Cannot find key with ID "${senderKeyId}" for the sender DID`
       )
     }
     const senderKeyAlgType =
@@ -274,8 +272,8 @@ export class Message implements IMessage {
         senderKey.type as EncryptionKeyType
       )
     if (senderKeyAlgType !== 'x25519-xsalsa20-poly1305') {
-      throw new SDKErrors.ERROR_ENCRYPTION_ERROR(
-        'Only the "x25519-xsalsa20-poly1305" encryption algorithm currently supported.'
+      throw new SDKErrors.EncryptionError(
+        'Only the "x25519-xsalsa20-poly1305" encryption algorithm currently supported'
       )
     }
 
@@ -323,7 +321,7 @@ export class Message implements IMessage {
    *
    * @param requiredProperties The list of required properties that need to be verified against a [[CType]].
    * @param cType A [[CType]] used to verify the properties.
-   * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] when the properties do not match the provide [[CType]].
+   * @throws [[CTypeHashMissingError]] when the properties do not match the provide [[CType]].
    */
   public static verifyRequiredCTypeProperties(
     requiredProperties: string[],

--- a/packages/messaging/src/Message.utils.spec.ts
+++ b/packages/messaging/src/Message.utils.spec.ts
@@ -849,7 +849,7 @@ describe('Messaging Utilities', () => {
 
     expect(() =>
       MessageUtils.decompressMessage(compressedMalformed)
-    ).toThrowError(SDKErrors.ERROR_MESSAGE_BODY_MALFORMED)
+    ).toThrowError(SDKErrors.UnknownMessageBodyTypeError)
 
     const malformed = {
       content: '',
@@ -857,20 +857,20 @@ describe('Messaging Utilities', () => {
     } as unknown as MessageBody
 
     expect(() => MessageUtils.compressMessage(malformed)).toThrowError(
-      SDKErrors.ERROR_MESSAGE_BODY_MALFORMED
+      SDKErrors.UnknownMessageBodyTypeError
     )
   })
   it('Checking required properties for given CType', () => {
     expect(() =>
       MessageUtils.verifyRequiredCTypeProperties(['id', 'name'], testCType)
-    ).toThrowError(SDKErrors.ERROR_CTYPE_PROPERTIES_NOT_MATCHING)
+    ).toThrowError(SDKErrors.CTypeUnknownPropertiesError)
 
     expect(() =>
       MessageUtils.verifyRequiredCTypeProperties(
         ['id', 'name'],
         testCTypeWithMultipleProperties
       )
-    ).not.toThrowError(SDKErrors.ERROR_CTYPE_PROPERTIES_NOT_MATCHING)
+    ).not.toThrowError(SDKErrors.CTypeUnknownPropertiesError)
 
     expect(() =>
       MessageUtils.verifyRequiredCTypeProperties(
@@ -1045,38 +1045,38 @@ describe('Messaging Utilities', () => {
     messageRequestTerms.receiver = 'did:kilt:thisisnotareceiveraddress'
     expect(() =>
       MessageUtils.errorCheckMessage(messageRequestTerms)
-    ).toThrowError(SDKErrors.ERROR_INVALID_DID_FORMAT)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
     // @ts-ignore
     messageSubmitTerms.sender = 'this is not a sender did'
     expect(() =>
       MessageUtils.errorCheckMessage(messageSubmitTerms)
-    ).toThrowError(SDKErrors.ERROR_INVALID_DID_FORMAT)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
     // @ts-ignore
     messageRejectTerms.sender = 'this is not a sender address'
     expect(() =>
       MessageUtils.errorCheckMessage(messageRejectTerms)
-    ).toThrowError(SDKErrors.ERROR_INVALID_DID_FORMAT)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
   })
   it('error check should throw errors on faulty bodies', () => {
     // @ts-ignore
     requestTermsBody.content.cTypeHash = 'this is not a ctype hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestTermsBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     submitTermsBody.content.delegationId = 'this is not a delegation id'
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitTermsBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
 
     rejectTermsBody.content.delegationId = 'this is not a delegation id'
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectTermsBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     // @ts-expect-error
     delete rejectTermsBody.content.claim.cTypeHash
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectTermsBody)
-    ).toThrowError(SDKErrors.ERROR_CTYPE_HASH_NOT_PROVIDED)
+    ).toThrowError(SDKErrors.CTypeHashMissingError)
     requestAttestationBody.content.requestForAttestation.claimerSignature = {
       signature: 'this is not the claimers signature',
       // @ts-ignore
@@ -1090,66 +1090,66 @@ describe('Messaging Utilities', () => {
       'this is not the claim hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitAttestationBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     // @ts-ignore
     rejectAttestationForClaimBody.content = 'this is not the root hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectAttestationForClaimBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     // @ts-ignore
     requestCredentialBody.content.cTypes[0].cTypeHash =
       'this is not a cTypeHash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestCredentialBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     // @ts-expect-error
     delete submitCredentialBody.content[0].attestation.revoked
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitCredentialBody)
-    ).toThrowError(SDKErrors.ERROR_REVOCATION_BIT_MISSING)
+    ).toThrowError(SDKErrors.RevokedTypeError)
     // @ts-ignore
     acceptCredentialBody.content[0] = 'this is not a cTypeHash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(acceptCredentialBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     // @ts-ignore
     rejectCredentialBody.content[0] = 'this is not a cTypeHash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectCredentialBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     delete requestAcceptDelegationBody.content.metaData
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestAcceptDelegationBody)
-    ).toThrowError(SDKErrors.ERROR_OBJECT_MALFORMED)
+    ).toThrowError(SDKErrors.ObjectUnverifiableError)
     requestAcceptDelegationBody.content.signatures.inviter.signature =
       'this is not a signature'
     expect(() =>
       MessageUtils.errorCheckMessageBody(requestAcceptDelegationBody)
-    ).toThrowError(SDKErrors.ERROR_SIGNATURE_DATA_TYPE)
+    ).toThrowError(SDKErrors.SignatureMalformedError)
     // @ts-ignore
     submitAcceptDelegationBody.content.signatures.invitee.keyUri =
       'this is not a key id'
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitAcceptDelegationBody)
-    ).toThrowError(SDKErrors.ERROR_SIGNATURE_DATA_TYPE)
+    ).toThrowError(SDKErrors.SignatureMalformedError)
     submitAcceptDelegationBody.content.delegationData.parentId =
       'this is not a parent id hash'
     expect(() =>
       MessageUtils.errorCheckMessageBody(submitAcceptDelegationBody)
-    ).toThrowError(SDKErrors.ERROR_DELEGATION_ID_TYPE)
+    ).toThrowError(SDKErrors.DelegationIdTypeError)
     // @ts-expect-error
     delete rejectAcceptDelegationBody.content.account
     expect(() =>
       MessageUtils.errorCheckMessageBody(rejectAcceptDelegationBody)
-    ).toThrowError(SDKErrors.ERROR_OWNER_NOT_PROVIDED)
+    ).toThrowError(SDKErrors.OwnerMissingError)
     informCreateDelegationBody.content.delegationId =
       'this is not a delegation id'
     expect(() =>
       MessageUtils.errorCheckMessageBody(informCreateDelegationBody)
-    ).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+    ).toThrowError(SDKErrors.HashMalformedError)
     expect(() =>
       MessageUtils.errorCheckMessageBody({} as MessageBody)
-    ).toThrowError(SDKErrors.ERROR_MESSAGE_BODY_MALFORMED)
+    ).toThrowError(SDKErrors.UnknownMessageBodyTypeError)
   })
   it('error check of the delegation data in messaging', () => {
     // @ts-expect-error
@@ -1165,19 +1165,19 @@ describe('Messaging Utilities', () => {
       MessageUtils.errorCheckDelegationData(
         requestAcceptDelegationBody.content.delegationData
       )
-    ).toThrowError(SDKErrors.ERROR_DELEGATION_ID_TYPE)
+    ).toThrowError(SDKErrors.DelegationIdTypeError)
     submitAcceptDelegationBody.content.delegationData.permissions = []
     expect(() =>
       MessageUtils.errorCheckDelegationData(
         submitAcceptDelegationBody.content.delegationData
       )
-    ).toThrowError(SDKErrors.ERROR_UNAUTHORIZED)
+    ).toThrowError(SDKErrors.UnauthorizedError)
     // @ts-expect-error
     delete submitAcceptDelegationBody.content.delegationData.id
     expect(() =>
       MessageUtils.errorCheckDelegationData(
         submitAcceptDelegationBody.content.delegationData
       )
-    ).toThrowError(SDKErrors.ERROR_DELEGATION_ID_MISSING)
+    ).toThrowError(SDKErrors.DelegationIdMissingError)
   })
 })

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -39,33 +39,28 @@ export function errorCheckDelegationData(
   const { permissions, id, parentId, isPCR, account } = delegationData
 
   if (!id) {
-    throw new SDKErrors.ERROR_DELEGATION_ID_MISSING()
-  } else if (typeof id !== 'string') {
-    throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
-  } else if (!isHex(id)) {
-    throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
+    throw new SDKErrors.DelegationIdMissingError()
+  } else if (typeof id !== 'string' || !isHex(id)) {
+    throw new SDKErrors.DelegationIdTypeError()
   }
 
   if (!account) {
-    throw new SDKErrors.ERROR_OWNER_NOT_PROVIDED()
-  } else DidUtils.validateKiltDidUri(account)
+    throw new SDKErrors.OwnerMissingError()
+  }
+  DidUtils.validateKiltDidUri(account)
 
   if (typeof isPCR !== 'boolean') {
     throw new TypeError('isPCR is expected to be a boolean')
   }
 
   if (permissions.length === 0 || permissions.length > 3) {
-    throw new SDKErrors.ERROR_UNAUTHORIZED(
+    throw new SDKErrors.UnauthorizedError(
       'Must have at least one permission and no more then two'
     )
   }
 
-  if (parentId) {
-    if (typeof parentId !== 'string') {
-      throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
-    } else if (!isHex(parentId)) {
-      throw new SDKErrors.ERROR_DELEGATION_ID_TYPE()
-    }
+  if (parentId && (typeof parentId !== 'string' || !isHex(parentId))) {
+    throw new SDKErrors.DelegationIdTypeError()
   }
 }
 
@@ -128,7 +123,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
     }
     case 'reject-attestation': {
       if (!isHex(body.content)) {
-        throw new SDKErrors.ERROR_HASH_MALFORMED()
+        throw new SDKErrors.HashMalformedError()
       }
       break
     }
@@ -143,7 +138,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
           requiredProperties?.forEach((requiredProps) => {
             if (typeof requiredProps !== 'string')
               throw new TypeError(
-                'required properties is expected to be a string'
+                'Required properties is expected to be a string'
               )
           })
         }
@@ -178,7 +173,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
       errorCheckDelegationData(body.content.delegationData)
       isDidSignature(body.content.signatures.inviter)
       if (!isJsonObject(body.content.metaData)) {
-        throw new SDKErrors.ERROR_OBJECT_MALFORMED()
+        throw new SDKErrors.ObjectUnverifiableError()
       }
       break
     }
@@ -202,7 +197,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
     }
 
     default:
-      throw new SDKErrors.ERROR_MESSAGE_BODY_MALFORMED()
+      throw new SDKErrors.UnknownMessageBodyTypeError()
   }
 }
 
@@ -223,18 +218,18 @@ export function errorCheckMessage(message: IMessage): void {
     inReplyTo,
   } = message
   if (messageId && typeof messageId !== 'string') {
-    throw new TypeError('message id is expected to be a string')
+    throw new TypeError('Message id is expected to be a string')
   }
   if (createdAt && typeof createdAt !== 'number') {
-    throw new TypeError('created at is expected to be a number')
+    throw new TypeError('Created at is expected to be a number')
   }
   if (receivedAt && typeof receivedAt !== 'number') {
-    throw new TypeError('received at is expected to be a number')
+    throw new TypeError('Received at is expected to be a number')
   }
   DidUtils.validateKiltDidUri(receiver)
   DidUtils.validateKiltDidUri(sender)
   if (inReplyTo && typeof inReplyTo !== 'string') {
-    throw new TypeError('in reply to is expected to be a string')
+    throw new TypeError('In reply to is expected to be a string')
   }
   errorCheckMessageBody(body)
 }
@@ -244,7 +239,7 @@ export function errorCheckMessage(message: IMessage): void {
  *
  * @param requiredProperties The list of required properties that need to be verified against a [[CType]].
  * @param cType A [[CType]] used to verify the properties.
- * @throws [[ERROR_CTYPE_HASH_NOT_PROVIDED]] when the properties do not match the provide [[CType]].
+ * @throws [[CTypeHashMissingError]] when the properties do not match the provide [[CType]].
  */
 export function verifyRequiredCTypeProperties(
   requiredProperties: string[],
@@ -252,11 +247,11 @@ export function verifyRequiredCTypeProperties(
 ): void {
   CType.verifyDataStructure(cType as ICType)
 
-  const validProperties = requiredProperties.find(
+  const unknownProperties = requiredProperties.find(
     (property) => !(property in cType.schema.properties)
   )
-  if (validProperties) {
-    throw new SDKErrors.ERROR_CTYPE_PROPERTIES_NOT_MATCHING()
+  if (unknownProperties) {
+    throw new SDKErrors.CTypeUnknownPropertiesError()
   }
 }
 
@@ -385,7 +380,7 @@ export function compressMessage(body: MessageBody): CompressedMessageBody {
       break
     }
     default:
-      throw new SDKErrors.ERROR_MESSAGE_BODY_MALFORMED()
+      throw new SDKErrors.UnknownMessageBodyTypeError()
   }
   return [body.type, compressedContents] as CompressedMessageBody
 }
@@ -520,7 +515,7 @@ export function decompressMessage(body: CompressedMessageBody): MessageBody {
       break
     }
     default:
-      throw new SDKErrors.ERROR_MESSAGE_BODY_MALFORMED()
+      throw new SDKErrors.UnknownMessageBodyTypeError()
   }
 
   return { type: body[0], content: decompressedContents } as MessageBody

--- a/packages/messaging/src/Message.utils.ts
+++ b/packages/messaging/src/Message.utils.ts
@@ -31,7 +31,6 @@ import { isDidSignature, Utils as DidUtils } from '@kiltprotocol/did'
  * Checks if delegation data is well formed.
  *
  * @param delegationData Delegation data to check.
- * @throws [[SDKError]] if delegationData is not a valid instance of [[IDelegationData]].
  */
 export function errorCheckDelegationData(
   delegationData: IDelegationData
@@ -68,7 +67,6 @@ export function errorCheckDelegationData(
  * Checks if the message body is well-formed.
  *
  * @param body The message body.
- * @throws [[SDKError]] if there are issues with form or content of the message body.
  */
 export function errorCheckMessageBody(body: MessageBody): void {
   switch (body.type) {
@@ -205,7 +203,6 @@ export function errorCheckMessageBody(body: MessageBody): void {
  * Checks if the message object is well-formed.
  *
  * @param message The message object.
- * @throws [[SDKError]] if there are issues with form or content of the message object.
  */
 export function errorCheckMessage(message: IMessage): void {
   const {
@@ -239,7 +236,6 @@ export function errorCheckMessage(message: IMessage): void {
  *
  * @param requiredProperties The list of required properties that need to be verified against a [[CType]].
  * @param cType A [[CType]] used to verify the properties.
- * @throws [[CTypeHashMissingError]] when the properties do not match the provide [[CType]].
  */
 export function verifyRequiredCTypeProperties(
   requiredProperties: string[],

--- a/packages/testing/scripts/fetchMetadata.js
+++ b/packages/testing/scripts/fetchMetadata.js
@@ -45,7 +45,7 @@ switch (true) {
     break
   default:
     throw new Error(
-      `can only handle ws/wss and http/https endpoints, received ${argv.endpoint}`
+      `Can only handle ws/wss and http/https endpoints, received "${argv.endpoint}"`
     )
 }
 
@@ -65,7 +65,7 @@ async function fetch() {
       metadata = JSON.stringify(api.runtimeMetadata.toJSON(), null, 2)
       break
     default:
-      throw new Error('unexpected output format')
+      throw new Error('Unexpected output format')
   }
 
   console.log(
@@ -79,7 +79,7 @@ async function fetch() {
 const timeout = new Promise((_, reject) => {
   setTimeout(() => {
     exitCode = exitCode || 124
-    reject(new Error('timeout waiting for metadata fetch'))
+    reject(new Error('Timeout waiting for metadata fetch'))
   }, 10000)
 })
 

--- a/packages/testing/src/mocks/mockedApi.utils.ts
+++ b/packages/testing/src/mocks/mockedApi.utils.ts
@@ -138,7 +138,7 @@ export function mockChainQueryReturn<T extends keyof ChainQueryTypes>(
     default:
       // should never occur
       throw new Error(
-        `Missing module ${outerQuery} for KILT chain. 
+        `Missing module "${outerQuery}" for KILT chain. 
         The following ones exist: attestation, ctype, delegation, did, portablegabi.`
       )
   }

--- a/packages/utils/src/DataUtils.spec.ts
+++ b/packages/utils/src/DataUtils.spec.ts
@@ -29,23 +29,23 @@ it('throws on address with other prefix', () => {
 
 it('throws for random strings', () => {
   expect(() => validateAddress('', 'test')).toThrowError(
-    SDKErrors.ERROR_ADDRESS_INVALID
+    SDKErrors.AddressInvalidError
   )
   expect(() => validateAddress('0x123', 'test')).toThrowError(
-    SDKErrors.ERROR_ADDRESS_INVALID
+    SDKErrors.AddressInvalidError
   )
   expect(() => validateAddress('bananenbabara', 'test')).toThrowError(
-    SDKErrors.ERROR_ADDRESS_INVALID
+    SDKErrors.AddressInvalidError
   )
   expect(() => validateAddress('ax843zoidsfho38290rdusa', 'test')).toThrowError(
-    SDKErrors.ERROR_ADDRESS_INVALID
+    SDKErrors.AddressInvalidError
   )
 })
 
 it('throws if address is no string', () => {
   expect(() =>
     validateAddress(Buffer.from([0, 0, 7]) as any, 'test')
-  ).toThrowError(SDKErrors.ERROR_ADDRESS_TYPE)
+  ).toThrowError(SDKErrors.AddressTypeError)
 })
 
 it('validates hash', () => {
@@ -59,25 +59,25 @@ it('throws on broken hashes', () => {
   const hash = Crypto.hashStr('test')
   expect(() => {
     validateHash(hash.substr(2), 'test')
-  }).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+  }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
     validateHash(hash.substr(0, 60), 'test')
-  }).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+  }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
     validateHash(hash.replace('0', 'O'), 'test')
-  }).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+  }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
     validateHash(`${hash.substr(0, hash.length - 1)}ß`, 'test')
-  }).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+  }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
     validateHash(hash.replace(/\w/i, 'P'), 'test')
-  }).toThrowError(SDKErrors.ERROR_HASH_MALFORMED)
+  }).toThrowError(SDKErrors.HashMalformedError)
 })
 
 it('throws if hash is no string', () => {
   expect(() =>
     validateHash(Buffer.from([0, 0, 7]) as any, 'test')
-  ).toThrowError(SDKErrors.ERROR_HASH_TYPE)
+  ).toThrowError(SDKErrors.HashTypeError)
 })
 
 describe('validate signature util', () => {
@@ -96,7 +96,7 @@ describe('validate signature util', () => {
   it('throws when signature does not check out', () => {
     expect(() =>
       validateSignature('dörte', signature, signer.address)
-    ).toThrowError(SDKErrors.ERROR_SIGNATURE_UNVERIFIABLE)
+    ).toThrowError(SDKErrors.SignatureUnverifiableError)
   })
 
   it('throws non-sdk error if input is bogus', () => {
@@ -109,16 +109,16 @@ describe('validate signature util', () => {
 
   it('throws when input is incomplete', () => {
     expect(() => validateSignature('data', null as any, 'signer')).toThrowError(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
     expect(() =>
       validateSignature('data', 'signature', undefined as any)
-    ).toThrowError(SDKErrors.ERROR_SIGNATURE_DATA_TYPE)
+    ).toThrowError(SDKErrors.SignatureMalformedError)
     expect(() =>
       validateSignature({ key: ['value'] } as any, 'signature', 'signer')
-    ).toThrowError(SDKErrors.ERROR_SIGNATURE_DATA_TYPE)
+    ).toThrowError(SDKErrors.SignatureMalformedError)
     expect(() => (validateSignature as any)()).toThrowError(
-      SDKErrors.ERROR_SIGNATURE_DATA_TYPE
+      SDKErrors.SignatureMalformedError
     )
   })
 })

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -16,8 +16,6 @@ import { ss58Format } from './ss58Format.js'
  *
  * @param address Address string to validate for correct Format.
  * @param name Contextual name of the address, e.g. "claim owner".
- * @throws [[AddressTypeError]] when address not of type string or of invalid Format.
- *
  * @returns Boolean whether the given address string checks out against the Format.
  */
 export function validateAddress(
@@ -38,8 +36,6 @@ export function validateAddress(
  *
  * @param hash Hash string to validate for correct Format.
  * @param name Contextual name of the address, e.g. "claim owner".
- * @throws [[HashTypeError]] when hash not of type string or of invalid Format.
- *
  * @returns Boolean whether the given hash string checks out against the Format.
  */
 export function validateHash(hash: string, name: string): boolean {
@@ -59,9 +55,6 @@ export function validateHash(hash: string, name: string): boolean {
  * @param data The signed string of data.
  * @param signature The signature of the data to be validated.
  * @param signer Address of the signer identity.
- * @throws [[SignatureMalformedError]] when parameters are of invalid type.
- * @throws [[SignatureUnverifiableError]] when the signature could not be validated against the data.
- *
  * @returns Boolean whether the signature is valid for the given data.
  */
 export function validateSignature(

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -16,7 +16,7 @@ import { ss58Format } from './ss58Format.js'
  *
  * @param address Address string to validate for correct Format.
  * @param name Contextual name of the address, e.g. "claim owner".
- * @throws [[ERROR_ADDRESS_TYPE]] when address not of type string or of invalid Format.
+ * @throws [[AddressTypeError]] when address not of type string or of invalid Format.
  *
  * @returns Boolean whether the given address string checks out against the Format.
  */
@@ -25,10 +25,10 @@ export function validateAddress(
   name: string
 ): boolean {
   if (typeof address !== 'string') {
-    throw new SDKErrors.ERROR_ADDRESS_TYPE()
+    throw new SDKErrors.AddressTypeError()
   }
   if (!checkAddress(address, ss58Format)[0]) {
-    throw new SDKErrors.ERROR_ADDRESS_INVALID(address, name)
+    throw new SDKErrors.AddressInvalidError(address, name)
   }
   return true
 }
@@ -38,17 +38,17 @@ export function validateAddress(
  *
  * @param hash Hash string to validate for correct Format.
  * @param name Contextual name of the address, e.g. "claim owner".
- * @throws [[ERROR_HASH_TYPE]] when hash not of type string or of invalid Format.
+ * @throws [[HashTypeError]] when hash not of type string or of invalid Format.
  *
  * @returns Boolean whether the given hash string checks out against the Format.
  */
 export function validateHash(hash: string, name: string): boolean {
   if (typeof hash !== 'string') {
-    throw new SDKErrors.ERROR_HASH_TYPE()
+    throw new SDKErrors.HashTypeError()
   }
   const blake2bPattern = new RegExp('(0x)[A-F0-9]{64}', 'i')
   if (!hash.match(blake2bPattern)) {
-    throw new SDKErrors.ERROR_HASH_MALFORMED(hash, name)
+    throw new SDKErrors.HashMalformedError(hash, name)
   }
   return true
 }
@@ -59,8 +59,8 @@ export function validateHash(hash: string, name: string): boolean {
  * @param data The signed string of data.
  * @param signature The signature of the data to be validated.
  * @param signer Address of the signer identity.
- * @throws [[ERROR_SIGNATURE_DATA_TYPE]] when parameters are of invalid type.
- * @throws [[ERROR_SIGNATURE_UNVERIFIABLE]] when the signature could not be validated against the data.
+ * @throws [[SignatureMalformedError]] when parameters are of invalid type.
+ * @throws [[SignatureUnverifiableError]] when the signature could not be validated against the data.
  *
  * @returns Boolean whether the signature is valid for the given data.
  */
@@ -74,10 +74,10 @@ export function validateSignature(
     typeof signature !== 'string' ||
     typeof signer !== 'string'
   ) {
-    throw new SDKErrors.ERROR_SIGNATURE_DATA_TYPE()
+    throw new SDKErrors.SignatureMalformedError()
   }
   if (!verify(data, signature, signer)) {
-    throw new SDKErrors.ERROR_SIGNATURE_UNVERIFIABLE()
+    throw new SDKErrors.SignatureUnverifiableError()
   }
   return true
 }

--- a/packages/utils/src/Decode.ts
+++ b/packages/utils/src/Decode.ts
@@ -23,7 +23,6 @@ export function codecIsType(codec: Codec, types: string[]): boolean {
  *
  * @param codec The codec to type check.
  * @param types An array of strings denoting types to check against.
- * @throws `TypeError` If codec type is not contained in the allowed `types`.
  */
 export function assertCodecIsType(codec: Codec, types: string[]): void {
   if (!codecIsType(codec, types))

--- a/packages/utils/src/Decode.ts
+++ b/packages/utils/src/Decode.ts
@@ -28,6 +28,6 @@ export function codecIsType(codec: Codec, types: string[]): boolean {
 export function assertCodecIsType(codec: Codec, types: string[]): void {
   if (!codecIsType(codec, types))
     throw new TypeError(
-      `expected Codec type(s) ${types}, got ${codec.toRawType()}`
+      `Expected Codec type(s) ${types}, got ${codec.toRawType()}`
     )
 }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -87,12 +87,7 @@ export class DelegationIdTypeError extends SDKError {}
 
 export class DelegationIdMissingError extends SDKError {}
 
-export class DelegationSignatureMissingError extends SDKError {
-  constructor() {
-    // TODO: better name
-    super("Delegatee's signature missing")
-  }
-}
+export class DelegateSignatureMissingError extends SDKError {}
 
 export class InvalidRootNodeError extends SDKError {}
 

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -135,8 +135,8 @@ export class HierarchyQueryError extends SDKError {
 }
 
 export class InvalidDidFormatError extends SDKError {
-  constructor(identifier: string) {
-    super(`Not a valid KILT DID "${identifier}"`)
+  constructor(identifier: string, options?: ErrorOptions) {
+    super(`Not a valid KILT DID "${identifier}"`, options)
   }
 }
 

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -14,8 +14,8 @@
 /* eslint-disable max-classes-per-file */
 
 export class SDKError extends Error {
-  constructor(message?: string) {
-    super(message)
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options)
     // this line is the only reason for using SDKError
     this.name = this.constructor.name
   }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -6,348 +6,225 @@
  */
 
 /**
- * SDKErrors are KILT-specific errors, with associated codes and descriptions.
+ * KILT-specific errors with descriptions.
  *
  * @packageDocumentation
  */
 
 /* eslint-disable max-classes-per-file */
 
-export abstract class SDKError extends Error {
-  constructor(...args: ConstructorParameters<ErrorConstructor>) {
-    super(...args)
+export class SDKError extends Error {
+  constructor(message?: string) {
+    super(message)
+    // this line is the only reason for using SDKError
     this.name = this.constructor.name
   }
 }
 
-export class ERROR_UNAUTHORIZED extends SDKError {}
+export class UnauthorizedError extends SDKError {}
 
-export class ERROR_CTYPE_HASH_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('CType hash missing')
-  }
-}
+export class CTypeHashMissingError extends SDKError {}
 
-export class ERROR_CTYPE_ID_NOT_MATCHING extends SDKError {
+export class CTypeIdMismatchError extends SDKError {
   constructor(fromSchema: string, provided: string) {
     super(
-      `Provided $id "${provided}" and schema $id "${fromSchema}" are not matching`
+      `Provided $id "${provided}" does not match schema $id "${fromSchema}"`
     )
   }
 }
 
-export class ERROR_CTYPE_PROPERTIES_NOT_MATCHING extends SDKError {
-  constructor() {
-    super('Required properties do not match CType properties')
-  }
-}
+export class CTypeUnknownPropertiesError extends SDKError {}
 
-export class ERROR_UNSUPPORTED_KEY extends SDKError {
+export class UnsupportedKeyError extends SDKError {
   constructor(keyType: string) {
-    super(`The provided key type "${keyType}" is currently not supported.`)
-  }
-}
-export class ERROR_ENCRYPTION_ERROR extends SDKError {}
-export class ERROR_DID_ERROR extends SDKError {}
-export class ERROR_DID_EXPORTER_ERROR extends SDKError {}
-export class ERROR_DID_BUILDER_ERROR extends SDKError {}
-export class ERROR_WEB3_NAME_ERROR extends SDKError {}
-
-export class ERROR_CLAIM_HASH_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('Claim hash missing')
-  }
-}
-export class ERROR_REVOCATION_BIT_MISSING extends SDKError {
-  constructor() {
-    super('Revoked identifier missing')
-  }
-}
-export class ERROR_OWNER_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('Owner missing')
-  }
-}
-export class ERROR_ATTESTATION_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('Attestation missing')
+    super(`The provided key type "${keyType}" is currently not supported`)
   }
 }
 
-export class ERROR_RFA_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('RequestForAttestation missing')
-  }
-}
+export class EncryptionError extends SDKError {}
 
-export class ERROR_LEGITIMATIONS_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('Legitimations missing')
-  }
-}
-export class ERROR_CLAIM_NONCE_MAP_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('Hashtree in Claim missing')
-  }
-}
-export class ERROR_CLAIM_NOT_PROVIDED extends SDKError {
-  constructor() {
-    super('Claim missing')
-  }
-}
-export class ERROR_ADDRESS_TYPE extends SDKError {
-  constructor() {
-    super('Address of wrong type')
-  }
-}
-export class ERROR_HASH_TYPE extends SDKError {
-  constructor() {
-    super('Hash of wrong type')
-  }
-}
+export class DidError extends SDKError {}
 
-export class ERROR_HASH_MALFORMED extends SDKError {
+export class DidExporterError extends SDKError {}
+
+export class DidBuilderError extends SDKError {}
+
+export class Web3NameError extends SDKError {}
+
+export class ClaimHashMissingError extends SDKError {}
+
+export class RevokedTypeError extends SDKError {}
+
+export class OwnerMissingError extends SDKError {}
+
+export class AttestationMissingError extends SDKError {}
+
+export class RequestForAttestationMissingError extends SDKError {}
+
+export class LegitimationsMissingError extends SDKError {}
+
+export class ClaimNonceMapMissingError extends SDKError {}
+
+export class ClaimMissingError extends SDKError {}
+
+export class AddressTypeError extends SDKError {}
+
+export class HashTypeError extends SDKError {}
+
+export class HashMalformedError extends SDKError {
   constructor(hash?: string, type?: string) {
-    let message = ''
     if (hash && type) {
-      message = `Provided ${type} hash invalid or malformed \nHash: ${hash}`
+      super(`Provided ${type} hash "${hash}" is invalid or malformed`)
     } else if (hash) {
-      message = `Provided hash invalid or malformed \nHash: ${hash}`
+      super(`Provided hash "${hash}" is invalid or malformed`)
     } else {
-      message = 'Provided hash invalid or malformed'
+      super('Provided hash invalid or malformed')
     }
-    super(message)
   }
 }
 
-export class ERROR_DELEGATION_ID_TYPE extends SDKError {
-  constructor() {
-    super('DelegationId of wrong type')
-  }
-}
+export class DelegationIdTypeError extends SDKError {}
 
-export class ERROR_DELEGATION_ID_MISSING extends SDKError {
-  constructor() {
-    super('DelegationId is missing')
-  }
-}
+export class DelegationIdMissingError extends SDKError {}
 
-export class ERROR_DELEGATION_SIGNATURE_MISSING extends SDKError {
+export class DelegationSignatureMissingError extends SDKError {
   constructor() {
+    // TODO: better name
     super("Delegatee's signature missing")
   }
 }
 
-export class ERROR_INVALID_ROOT_NODE extends SDKError {
-  constructor() {
-    super('The given node is not a valid root node')
-  }
-}
+export class InvalidRootNodeError extends SDKError {}
 
-export class ERROR_INVALID_DELEGATION_NODE extends SDKError {
-  constructor() {
-    super('The given node is not a valid delegation node')
-  }
-}
+export class InvalidDelegationNodeError extends SDKError {}
 
-export class ERROR_CLAIM_CONTENTS_MALFORMED extends SDKError {
-  constructor() {
-    super('Claim contents malformed')
-  }
-}
-export class ERROR_OBJECT_MALFORMED extends SDKError {
-  constructor() {
-    super('Object form is not verifiable')
-  }
-}
-export class ERROR_CTYPE_OWNER_TYPE extends SDKError {
-  constructor() {
-    super('CType owner of wrong type')
-  }
-}
-export class ERROR_QUOTE_MALFORMED extends SDKError {
-  constructor() {
-    super('Quote form is not verifiable')
-  }
-}
+export class ClaimContentsMalformedError extends SDKError {}
 
-export class ERROR_CLAIM_NONCE_MAP_MALFORMED extends SDKError {
+export class ObjectUnverifiableError extends SDKError {}
+
+export class CTypeOwnerTypeError extends SDKError {}
+
+export class QuoteUnverifiableError extends SDKError {}
+
+export class ClaimNonceMapMalformedError extends SDKError {
   constructor(statement?: string) {
-    let message = ''
     if (statement) {
-      message = `Nonce map malformed or incomplete: no nonce for statement "${statement}"`
+      super(`Nonce map malformed or incomplete for statement "${statement}"`)
     } else {
-      message = `Nonce map malformed or incomplete`
+      super(`Nonce map malformed or incomplete`)
     }
-    super(message)
   }
 }
 
-export class ERROR_MESSAGE_BODY_MALFORMED extends SDKError {
-  constructor() {
-    super('Message body is malformed or wrong type')
-  }
-}
+export class UnknownMessageBodyTypeError extends SDKError {}
 
-export class ERROR_SIGNATURE_DATA_TYPE extends SDKError {
-  constructor() {
-    super('Signature malformed')
-  }
-}
-export class ERROR_DID_IDENTIFIER_MISMATCH extends SDKError {
+export class SignatureMalformedError extends SDKError {}
+
+export class DidIdentifierMismatchError extends SDKError {
   constructor(identifier: string, id: string) {
     super(
-      `This identifier (${identifier}) doesn't match the DID Document's identifier (${id})`
+      `The identifier "${identifier}" doesn't match the DID Document's identifier "${id}"`
     )
   }
 }
-export class ERROR_HIERARCHY_QUERY extends SDKError {
+
+export class HierarchyQueryError extends SDKError {
   constructor(rootId: string) {
-    super(`Could not find root node with id ${rootId}`)
+    super(`Could not find root node with id "${rootId}"`)
   }
 }
-export class ERROR_INVALID_DID_FORMAT extends SDKError {
+
+export class InvalidDidFormatError extends SDKError {
   constructor(identifier: string) {
-    super(`Not a valid KILT did: ${identifier}`)
+    super(`Not a valid KILT DID "${identifier}"`)
   }
 }
-export class ERROR_UNSUPPORTED_DID extends SDKError {
+
+export class UnsupportedDidError extends SDKError {
   constructor(input: string) {
-    super(`The DID ${input} is not supported.`)
+    super(`The DID "${input}" is not supported`)
   }
 }
 
-export class ERROR_ADDRESS_INVALID extends SDKError {
+export class AddressInvalidError extends SDKError {
   constructor(address?: string, type?: string) {
-    let message = ''
     if (address && type) {
-      message = `Provided ${type} address invalid \n\n    Address: ${address}`
+      super(`Provided ${type} address "${address}" is invalid`)
     } else if (address) {
-      message = `Provided address invalid \n\n    Address: ${address}`
+      super(`Provided address "${address}" is invalid`)
     } else {
-      message = `Provided address invalid`
+      super(`Provided address invalid`)
     }
-    super(message)
   }
 }
 
-export class ERROR_LEGITIMATIONS_UNVERIFIABLE extends SDKError {
-  constructor() {
-    super('Legitimations could not be verified')
-  }
-}
-export class ERROR_SIGNATURE_UNVERIFIABLE extends SDKError {
-  constructor() {
-    super('Signature could not be verified')
-  }
-}
-export class ERROR_CREDENTIAL_UNVERIFIABLE extends SDKError {
-  constructor() {
-    super('Credential could not be verified')
-  }
-}
+export class LegitimationsUnverifiableError extends SDKError {}
 
-export class ERROR_CLAIM_UNVERIFIABLE extends SDKError {
-  constructor() {
-    super('Claim could not be verified')
-  }
-}
+export class SignatureUnverifiableError extends SDKError {}
 
-export class ERROR_NESTED_CLAIM_UNVERIFIABLE extends SDKError {
-  constructor() {
-    super('Nested claim data does not validate against CType')
-  }
-}
+export class CredentialUnverifiableError extends SDKError {}
 
-export class ERROR_IDENTITY_MISMATCH extends SDKError {
+export class ClaimUnverifiableError extends SDKError {}
+
+export class NestedClaimUnverifiableError extends SDKError {}
+
+export class IdentityMismatchError extends SDKError {
   constructor(context?: string, type?: string) {
-    let message = ''
     if (type && context) {
-      message = `${type} is not owner of the ${context}`
+      super(`${type} is not owner of the ${context}`)
     } else if (context) {
-      message = `Identity is not owner of the ${context}`
+      super(`Identity is not owner of the ${context}`)
     } else {
-      message = 'Addresses expected to be equal mismatched'
+      super('Addresses expected to be equal mismatched')
     }
-    super(message)
   }
 }
 
-export class ERROR_WS_ADDRESS_NOT_SET extends SDKError {
+export class WsAddressNotSetError extends SDKError {
   constructor() {
     super('Node address to connect to not configured!')
   }
 }
 
-export class ERROR_ROOT_HASH_UNVERIFIABLE extends SDKError {
-  constructor() {
-    super('RootHash could not be verified')
+export class RootHashUnverifiableError extends SDKError {}
+
+export class DecompressionArrayError extends SDKError {
+  constructor(type = 'object') {
+    super(`Provided compressed ${type} not an Array or not of defined length`)
   }
 }
 
-export class ERROR_DECOMPRESSION_ARRAY extends SDKError {
-  constructor(type?: string) {
-    let message = ''
-    if (type) {
-      message = `Provided compressed ${type} not an Array or not of defined length`
-    } else {
-      message =
-        'Provided compressed object not an Array or not of defined length'
-    }
-    super(message)
-  }
-}
-
-export class ERROR_COMPRESS_OBJECT extends SDKError {
+export class CompressObjectError extends SDKError {
   constructor(object?: Record<string, any>, type?: string) {
-    let message = ''
-    if (object && type) {
-      message = `Property Not Provided while compressing ${type}:\n${JSON.stringify(
-        object,
-        null,
-        2
-      )}`
-    } else if (object) {
-      message = `Property Not Provided while compressing object:\n${JSON.stringify(
-        object,
-        null,
-        2
-      )}`
+    if (object) {
+      const json = JSON.stringify(object, null, 2)
+      if (type) {
+        super(`Property Not Provided while compressing ${type}:\n${json}`)
+      } else {
+        super(`Property Not Provided while compressing object:\n${json}`)
+      }
     } else {
-      message = `Property Not Provided while compressing object`
+      super(`Property Not Provided while compressing object`)
     }
-
-    super(message)
   }
 }
 
-export class ERROR_DECODING_MESSAGE extends SDKError {
-  constructor() {
-    super('Error decoding message')
-  }
-}
-export class ERROR_PARSING_MESSAGE extends SDKError {
-  constructor() {
-    super('Error parsing message body')
-  }
-}
+export class DecodingMessageError extends SDKError {}
 
-export class ERROR_TIMEOUT extends SDKError {
-  constructor() {
-    super('operation timed out')
-  }
-}
+export class ParsingMessageError extends SDKError {}
 
-export class ERROR_INVALID_PROOF_FOR_STATEMENT extends SDKError {
+export class TimeoutError extends SDKError {}
+
+export class InvalidProofForStatementError extends SDKError {
   constructor(statement: string) {
-    super(`Proof could not be verified for statement\n${statement}`)
+    super(`Proof could not be verified for statement:\n${statement}`)
   }
 }
 
-export class ERROR_NO_PROOF_FOR_STATEMENT extends SDKError {
+export class NoProofForStatementError extends SDKError {
   constructor(statement: string) {
-    super(`No matching proof found for statement\n${statement}`)
+    super(`No matching proof found for statement:\n${statement}`)
   }
 }
 
-export class ERROR_CODEC_MISMATCH extends SDKError {}
+export class CodecMismatchError extends SDKError {}

--- a/packages/utils/src/json-schema/dereference.ts
+++ b/packages/utils/src/json-schema/dereference.ts
@@ -100,7 +100,7 @@ export function dereference(
   // compute the schema's URI and add it to the mapping.
   const schemaURI = baseURI.href + (basePointer ? '#' + basePointer : '')
   if (lookup[schemaURI] !== undefined) {
-    throw new Error(`Duplicate schema URI "${schemaURI}".`)
+    throw new Error(`Duplicate schema URI "${schemaURI}"`)
   }
   lookup[schemaURI] = schema
 

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -42,7 +42,7 @@ export function fromCredentialIRI(credentialId: string): HexString {
     : credentialId
   if (!isHex(hexString))
     throw new Error(
-      'credential id is not a valid identifier (could not extract base16 / hex encoded string)'
+      'Credential id is not a valid identifier (could not extract base16 / hex encoded string)'
     )
   return hexString
 }
@@ -58,7 +58,7 @@ export function toCredentialIRI(rootHash: string): string {
     return rootHash
   }
   if (!isHex(rootHash))
-    throw new Error('root hash is not a base16 / hex encoded string)')
+    throw new Error('Root hash is not a base16 / hex encoded string)')
   return KILT_CREDENTIAL_IRI_PREFIX + rootHash
 }
 

--- a/packages/vc-export/src/presentationUtils.ts
+++ b/packages/vc-export/src/presentationUtils.ts
@@ -47,7 +47,7 @@ export async function updateCredentialDigestProof(
   )
   if (statements.length < 1)
     throw new Error(
-      `no statements extracted from ${JSON.stringify(
+      `No statements extracted from ${JSON.stringify(
         credential.credentialSubject
       )}`
     )
@@ -56,7 +56,7 @@ export async function updateCredentialDigestProof(
     if (Object.keys(proof.nonces).includes(digest)) {
       claimNonces[digest] = proof.nonces[digest]
     } else {
-      throw new Error(`nonce missing for ${stmt}`)
+      throw new Error(`Nonce missing for "${stmt}"`)
     }
   })
 
@@ -81,7 +81,7 @@ export async function removeProperties(
   const unknownProps = whitelist.filter((prop) => !propertyNames.includes(prop))
   if (unknownProps.length > 0) {
     throw new Error(
-      `whitelisted properties ${unknownProps} do not exist on this credential`
+      `Whitelisted properties "${unknownProps}" do not exist on this credential`
     )
   }
   // copy credential
@@ -99,7 +99,7 @@ export async function removeProperties(
   )
   if (oldClaimsProof.length !== 1)
     throw new Error(
-      `expected exactly one proof of type ${KILT_CREDENTIAL_DIGEST_PROOF_TYPE}`
+      `Expected exactly one proof of type "${KILT_CREDENTIAL_DIGEST_PROOF_TYPE}"`
     )
   proofs = proofs.filter((p) => p.type !== KILT_CREDENTIAL_DIGEST_PROOF_TYPE)
   // compute new (reduced) proof

--- a/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltAttestedSuite.ts
@@ -65,9 +65,9 @@ export class KiltAttestedSuite extends KiltAbstractSuite {
     try {
       const { document, proof } = options
       if (!document || typeof document !== 'object')
-        throw new TypeError('document must be a JsonLd object')
+        throw new TypeError('Document must be a JsonLd object')
       if (!proof || typeof proof !== 'object')
-        throw new TypeError('proof must be a JsonLd object')
+        throw new TypeError('Proof must be a JsonLd object')
       const compactedDoc = await this.compactDoc(document, options)
       const compactedProof = await this.compactProof<AttestedProof>(
         proof,

--- a/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltIntegritySuite.ts
@@ -40,9 +40,9 @@ export class KiltDisclosureSuite extends KiltAbstractSuite {
     try {
       const { document, proof } = options
       if (!document || typeof document !== 'object')
-        throw new TypeError('document must be a JsonLd object')
+        throw new TypeError('Document must be a JsonLd object')
       if (!proof || typeof proof !== 'object')
-        throw new TypeError('proof must be a JsonLd object')
+        throw new TypeError('Proof must be a JsonLd object')
       const compactedDoc = await this.compactDoc(document, options)
       const compactedProof = await this.compactProof<CredentialDigestProof>(
         proof,

--- a/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.ts
+++ b/packages/vc-export/src/vc-js/suites/KiltSignatureSuite.ts
@@ -35,9 +35,9 @@ export class KiltSignatureSuite extends KiltAbstractSuite {
     try {
       const { document, proof, documentLoader } = options
       if (!document || typeof document !== 'object')
-        throw new TypeError('document must be a JsonLd object')
+        throw new TypeError('Document must be a JsonLd object')
       if (!proof || typeof proof !== 'object')
-        throw new TypeError('proof must be a JsonLd object')
+        throw new TypeError('Proof must be a JsonLd object')
       const compactedDoc = await this.compactDoc(document, options)
       const compactedProof = await this.compactProof<SelfSignedProof>(
         proof,

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -218,8 +218,8 @@ async function runAll() {
     testDid.uri !==
     `did:kilt:light:01${address}:z1Ac9CMtYCTRWjetJfJqJoV7FcPDD9nHPHDHry7t3KZmvYe1HQP1tgnBuoG3enuGaowpF8V88sCxytDPDy6ZxhW`
   ) {
-    throw new Error('Did Test Unsuccessful')
-  } else console.info(`light did successfully created`)
+    throw new Error('DID Test Unsuccessful')
+  } else console.info(`light DID successfully created`)
 
   // Chain Did workflow -> creation & deletion
   console.log('DID workflow started')
@@ -241,9 +241,9 @@ async function runAll() {
     !resolved.metadata.deactivated &&
     resolved.details?.uri === fullDid.uri
   ) {
-    console.info('Did matches!')
+    console.info('DID matches')
   } else {
-    throw new Error('Dids not matching!')
+    throw new Error('DIDs do not match')
   }
 
   const extrinsic = await Did.Chain.getDeleteDidExtrinsic(
@@ -261,9 +261,9 @@ async function runAll() {
 
   const resolvedAgain = await Did.resolveDoc(fullDid.uri)
   if (resolvedAgain?.metadata.deactivated) {
-    console.info('Did successfully deleted!')
+    console.info('DID successfully deleted')
   } else {
-    throw new Error('Did not successfully deleted')
+    throw new Error('DID was not deleted')
   }
 
   // CType workflow
@@ -296,9 +296,9 @@ async function runAll() {
 
   const stored = await CType.verifyStored(DriversLicense)
   if (stored) {
-    console.info('CType successfully stored onchain!')
+    console.info('CType successfully stored on chain')
   } else {
-    throw new Error('ctype not stored!')
+    throw new Error('CType not stored')
   }
 
   const result = await CType.verifyOwner({
@@ -306,9 +306,9 @@ async function runAll() {
     owner: alice.uri,
   })
   if (result) {
-    console.info('owner verified')
+    console.info('Owner verified')
   } else {
-    throw new Error('ctype owner does not match ctype creator did')
+    throw new Error('CType owner does not match ctype creator DID')
   }
 
   // Attestation workflow
@@ -327,7 +327,7 @@ async function runAll() {
     bob.authenticationKey.id
   )
   if (!RequestForAttestation.isIRequestForAttestation(request))
-    throw new Error('Not a valid Request!')
+    throw new Error('Not a valid Request')
   else {
     if (RequestForAttestation.verifyDataIntegrity(request))
       console.info('Req4Att data verified')
@@ -363,13 +363,13 @@ async function runAll() {
     alice
   )
   if (JSON.stringify(message.body) !== JSON.stringify(decryptedMessage.body)) {
-    throw new Error('original and decrypted message are not the same')
+    throw new Error('Original and decrypted message are not the same')
   }
 
   const attestation = Attestation.fromRequestAndDid(request, alice.uri)
   const credential = Credential.fromRequestAndAttestation(request, attestation)
   if (Credential.verifyDataIntegrity(credential))
-    console.info('Attested Claim Data verified!')
+    console.info('Attested Claim Data verified')
   else throw new Error('Attested Claim data not verifiable')
 
   const txAtt = await Attestation.getStoreTx(attestation)
@@ -382,9 +382,9 @@ async function runAll() {
     resolveOn: Blockchain.IS_IN_BLOCK,
   })
   if (await Credential.verify(credential)) {
-    console.info('Attested Claim verified with chain.')
+    console.info('Attested Claim verified with chain')
   } else {
-    throw new Error('attested Claim not verifiable with chain')
+    throw new Error('Attested Claim not verifiable with chain')
   }
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

Errors in the JavaScript ecosystem have TitleCase names and `Error` as a suffix. The first letter of the error message is capitalized, and messages usually do not end with a dot. The cited values are put in quotes. Errors are instantiated using the `new` keyword.

As a follow-up, I suggest dropping the common namespace for errors and import them directly. This will also allow moving module-specific errors into the modules.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
