### PR TITLE
chore: use esnext as target & lib in tsconfig

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "es2017",
-    "lib": ["es6"],
+    "target": "ESNext",
+    "lib": ["ESNext"],
     "sourceMap": false,
     "strict": true,
     "allowJs": true,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2088
This PR changes target and lib for tsconfig to esnext to allow us to use new javascript features (e.g. Error causes)

## How to test:
- Tests should run through
- Bundle tests have to work

## Checklist:

- [ ] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
