### PR TITLE
feat: use finalization defaults

### DIFF
--- a/packages/core/src/__integrationtests__/Deposit.spec.ts
+++ b/packages/core/src/__integrationtests__/Deposit.spec.ts
@@ -28,7 +28,6 @@ import {
   SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import { DecoderUtils } from '@kiltprotocol/utils'
-import { Blockchain } from '@kiltprotocol/chain-helpers'
 import { BN } from '@polkadot/util'
 import {
   devFaucet,
@@ -68,7 +67,7 @@ async function checkDeleteFullDid(
   const didResult = await Did.Chain.queryDetails(fullDid.identifier)
   const didDeposit = didResult!.deposit
 
-  await submitExtrinsic(tx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(tx, identity)
 
   const balanceAfterDeleting = await Balance.getBalances(identity.address)
 
@@ -94,7 +93,7 @@ async function checkReclaimFullDid(
   const didResult = await Did.Chain.queryDetails(fullDid.identifier)
   const didDeposit = didResult!.deposit
 
-  await submitExtrinsic(tx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(tx, identity)
 
   const balanceAfterRevoking = await Balance.getBalances(identity.address)
 
@@ -119,7 +118,7 @@ async function checkRemoveFullDidAttestation(
     identity.address
   )
 
-  await submitExtrinsic(authorizedTx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(authorizedTx, identity)
 
   const attestationResult = await queryRaw(attestation.claimHash)
   DecoderUtils.assertCodecIsType(attestationResult, [
@@ -141,7 +140,7 @@ async function checkRemoveFullDidAttestation(
     identity.address
   )
 
-  await submitExtrinsic(authorizedTx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(authorizedTx, identity)
 
   const balanceAfterRemoving = await Balance.getBalances(identity.address)
 
@@ -166,7 +165,7 @@ async function checkReclaimFullDidAttestation(
     identity.address
   )
 
-  await submitExtrinsic(authorizedTx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(authorizedTx, identity)
 
   const balanceBeforeReclaiming = await Balance.getBalances(identity.address)
   attestation = Attestation.fromCredentialAndDid(credential, fullDid.uri)
@@ -182,7 +181,7 @@ async function checkReclaimFullDidAttestation(
     ? attestationResult.unwrap().deposit.amount.toBn()
     : new BN(0)
 
-  await submitExtrinsic(tx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(tx, identity)
 
   const balanceAfterDeleting = await Balance.getBalances(identity.address)
 
@@ -207,7 +206,7 @@ async function checkDeletedDidReclaimAttestation(
     identity.address
   )
 
-  await submitExtrinsic(authorizedTx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(authorizedTx, identity)
 
   storedEndpointsCount = await Did.Chain.queryEndpointsCounts(
     fullDid.identifier
@@ -218,11 +217,11 @@ async function checkDeletedDidReclaimAttestation(
   const deleteDid = await Did.Chain.getDeleteDidExtrinsic(storedEndpointsCount)
   tx = await Did.authorizeExtrinsic(fullDid, deleteDid, sign, identity.address)
 
-  await submitExtrinsic(tx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(tx, identity)
 
   tx = await Attestation.getReclaimDepositTx(attestation.claimHash)
 
-  await submitExtrinsic(tx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(tx, identity)
 }
 
 async function checkWeb3Deposit(
@@ -241,7 +240,7 @@ async function checkWeb3Deposit(
     sign,
     identity.address
   )
-  await submitExtrinsic(didAuthorizedTx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(didAuthorizedTx, identity)
   const balanceAfterClaiming = await Balance.getBalances(identity.address)
   if (
     !balanceAfterClaiming.reserved
@@ -258,7 +257,7 @@ async function checkWeb3Deposit(
     sign,
     identity.address
   )
-  await submitExtrinsic(didAuthorizedTx, identity, Blockchain.IS_FINALIZED)
+  await submitExtrinsic(didAuthorizedTx, identity)
   const balanceAfterReleasing = await Balance.getBalances(identity.address)
 
   if (!balanceAfterReleasing.reserved.eq(balanceBeforeClaiming.reserved)) {
@@ -298,7 +297,7 @@ beforeAll(async () => {
       attesterKey.sign,
       devFaucet.address
     )
-    await submitExtrinsic(extrinsic, devFaucet, Blockchain.IS_IN_BLOCK)
+    await submitExtrinsic(extrinsic, devFaucet)
   }
 
   const rawClaim = {

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -16,7 +16,6 @@ import type {
   KeyringPair,
   KiltKeyringPair,
 } from '@kiltprotocol/types'
-import { Blockchain } from '@kiltprotocol/chain-helpers'
 import {
   createFullDidFromSeed,
   KeyTool,
@@ -80,7 +79,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       bobbyBroke.address
     )
 
-    const p = submitExtrinsic(authorizedTx, bobbyBroke, Blockchain.IS_IN_BLOCK)
+    const p = submitExtrinsic(authorizedTx, bobbyBroke)
 
     await expect(p).rejects.toThrowError('Inability to pay some fees')
   }, 30_000)
@@ -94,7 +93,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       paymentAccount.address
     )
 
-    await submitExtrinsic(authorizedTx, paymentAccount, Blockchain.IS_IN_BLOCK)
+    await submitExtrinsic(authorizedTx, paymentAccount)
   }, 30_000)
 
   it('should be possible to lookup the DID identifier with the given nick', async () => {
@@ -128,11 +127,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       paymentAccount.address
     )
 
-    const p = submitExtrinsic(
-      authorizedTx,
-      paymentAccount,
-      Blockchain.IS_IN_BLOCK
-    )
+    const p = submitExtrinsic(authorizedTx, paymentAccount)
 
     await expect(p).rejects.toMatchObject({
       section: 'web3Names',
@@ -149,11 +144,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       paymentAccount.address
     )
 
-    const p = submitExtrinsic(
-      authorizedTx,
-      paymentAccount,
-      Blockchain.IS_IN_BLOCK
-    )
+    const p = submitExtrinsic(authorizedTx, paymentAccount)
 
     await expect(p).rejects.toMatchObject({
       section: 'web3Names',
@@ -163,7 +154,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should not be possible to remove a w3n by another payment account', async () => {
     const tx = await Web3Names.getReclaimDepositTx(nick)
-    const p = submitExtrinsic(tx, otherPaymentAccount, Blockchain.IS_IN_BLOCK)
+    const p = submitExtrinsic(tx, otherPaymentAccount)
     await expect(p).rejects.toMatchObject({
       section: 'web3Names',
       name: 'NotAuthorized',
@@ -172,7 +163,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should be possible to remove a w3n by the payment account', async () => {
     const tx = await Web3Names.getReclaimDepositTx(nick)
-    await submitExtrinsic(tx, paymentAccount, Blockchain.IS_IN_BLOCK)
+    await submitExtrinsic(tx, paymentAccount)
   }, 30_000)
 
   it('should be possible to remove a w3n by the owner did', async () => {
@@ -184,11 +175,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       w3nCreatorKey.sign,
       paymentAccount.address
     )
-    await submitExtrinsic(
-      prepareAuthorizedTx,
-      paymentAccount,
-      Blockchain.IS_IN_BLOCK
-    )
+    await submitExtrinsic(prepareAuthorizedTx, paymentAccount)
 
     const tx = await Web3Names.getReleaseByOwnerTx()
     const authorizedTx = await Did.authorizeExtrinsic(
@@ -197,7 +184,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
       w3nCreatorKey.sign,
       paymentAccount.address
     )
-    await submitExtrinsic(authorizedTx, paymentAccount, Blockchain.IS_IN_BLOCK)
+    await submitExtrinsic(authorizedTx, paymentAccount)
   }, 40_000)
 })
 

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -21,7 +21,6 @@ import type {
   SignCallback,
   SigningAlgorithms,
   SigningData,
-  SubmittableExtrinsic,
 } from '@kiltprotocol/types'
 import type { KeypairType } from '@polkadot/util-crypto/types'
 
@@ -39,13 +38,7 @@ const {
   BalanceUtils,
 } = kilt
 
-function getDefaultMigrationHandler(submitter: KeyringPair) {
-  return async (e: SubmittableExtrinsic) => {
-    await Blockchain.signAndSubmitTx(e, submitter, {
-      resolveOn: Blockchain.IS_IN_BLOCK,
-    })
-  }
-}
+const resolveOn = Blockchain.IS_IN_BLOCK
 
 function makeSignCallback(keypair: KeyringPair): SignCallback {
   return async function sign<A extends SigningAlgorithms>({
@@ -142,8 +135,8 @@ async function createFullDidFromKeypair(
   const sign = makeSignCallback(keypair)
 
   const creationTx = await Did.Chain.getStoreTx(lightDid, payer.address, sign)
+  await Blockchain.signAndSubmitTx(creationTx, payer, { resolveOn })
 
-  await getDefaultMigrationHandler(payer)(creationTx)
   const fullDid = await Did.query(Did.Utils.getFullDidUri(lightDid.uri))
   if (!fullDid) throw new Error('Cannot query created DID')
 
@@ -158,9 +151,7 @@ async function createFullDidFromKeypair(
     sign,
     submitter: payer.address,
   })
-  await Blockchain.signAndSubmitTx(extrinsic, payer, {
-    resolveOn: Blockchain.IS_IN_BLOCK,
-  })
+  await Blockchain.signAndSubmitTx(extrinsic, payer, { resolveOn })
 
   const updatedFullDid = await Did.query(fullDid.uri)
   if (!updatedFullDid) throw new Error('Could not update DID keys')
@@ -236,9 +227,7 @@ async function runAll() {
     devFaucet.address,
     sign
   )
-  await Blockchain.signAndSubmitTx(createTx, devFaucet, {
-    resolveOn: Blockchain.IS_IN_BLOCK,
-  })
+  await Blockchain.signAndSubmitTx(createTx, devFaucet, { resolveOn })
   const fullDid = await Did.query(
     Did.Utils.getFullDidUriFromKey(authentication[0])
   )
@@ -266,9 +255,7 @@ async function runAll() {
     devFaucet.address
   )
 
-  await Blockchain.signAndSubmitTx(deleteTx, devFaucet, {
-    resolveOn: Blockchain.IS_IN_BLOCK,
-  })
+  await Blockchain.signAndSubmitTx(deleteTx, devFaucet, { resolveOn })
 
   const resolvedAgain = await Did.resolveDoc(fullDid.uri)
   if (resolvedAgain?.metadata.deactivated) {
@@ -302,9 +289,7 @@ async function runAll() {
     devFaucet.address
   )
 
-  await Blockchain.signAndSubmitTx(authorizedTx, devFaucet, {
-    resolveOn: Blockchain.IS_IN_BLOCK,
-  })
+  await Blockchain.signAndSubmitTx(authorizedTx, devFaucet, { resolveOn })
 
   const stored = await CType.verifyStored(DriversLicense)
   if (stored) {
@@ -385,9 +370,7 @@ async function runAll() {
     aliceSign,
     devFaucet.address
   )
-  await Blockchain.signAndSubmitTx(authorizedAttTx, devFaucet, {
-    resolveOn: Blockchain.IS_IN_BLOCK,
-  })
+  await Blockchain.signAndSubmitTx(authorizedAttTx, devFaucet, { resolveOn })
   if (await Attestation.checkValidity(credential.rootHash)) {
     console.info('Attestation verified with chain')
   } else {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

We already have reasonable defaults for when to resolve the submit transaction promise. I removed the boilerplate-y over-specification of those.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
