### PR TITLE
fix: augmentation hacks

### DIFF
--- a/packages/augment-api/package.json
+++ b/packages/augment-api/package.json
@@ -10,11 +10,6 @@
       "types": "./lib/cjs/index.d.ts",
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
-    },
-    "./augment": {
-      "types": "./lib/cjs/augment.d.ts",
-      "import": "./lib/esm/augment.js",
-      "require": "./lib/cjs/augment.js"
     }
   },
   "files": [

--- a/packages/augment-api/package.json
+++ b/packages/augment-api/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@polkadot/typegen": "^9.0.0",
     "@types/websocket": "^1.0.0",
+    "glob": "^7.1.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",

--- a/packages/augment-api/scripts/fixTypes.mjs
+++ b/packages/augment-api/scripts/fixTypes.mjs
@@ -6,12 +6,28 @@
  */
 
 import { readFile, writeFile } from 'fs/promises'
-
-const path = 'src/interfaces/augment-api-tx.ts'
+import glob from 'glob'
 ;(async () => {
+  const path = 'src/interfaces/augment-api-tx.ts'
   const source = await readFile(path, 'utf8')
   const fixed = source.replace(/\b(Ed25519|Sr25519|X25519|Ecdsa)\b/g, (match) =>
     match.toLowerCase()
   )
   await writeFile(path, fixed, 'utf8')
 })()
+
+const regex = /^(ex|im)port .+ from '\.[^\.;']+(?=';$)/gm
+glob('./src/**/*.ts', async (err, matches) => {
+  if (err) throw err
+  matches.forEach(async (path) => {
+    const source = await readFile(path, 'utf8')
+    let matched = false
+    const fixed = source.replace(regex, (match) => {
+      matched = true
+      return match + '.js'
+    })
+    if (!matched) return
+    console.log(`adding .js extention to import in ${path}`)
+    await writeFile(path, fixed, 'utf8')
+  })
+})

--- a/packages/augment-api/src/interfaces/extraDefs/index.ts
+++ b/packages/augment-api/src/interfaces/extraDefs/index.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export * from './types';
+export * from './types.js';

--- a/packages/augment-api/src/interfaces/index.ts
+++ b/packages/augment-api/src/interfaces/index.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export * from './types';
+export * from './types.js';

--- a/packages/augment-api/src/interfaces/types.ts
+++ b/packages/augment-api/src/interfaces/types.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export * from './extraDefs/types';
+export * from './extraDefs/types.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,7 @@ __metadata:
   dependencies:
     "@polkadot/typegen": ^9.0.0
     "@types/websocket": ^1.0.0
+    glob: ^7.1.1
     rimraf: ^3.0.2
     ts-node: ^10.4.0
     typescript: ^4.5.4


### PR DESCRIPTION
## no ticket

For es module imports every import needs a file extension, which we generally check with an eslint rule.
We don't for autogenerated files in the augment-api package, however, because these are marked with eslint-disable.
This has resulted in import issues.

This fix runs a regex-based search-replace to fix any affected import in the directory where autogenerated files are placed.

## How to test:

All imports should now have an extension.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
