### PR TITLE
fix: testcontainer startup await once and for all

### DIFF
--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -33,15 +33,17 @@ import { connect, init } from '../kilt'
 export const EXISTENTIAL_DEPOSIT = new BN(10 ** 13)
 const ENDOWMENT = EXISTENTIAL_DEPOSIT.muln(10000)
 
+const WS_PORT = 9944
+
 async function getStartedTestContainer(): Promise<StartedTestContainer> {
   try {
     const image =
       process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/mashnet-node'
     console.log(`using testcontainer with image ${image}`)
     const testcontainer = new GenericContainer(image)
-      .withCmd(['--dev', '--ws-port', '9944', '--ws-external'])
-      .withExposedPorts(9944)
-      .withWaitStrategy(Wait.forLogMessage(/idle/i))
+      .withCmd(['--dev', `--ws-port=${WS_PORT}`, '--ws-external'])
+      .withExposedPorts(WS_PORT)
+      .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
     const started = await testcontainer.start()
     return started
   } catch (error) {

--- a/tests/bundle.spec.ts
+++ b/tests/bundle.spec.ts
@@ -20,14 +20,16 @@ declare global {
 
 let testcontainer: StartedTestContainer
 
+const WS_PORT = 9944
+
 test.beforeAll(async () => {
   // start dev node with testcontainers
   testcontainer = await new GenericContainer(
     process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/mashnet-node:latest'
   )
-    .withCmd(['--dev', '--ws-port', '9944', '--ws-external'])
-    .withExposedPorts({ container: 9944, host: 9944 })
-    .withWaitStrategy(Wait.forLogMessage('Idle'))
+    .withCmd(['--dev', `--ws-port=${WS_PORT}`, '--ws-external'])
+    .withExposedPorts({ container: WS_PORT, host: WS_PORT })
+    .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
     .start()
 })
 


### PR DESCRIPTION
## fixes all those broken workflows

Don't known why I didn't do that already, but if we're searching the logs for the specified ws port to determine if an image is ready, this should fix all broken waits once and for all.

## How to test:
Test integration & bundle with a bunch of different images.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
