### PR TITLE
feat!: drop keySelection

### DIFF
--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -48,9 +48,6 @@ const FULL_KILT_DID_REGEX =
 const LIGHT_KILT_DID_REGEX =
   /^did:kilt:light:(?<authKeyType>[0-9]{2})(?<address>4[1-9a-km-zA-HJ-NP-Z]{47,48})(:(?<encodedDetails>.+?))?(?<fragment>#[^#\n]+)?$/
 
-export const defaultKeySelectionCallback = <T>(keys: T[]): Promise<T | null> =>
-  Promise.resolve(keys[0] || null)
-
 function isKiltAddress(input: string): input is KiltAddress {
   return checkAddress(input, ss58Format)[0]
 }

--- a/packages/types/src/DidDetails.ts
+++ b/packages/types/src/DidDetails.ts
@@ -175,5 +175,3 @@ export interface DidDetails {
 
   service?: DidServiceEndpoint[]
 }
-
-export type DidKeySelectionCallback<T> = (keys: T[]) => Promise<T | null>


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

Looks like we only ever choose from one key, let’s remove the keySelection for now to avoid confusion.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
