### PR TITLE
feat: clarity in Credential.verify

### DIFF
--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -396,13 +396,17 @@ export async function verify(
     if (!isSchemaValid) throw new SDKErrors.CredentialUnverifiableError()
   }
 
-  if (challenge || !allowUnsigned) {
-    const isSignatureCorrect = await verifySignature(credential, {
+  let isSignatureCorrect = false
+  if (challenge || credential.claimerSignature) {
+    isSignatureCorrect = await verifySignature(credential, {
       challenge,
       resolver,
     })
-    if (!isSignatureCorrect) throw new SDKErrors.SignatureUnverifiableError()
+  } else if (allowUnsigned) {
+    isSignatureCorrect = true
   }
+
+  if (!isSignatureCorrect) throw new SDKErrors.SignatureUnverifiableError()
 }
 
 /**

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -393,20 +393,26 @@ export async function verify(
 
   if (ctype) {
     const isSchemaValid = verifyAgainstCType(credential, ctype)
-    if (!isSchemaValid) throw new SDKErrors.CredentialUnverifiableError()
+    if (!isSchemaValid)
+      throw new SDKErrors.CredentialUnverifiableError(
+        'CType verification failed'
+      )
   }
 
-  let isSignatureCorrect = false
   if (challenge || credential.claimerSignature) {
-    isSignatureCorrect = await verifySignature(credential, {
+    const isSignatureCorrect = await verifySignature(credential, {
       challenge,
       resolver,
     })
-  } else if (allowUnsigned) {
-    isSignatureCorrect = true
+    if (!isSignatureCorrect)
+      throw new SDKErrors.CredentialUnverifiableError(
+        'Signature not verifiable'
+      )
+  } else if (!allowUnsigned) {
+    throw new SDKErrors.CredentialUnverifiableError(
+      'Signature required, but not provided'
+    )
   }
-
-  if (!isSignatureCorrect) throw new SDKErrors.SignatureUnverifiableError()
 }
 
 /**


### PR DESCRIPTION
This PR adds clarity to the Credential.verify checks and always checks signature, if it is present.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
