### PR TITLE
feat: align from *Extrinsic to *Tx method names

### DIFF
--- a/packages/core/src/__integrationtests__/AccountLinking.spec.ts
+++ b/packages/core/src/__integrationtests__/AccountLinking.spec.ts
@@ -29,7 +29,7 @@ import {
   createEndowedTestAccount,
   fundAccount,
   initializeApi,
-  submitExtrinsic,
+  submitTx,
 } from './utils'
 import { disconnect } from '../kilt'
 
@@ -80,7 +80,7 @@ describe('When there is an on-chain DID', () => {
       ).toBe(true)
 
       const associateSenderTx = api.tx.didLookup.associateSender()
-      const signedTx = await Did.authorizeExtrinsic(
+      const signedTx = await Did.authorizeTx(
         did.uri,
         associateSenderTx,
         didKey.getSignCallback(did),
@@ -89,7 +89,7 @@ describe('When there is an on-chain DID', () => {
       const balanceBefore = (
         await api.query.system.account(paymentAccount.address)
       ).data
-      await submitExtrinsic(signedTx, paymentAccount)
+      await submitTx(signedTx, paymentAccount)
 
       // Check that the deposit has been taken from the sender's balance.
       const balanceAfter = (
@@ -123,7 +123,7 @@ describe('When there is an on-chain DID', () => {
     }, 30_000)
     it('should be possible to associate the tx sender to a new DID', async () => {
       const associateSenderTx = api.tx.didLookup.associateSender()
-      const signedTx = await Did.authorizeExtrinsic(
+      const signedTx = await Did.authorizeTx(
         newDid.uri,
         associateSenderTx,
         newDidKey.getSignCallback(newDid),
@@ -132,7 +132,7 @@ describe('When there is an on-chain DID', () => {
       const balanceBefore = (
         await api.query.system.account(paymentAccount.address)
       ).data
-      await submitExtrinsic(signedTx, paymentAccount)
+      await submitTx(signedTx, paymentAccount)
 
       // Reserve should not change when replacing the link
       const balanceAfter = (
@@ -180,7 +180,7 @@ describe('When there is an on-chain DID', () => {
       const balanceBefore = (
         await api.query.system.account(paymentAccount.address)
       ).data
-      await submitExtrinsic(removeSenderTx, paymentAccount)
+      await submitTx(removeSenderTx, paymentAccount)
 
       // Check that the deposit has been returned to the sender's balance.
       const balanceAfter = (
@@ -235,7 +235,7 @@ describe('When there is an on-chain DID', () => {
           did.uri,
           async (payload) => keypair.sign(payload, { withType: false })
         )
-        const signedTx = await Did.authorizeExtrinsic(
+        const signedTx = await Did.authorizeTx(
           did.uri,
           api.tx.didLookup.associateAccount(...args),
           didKey.getSignCallback(did),
@@ -244,7 +244,7 @@ describe('When there is an on-chain DID', () => {
         const balanceBefore = (
           await api.query.system.account(paymentAccount.address)
         ).data
-        await submitExtrinsic(signedTx, paymentAccount)
+        await submitTx(signedTx, paymentAccount)
 
         // Check that the deposit has been taken from the sender's balance.
         const balanceAfter = (
@@ -290,7 +290,7 @@ describe('When there is an on-chain DID', () => {
           newDid.uri,
           async (payload) => keypair.sign(payload, { withType: false })
         )
-        const signedTx = await Did.authorizeExtrinsic(
+        const signedTx = await Did.authorizeTx(
           newDid.uri,
           api.tx.didLookup.associateAccount(...args),
           newDidKey.getSignCallback(newDid),
@@ -299,7 +299,7 @@ describe('When there is an on-chain DID', () => {
         const balanceBefore = (
           await api.query.system.account(paymentAccount.address)
         ).data
-        await submitExtrinsic(signedTx, paymentAccount)
+        await submitTx(signedTx, paymentAccount)
 
         // Reserve should not change when replacing the link
         const balanceAfter = (
@@ -358,7 +358,7 @@ describe('When there is an on-chain DID', () => {
       it('should be possible for the DID to remove the link', async () => {
         const removeLinkTx =
           api.tx.didLookup.removeAccountAssociation(keypairChain)
-        const signedTx = await Did.authorizeExtrinsic(
+        const signedTx = await Did.authorizeTx(
           newDid.uri,
           removeLinkTx,
           newDidKey.getSignCallback(newDid),
@@ -367,7 +367,7 @@ describe('When there is an on-chain DID', () => {
         const balanceBefore = (
           await api.query.system.account(paymentAccount.address)
         ).data
-        await submitExtrinsic(signedTx, paymentAccount)
+        await submitTx(signedTx, paymentAccount)
 
         // Check that the deposit has been returned to the sender's balance.
         const balanceAfter = (
@@ -426,7 +426,7 @@ describe('When there is an on-chain DID', () => {
         did.uri,
         async (payload) => genericAccount.sign(payload, { withType: true })
       )
-      const signedTx = await Did.authorizeExtrinsic(
+      const signedTx = await Did.authorizeTx(
         did.uri,
         api.tx.didLookup.associateAccount(...args),
         didKey.getSignCallback(did),
@@ -435,7 +435,7 @@ describe('When there is an on-chain DID', () => {
       const balanceBefore = (
         await api.query.system.account(paymentAccount.address)
       ).data
-      await submitExtrinsic(signedTx, paymentAccount)
+      await submitTx(signedTx, paymentAccount)
 
       // Check that the deposit has been taken from the sender's balance.
       const balanceAfter = (
@@ -481,13 +481,13 @@ describe('When there is an on-chain DID', () => {
 
     it('should be possible to add a Web3 name for the linked DID and retrieve it starting from the linked account', async () => {
       const web3NameClaimTx = api.tx.web3Names.claim('test-name')
-      const signedTx = await Did.authorizeExtrinsic(
+      const signedTx = await Did.authorizeTx(
         did.uri,
         web3NameClaimTx,
         didKey.getSignCallback(did),
         paymentAccount.address
       )
-      await submitExtrinsic(signedTx, paymentAccount)
+      await submitTx(signedTx, paymentAccount)
 
       // Check that the Web3 name has been linked to the DID
       const { owner } = Did.web3NameOwnerFromChain(
@@ -506,7 +506,7 @@ describe('When there is an on-chain DID', () => {
       const balanceBefore = (
         await api.query.system.account(paymentAccount.address)
       ).data
-      await submitExtrinsic(reclaimDepositTx, genericAccount)
+      await submitTx(reclaimDepositTx, genericAccount)
 
       // Check that the deposit has been returned to the sender's balance.
       const balanceAfter = (

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -33,7 +33,7 @@ import {
   driversLicenseCType,
   initializeApi,
   isCtypeOnChain,
-  submitExtrinsic,
+  submitTx,
 } from './utils'
 
 let tokenHolder: KiltKeyringPair
@@ -81,15 +81,13 @@ describe('handling attestations that do not exist', () => {
 
   it('Attestation.getRevokeTx', async () => {
     const draft = api.tx.attestation.revoke(claimHash, null)
-    const authorized = await Did.authorizeExtrinsic(
+    const authorized = await Did.authorizeTx(
       attester.uri,
       draft,
       attesterKey.getSignCallback(attester),
       tokenHolder.address
     )
-    await expect(
-      submitExtrinsic(authorized, tokenHolder)
-    ).rejects.toMatchObject({
+    await expect(submitTx(authorized, tokenHolder)).rejects.toMatchObject({
       section: 'attestation',
       name: 'AttestationNotFound',
     })
@@ -97,15 +95,13 @@ describe('handling attestations that do not exist', () => {
 
   it('Attestation.getRemoveTx', async () => {
     const draft = api.tx.attestation.remove(claimHash, null)
-    const authorized = await Did.authorizeExtrinsic(
+    const authorized = await Did.authorizeTx(
       attester.uri,
       draft,
       attesterKey.getSignCallback(attester),
       tokenHolder.address
     )
-    await expect(
-      submitExtrinsic(authorized, tokenHolder)
-    ).rejects.toMatchObject({
+    await expect(submitTx(authorized, tokenHolder)).rejects.toMatchObject({
       section: 'attestation',
       name: 'AttestationNotFound',
     })
@@ -116,13 +112,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   beforeAll(async () => {
     const ctypeExists = await isCtypeOnChain(driversLicenseCType)
     if (ctypeExists) return
-    const tx = await Did.authorizeExtrinsic(
+    const tx = await Did.authorizeTx(
       attester.uri,
       api.tx.ctype.add(CType.toChain(driversLicenseCType)),
       attesterKey.getSignCallback(attester),
       tokenHolder.address
     )
-    await submitExtrinsic(tx, tokenHolder)
+    await submitTx(tx, tokenHolder)
   }, 60_000)
 
   it('should be possible to make a claim', async () => {
@@ -173,13 +169,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attestation.cTypeHash,
       null
     )
-    const authorizedStoreTx = await Did.authorizeExtrinsic(
+    const authorizedStoreTx = await Did.authorizeTx(
       attester.uri,
       storeTx,
       attesterKey.getSignCallback(attester),
       tokenHolder.address
     )
-    await submitExtrinsic(authorizedStoreTx, tokenHolder)
+    await submitTx(authorizedStoreTx, tokenHolder)
     const storedAttestation = Attestation.fromChain(
       await api.query.attestation.attestations(attestation.claimHash),
       attestation.claimHash
@@ -189,7 +185,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     // Claim the deposit back by submitting the reclaimDeposit extrinsic with the deposit payer's account.
     const reclaimTx = api.tx.attestation.reclaimDeposit(attestation.claimHash)
-    await submitExtrinsic(reclaimTx, tokenHolder)
+    await submitTx(reclaimTx, tokenHolder)
 
     // Test that the attestation has been deleted.
     expect(
@@ -227,14 +223,14 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attestation.cTypeHash,
       null
     )
-    const authorizedStoreTx = await Did.authorizeExtrinsic(
+    const authorizedStoreTx = await Did.authorizeTx(
       attester.uri,
       storeTx,
       getSignCallback(attester),
       keypair.address
     )
     await expect(
-      submitExtrinsic(authorizedStoreTx, keypair)
+      submitTx(authorizedStoreTx, keypair)
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low"`
     )
@@ -276,7 +272,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       attestation.cTypeHash,
       null
     )
-    const authorizedStoreTx = await Did.authorizeExtrinsic(
+    const authorizedStoreTx = await Did.authorizeTx(
       attester.uri,
       storeTx,
       attesterKey.getSignCallback(attester),
@@ -284,7 +280,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
     )
 
     await expect(
-      submitExtrinsic(authorizedStoreTx, tokenHolder)
+      submitTx(authorizedStoreTx, tokenHolder)
     ).rejects.toMatchObject({ section: 'ctype', name: 'CTypeNotFound' })
   }, 60_000)
 
@@ -310,13 +306,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attestation.cTypeHash,
         null
       )
-      const authorizedStoreTx = await Did.authorizeExtrinsic(
+      const authorizedStoreTx = await Did.authorizeTx(
         attester.uri,
         storeTx,
         attesterKey.getSignCallback(attester),
         tokenHolder.address
       )
-      await submitExtrinsic(authorizedStoreTx, tokenHolder)
+      await submitTx(authorizedStoreTx, tokenHolder)
 
       await Credential.verifyPresentation(presentation)
       const storedAttestation = Attestation.fromChain(
@@ -333,7 +329,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         attestation.cTypeHash,
         null
       )
-      const authorizedStoreTx = await Did.authorizeExtrinsic(
+      const authorizedStoreTx = await Did.authorizeTx(
         attester.uri,
         storeTx,
         attesterKey.getSignCallback(attester),
@@ -341,7 +337,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
 
       await expect(
-        submitExtrinsic(authorizedStoreTx, tokenHolder)
+        submitTx(authorizedStoreTx, tokenHolder)
       ).rejects.toMatchObject({
         section: 'attestation',
         name: 'AlreadyAttested',
@@ -368,7 +364,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     it('should not be possible for the claimer to revoke an attestation', async () => {
       const revokeTx = api.tx.attestation.revoke(attestation.claimHash, null)
-      const authorizedRevokeTx = await Did.authorizeExtrinsic(
+      const authorizedRevokeTx = await Did.authorizeTx(
         claimer.uri,
         revokeTx,
         claimerKey.getSignCallback(claimer),
@@ -376,7 +372,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       )
 
       await expect(
-        submitExtrinsic(authorizedRevokeTx, tokenHolder)
+        submitTx(authorizedRevokeTx, tokenHolder)
       ).rejects.toMatchObject({ section: 'attestation', name: 'Unauthorized' })
       const storedAttestation = Attestation.fromChain(
         await api.query.attestation.attestations(attestation.claimHash),
@@ -395,13 +391,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       expect(storedAttestation?.revoked).toBe(false)
 
       const revokeTx = api.tx.attestation.revoke(attestation.claimHash, null)
-      const authorizedRevokeTx = await Did.authorizeExtrinsic(
+      const authorizedRevokeTx = await Did.authorizeTx(
         attester.uri,
         revokeTx,
         attesterKey.getSignCallback(attester),
         tokenHolder.address
       )
-      await submitExtrinsic(authorizedRevokeTx, tokenHolder)
+      await submitTx(authorizedRevokeTx, tokenHolder)
 
       const storedAttestationAfter = Attestation.fromChain(
         await api.query.attestation.attestations(attestation.claimHash),
@@ -413,13 +409,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
     it('should be possible for the deposit payer to remove an attestation', async () => {
       const removeTx = api.tx.attestation.remove(attestation.claimHash, null)
-      const authorizedRemoveTx = await Did.authorizeExtrinsic(
+      const authorizedRemoveTx = await Did.authorizeTx(
         attester.uri,
         removeTx,
         attesterKey.getSignCallback(attester),
         tokenHolder.address
       )
-      await submitExtrinsic(authorizedRemoveTx, tokenHolder)
+      await submitTx(authorizedRemoveTx, tokenHolder)
     }, 40_000)
   })
 
@@ -444,13 +440,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
       const storeTx = api.tx.ctype.add(
         CType.toChain(officialLicenseAuthorityCType)
       )
-      const authorizedStoreTx = await Did.authorizeExtrinsic(
+      const authorizedStoreTx = await Did.authorizeTx(
         attester.uri,
         storeTx,
         attesterKey.getSignCallback(attester),
         tokenHolder.address
       )
-      await submitExtrinsic(authorizedStoreTx, tokenHolder)
+      await submitTx(authorizedStoreTx, tokenHolder)
 
       expect(await isCtypeOnChain(officialLicenseAuthorityCType)).toBe(true)
     }, 45_000)
@@ -479,13 +475,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         licenseAuthorizationGranted.cTypeHash,
         null
       )
-      const authorizedStoreTx = await Did.authorizeExtrinsic(
+      const authorizedStoreTx = await Did.authorizeTx(
         anotherAttester.uri,
         storeTx,
         anotherAttesterKey.getSignCallback(anotherAttester),
         tokenHolder.address
       )
-      await submitExtrinsic(authorizedStoreTx, tokenHolder)
+      await submitTx(authorizedStoreTx, tokenHolder)
 
       // make credential including legitimation
       const iBelieveICanDrive = Claim.fromCTypeAndClaimContents(
@@ -509,13 +505,13 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         licenseGranted.cTypeHash,
         null
       )
-      const authorizedStoreTx2 = await Did.authorizeExtrinsic(
+      const authorizedStoreTx2 = await Did.authorizeTx(
         attester.uri,
         storeTx2,
         attesterKey.getSignCallback(attester),
         tokenHolder.address
       )
-      await submitExtrinsic(authorizedStoreTx2, tokenHolder)
+      await submitTx(authorizedStoreTx2, tokenHolder)
 
       const storedAttLicense = Attestation.fromChain(
         await api.query.attestation.attestations(licenseGranted.claimHash),

--- a/packages/core/src/__integrationtests__/Balance.spec.ts
+++ b/packages/core/src/__integrationtests__/Balance.spec.ts
@@ -22,7 +22,7 @@ import {
   devFaucet,
   EXISTENTIAL_DEPOSIT,
   initializeApi,
-  submitExtrinsic,
+  submitTx,
 } from './utils'
 
 let api: ApiPromise
@@ -70,7 +70,7 @@ describe('when there is a dev chain with a faucet', () => {
     api.query.system.account(address, spy)
     const balanceBefore = (await api.query.system.account(faucet.address)).data
     const transferTx = api.tx.balances.transfer(address, EXISTENTIAL_DEPOSIT)
-    await submitExtrinsic(transferTx, faucet)
+    await submitTx(transferTx, faucet)
     const balanceAfter = (await api.query.system.account(faucet.address)).data
     const balanceIdent = (await api.query.system.account(address)).data
 
@@ -100,7 +100,7 @@ describe('When there are haves and have-nots', () => {
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
-    await submitExtrinsic(transferTx, richieRich)
+    await submitTx(transferTx, richieRich)
     const balanceTo = (await api.query.system.account(stormyD.address)).data
     expect(balanceTo.free.toNumber()).toBe(EXISTENTIAL_DEPOSIT.toNumber())
   }, 40_000)
@@ -112,7 +112,7 @@ describe('When there are haves and have-nots', () => {
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
-    await expect(submitExtrinsic(transferTx, bobbyBroke)).rejects.toThrowError(
+    await expect(submitTx(transferTx, bobbyBroke)).rejects.toThrowError(
       '1010: Invalid Transaction'
     )
 
@@ -130,7 +130,7 @@ describe('When there are haves and have-nots', () => {
       bobbyBroke.address,
       RichieBalance.free
     )
-    await expect(submitExtrinsic(transferTx, richieRich)).rejects.toThrowError()
+    await expect(submitTx(transferTx, richieRich)).rejects.toThrowError()
 
     const newBalance = (await api.query.system.account(stormyD.address)).data
     const zeroBalance = (await api.query.system.account(bobbyBroke.address))
@@ -147,12 +147,12 @@ describe('When there are haves and have-nots', () => {
       richieRich.address,
       EXISTENTIAL_DEPOSIT
     )
-    await submitExtrinsic(transferTx1, faucet)
+    await submitTx(transferTx1, faucet)
     const transferTx2 = api.tx.balances.transfer(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
-    await submitExtrinsic(transferTx2, faucet)
+    await submitTx(transferTx2, faucet)
 
     expect(spy).toBeCalledTimes(3)
   }, 30_000)
@@ -165,7 +165,7 @@ describe('When there are haves and have-nots', () => {
       api.tx.balances.transfer(richieRich.address, EXISTENTIAL_DEPOSIT),
       api.tx.balances.transfer(stormyD.address, EXISTENTIAL_DEPOSIT),
     ])
-    await submitExtrinsic(batch, faucet)
+    await submitTx(batch, faucet)
 
     expect(listener).toBeCalledTimes(2)
   }, 50_000)

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -17,7 +17,7 @@ import { Blockchain } from '@kiltprotocol/chain-helpers'
 import { makeSigningKeyTool } from '@kiltprotocol/testing'
 
 import { toFemtoKilt } from '../balance/Balance.utils'
-import { devCharlie, devFaucet, initializeApi, submitExtrinsic } from './utils'
+import { devCharlie, devFaucet, initializeApi, submitTx } from './utils'
 import { disconnect } from '../kilt'
 
 let api: ApiPromise
@@ -38,7 +38,7 @@ describe('Chain returns specific errors, that we check for', () => {
       testIdentity.address,
       toFemtoKilt(10000)
     )
-    await submitExtrinsic(transferTx, faucet)
+    await submitTx(transferTx, faucet)
   }, 40000)
 
   it(`throws TxOutdated error if the nonce was already used for Tx in block`, async () => {

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -20,11 +20,7 @@ import { Crypto } from '@kiltprotocol/utils'
 import { ApiPromise } from '@polkadot/api'
 import * as CType from '../ctype'
 import { disconnect } from '../kilt'
-import {
-  createEndowedTestAccount,
-  initializeApi,
-  submitExtrinsic,
-} from './utils'
+import { createEndowedTestAccount, initializeApi, submitTx } from './utils'
 
 let api: ApiPromise
 beforeAll(async () => {
@@ -60,28 +56,26 @@ describe('When there is an CtypeCreator and a verifier', () => {
     const ctype = makeCType()
     const { keypair, getSignCallback } = makeSigningKeyTool()
     const storeTx = api.tx.ctype.add(CType.toChain(ctype))
-    const authorizedStoreTx = await Did.authorizeExtrinsic(
+    const authorizedStoreTx = await Did.authorizeTx(
       ctypeCreator.uri,
       storeTx,
       getSignCallback(ctypeCreator),
       keypair.address
     )
-    await expect(
-      submitExtrinsic(authorizedStoreTx, keypair)
-    ).rejects.toThrowError()
+    await expect(submitTx(authorizedStoreTx, keypair)).rejects.toThrowError()
     await expect(CType.verifyStored(ctype)).rejects.toThrow()
   }, 20_000)
 
   it('should be possible to create a claim type', async () => {
     const ctype = makeCType()
     const storeTx = api.tx.ctype.add(CType.toChain(ctype))
-    const authorizedStoreTx = await Did.authorizeExtrinsic(
+    const authorizedStoreTx = await Did.authorizeTx(
       ctypeCreator.uri,
       storeTx,
       key.getSignCallback(ctypeCreator),
       paymentAccount.address
     )
-    await submitExtrinsic(authorizedStoreTx, paymentAccount)
+    await submitTx(authorizedStoreTx, paymentAccount)
 
     expect(CType.fromChain(await api.query.ctype.ctypes(ctype.hash))).toBe(
       ctypeCreator.uri
@@ -95,23 +89,23 @@ describe('When there is an CtypeCreator and a verifier', () => {
   it('should not be possible to create a claim type that exists', async () => {
     const ctype = makeCType()
     const storeTx = api.tx.ctype.add(CType.toChain(ctype))
-    const authorizedStoreTx = await Did.authorizeExtrinsic(
+    const authorizedStoreTx = await Did.authorizeTx(
       ctypeCreator.uri,
       storeTx,
       key.getSignCallback(ctypeCreator),
       paymentAccount.address
     )
-    await submitExtrinsic(authorizedStoreTx, paymentAccount)
+    await submitTx(authorizedStoreTx, paymentAccount)
 
     const storeTx2 = api.tx.ctype.add(CType.toChain(ctype))
-    const authorizedStoreTx2 = await Did.authorizeExtrinsic(
+    const authorizedStoreTx2 = await Did.authorizeTx(
       ctypeCreator.uri,
       storeTx2,
       key.getSignCallback(ctypeCreator),
       paymentAccount.address
     )
     await expect(
-      submitExtrinsic(authorizedStoreTx2, paymentAccount)
+      submitTx(authorizedStoreTx2, paymentAccount)
     ).rejects.toMatchObject({ section: 'ctype', name: 'CTypeAlreadyExists' })
 
     expect(CType.fromChain(await api.query.ctype.ctypes(ctype.hash))).toBe(

--- a/packages/core/src/__integrationtests__/Deposit.spec.ts
+++ b/packages/core/src/__integrationtests__/Deposit.spec.ts
@@ -34,7 +34,7 @@ import {
   endowAccounts,
   initializeApi,
   isCtypeOnChain,
-  submitExtrinsic,
+  submitTx,
 } from './utils'
 import * as Attestation from '../attestation'
 import * as Claim from '../claim'
@@ -58,12 +58,7 @@ async function checkDeleteFullDid(
   )
   const deleteDid = api.tx.did.delete(storedEndpointsCount)
 
-  tx = await Did.authorizeExtrinsic(
-    fullDid.uri,
-    deleteDid,
-    sign,
-    identity.address
-  )
+  tx = await Did.authorizeTx(fullDid.uri, deleteDid, sign, identity.address)
 
   const balanceBeforeDeleting = (
     await api.query.system.account(identity.address)
@@ -74,7 +69,7 @@ async function checkDeleteFullDid(
   )
   const didDeposit = didResult.deposit
 
-  await submitExtrinsic(tx, identity)
+  await submitTx(tx, identity)
 
   const balanceAfterDeleting = (
     await api.query.system.account(identity.address)
@@ -103,7 +98,7 @@ async function checkReclaimFullDid(
   )
   const didDeposit = didResult.deposit
 
-  await submitExtrinsic(tx, identity)
+  await submitTx(tx, identity)
 
   const balanceAfterRevoking = (
     await api.query.system.account(identity.address)
@@ -127,14 +122,9 @@ async function checkRemoveFullDidAttestation(
     attestation.cTypeHash,
     null
   )
-  authorizedTx = await Did.authorizeExtrinsic(
-    fullDid.uri,
-    tx,
-    sign,
-    identity.address
-  )
+  authorizedTx = await Did.authorizeTx(fullDid.uri, tx, sign, identity.address)
 
-  await submitExtrinsic(authorizedTx, identity)
+  await submitTx(authorizedTx, identity)
 
   const attestationResult = await api.query.attestation.attestations(
     attestation.claimHash
@@ -149,14 +139,9 @@ async function checkRemoveFullDidAttestation(
   attestation = Attestation.fromCredentialAndDid(credential, fullDid.uri)
 
   tx = api.tx.attestation.remove(attestation.claimHash, null)
-  authorizedTx = await Did.authorizeExtrinsic(
-    fullDid.uri,
-    tx,
-    sign,
-    identity.address
-  )
+  authorizedTx = await Did.authorizeTx(fullDid.uri, tx, sign, identity.address)
 
-  await submitExtrinsic(authorizedTx, identity)
+  await submitTx(authorizedTx, identity)
 
   const balanceAfterRemoving = (
     await api.query.system.account(identity.address)
@@ -180,14 +165,9 @@ async function checkReclaimFullDidAttestation(
     attestation.cTypeHash,
     null
   )
-  authorizedTx = await Did.authorizeExtrinsic(
-    fullDid.uri,
-    tx,
-    sign,
-    identity.address
-  )
+  authorizedTx = await Did.authorizeTx(fullDid.uri, tx, sign, identity.address)
 
-  await submitExtrinsic(authorizedTx, identity)
+  await submitTx(authorizedTx, identity)
 
   const balanceBeforeReclaiming = (
     await api.query.system.account(identity.address)
@@ -203,7 +183,7 @@ async function checkReclaimFullDidAttestation(
     ? attestationResult.unwrap().deposit.amount.toBn()
     : new BN(0)
 
-  await submitExtrinsic(tx, identity)
+  await submitTx(tx, identity)
 
   const balanceAfterDeleting = (
     await api.query.system.account(identity.address)
@@ -227,14 +207,9 @@ async function checkDeletedDidReclaimAttestation(
     attestation.cTypeHash,
     null
   )
-  authorizedTx = await Did.authorizeExtrinsic(
-    fullDid.uri,
-    tx,
-    sign,
-    identity.address
-  )
+  authorizedTx = await Did.authorizeTx(fullDid.uri, tx, sign, identity.address)
 
-  await submitExtrinsic(authorizedTx, identity)
+  await submitTx(authorizedTx, identity)
 
   storedEndpointsCount = await api.query.did.didEndpointsCount(
     Did.toChain(fullDid.uri)
@@ -243,18 +218,13 @@ async function checkDeletedDidReclaimAttestation(
   attestation = Attestation.fromCredentialAndDid(credential, fullDid.uri)
 
   const deleteDid = api.tx.did.delete(storedEndpointsCount)
-  tx = await Did.authorizeExtrinsic(
-    fullDid.uri,
-    deleteDid,
-    sign,
-    identity.address
-  )
+  tx = await Did.authorizeTx(fullDid.uri, deleteDid, sign, identity.address)
 
-  await submitExtrinsic(tx, identity)
+  await submitTx(tx, identity)
 
   tx = api.tx.attestation.reclaimDeposit(attestation.claimHash)
 
-  await submitExtrinsic(tx, identity)
+  await submitTx(tx, identity)
 }
 
 async function checkWeb3Deposit(
@@ -269,13 +239,13 @@ async function checkWeb3Deposit(
 
   const depositAmount = api.consts.web3Names.deposit.toBn()
   const claimTx = api.tx.web3Names.claim(web3Name)
-  let didAuthorizedTx = await Did.authorizeExtrinsic(
+  let didAuthorizedTx = await Did.authorizeTx(
     fullDid.uri,
     claimTx,
     sign,
     identity.address
   )
-  await submitExtrinsic(didAuthorizedTx, identity)
+  await submitTx(didAuthorizedTx, identity)
   const balanceAfterClaiming = (
     await api.query.system.account(identity.address)
   ).data
@@ -288,13 +258,13 @@ async function checkWeb3Deposit(
   }
 
   const releaseTx = api.tx.web3Names.releaseByOwner()
-  didAuthorizedTx = await Did.authorizeExtrinsic(
+  didAuthorizedTx = await Did.authorizeTx(
     fullDid.uri,
     releaseTx,
     sign,
     identity.address
   )
-  await submitExtrinsic(didAuthorizedTx, identity)
+  await submitTx(didAuthorizedTx, identity)
   const balanceAfterReleasing = (
     await api.query.system.account(identity.address)
   ).data
@@ -330,13 +300,13 @@ beforeAll(async () => {
 
   const ctypeExists = await isCtypeOnChain(driversLicenseCType)
   if (!ctypeExists) {
-    const extrinsic = await Did.authorizeExtrinsic(
+    const extrinsic = await Did.authorizeTx(
       attester.uri,
       api.tx.ctype.add(CType.toChain(driversLicenseCType)),
       attesterKey.getSignCallback(attester),
       devFaucet.address
     )
-    await submitExtrinsic(extrinsic, devFaucet)
+    await submitTx(extrinsic, devFaucet)
   }
 
   const rawClaim = {

--- a/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
+++ b/packages/core/src/__integrationtests__/ErrorHandler.spec.ts
@@ -27,7 +27,7 @@ import {
   addressFromRandom,
   createEndowedTestAccount,
   initializeApi,
-  submitExtrinsic,
+  submitTx,
 } from './utils'
 
 let paymentAccount: KiltKeyringPair
@@ -47,9 +47,10 @@ beforeAll(async () => {
 
 it('records an extrinsic error when transferring less than the existential amount to new identity', async () => {
   const transferTx = api.tx.balances.transfer(addressFromRandom(), new BN(1))
-  await expect(
-    submitExtrinsic(transferTx, paymentAccount)
-  ).rejects.toMatchObject({ section: 'balances', name: 'ExistentialDeposit' })
+  await expect(submitTx(transferTx, paymentAccount)).rejects.toMatchObject({
+    section: 'balances',
+    name: 'ExistentialDeposit',
+  })
 }, 30_000)
 
 it('records an extrinsic error when ctype does not exist', async () => {
@@ -67,13 +68,13 @@ it('records an extrinsic error when ctype does not exist', async () => {
     attestation.cTypeHash,
     null
   )
-  const tx = await Did.authorizeExtrinsic(
+  const tx = await Did.authorizeTx(
     someDid.uri,
     storeTx,
     key.getSignCallback(someDid),
     paymentAccount.address
   )
-  await expect(submitExtrinsic(tx, paymentAccount)).rejects.toMatchObject({
+  await expect(submitTx(tx, paymentAccount)).rejects.toMatchObject({
     section: 'ctype',
     name: 'CTypeNotFound',
   })

--- a/packages/core/src/__integrationtests__/Web3Names.spec.ts
+++ b/packages/core/src/__integrationtests__/Web3Names.spec.ts
@@ -24,11 +24,7 @@ import {
 import * as Did from '@kiltprotocol/did'
 import type { ApiPromise } from '@polkadot/api'
 import { disconnect } from '../kilt'
-import {
-  createEndowedTestAccount,
-  initializeApi,
-  submitExtrinsic,
-} from './utils'
+import { createEndowedTestAccount, initializeApi, submitTx } from './utils'
 
 let api: ApiPromise
 
@@ -74,28 +70,28 @@ describe('When there is an Web3NameCreator and a payer', () => {
   it('should not be possible to create a w3n name w/o tokens', async () => {
     const tx = api.tx.web3Names.claim(nick)
     const bobbyBroke = makeSigningKeyTool().keypair
-    const authorizedTx = await Did.authorizeExtrinsic(
+    const authorizedTx = await Did.authorizeTx(
       w3nCreator.uri,
       tx,
       w3nCreatorKey.getSignCallback(w3nCreator),
       bobbyBroke.address
     )
 
-    const p = submitExtrinsic(authorizedTx, bobbyBroke)
+    const p = submitTx(authorizedTx, bobbyBroke)
 
     await expect(p).rejects.toThrowError('Inability to pay some fees')
   }, 30_000)
 
   it('should be possible to create a w3n name with enough tokens', async () => {
     const tx = api.tx.web3Names.claim(nick)
-    const authorizedTx = await Did.authorizeExtrinsic(
+    const authorizedTx = await Did.authorizeTx(
       w3nCreator.uri,
       tx,
       w3nCreatorKey.getSignCallback(w3nCreator),
       paymentAccount.address
     )
 
-    await submitExtrinsic(authorizedTx, paymentAccount)
+    await submitTx(authorizedTx, paymentAccount)
   }, 30_000)
 
   it('should be possible to lookup the DID uri with the given nick', async () => {
@@ -114,14 +110,14 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should not be possible to create the same w3n twice', async () => {
     const tx = api.tx.web3Names.claim(nick)
-    const authorizedTx = await Did.authorizeExtrinsic(
+    const authorizedTx = await Did.authorizeTx(
       otherWeb3NameCreator.uri,
       tx,
       otherW3NCreatorKey.getSignCallback(otherWeb3NameCreator),
       paymentAccount.address
     )
 
-    const p = submitExtrinsic(authorizedTx, paymentAccount)
+    const p = submitTx(authorizedTx, paymentAccount)
 
     await expect(p).rejects.toMatchObject({
       section: 'web3Names',
@@ -131,14 +127,14 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should not be possible to create a second w3n for the same did', async () => {
     const tx = api.tx.web3Names.claim('nick2')
-    const authorizedTx = await Did.authorizeExtrinsic(
+    const authorizedTx = await Did.authorizeTx(
       w3nCreator.uri,
       tx,
       w3nCreatorKey.getSignCallback(w3nCreator),
       paymentAccount.address
     )
 
-    const p = submitExtrinsic(authorizedTx, paymentAccount)
+    const p = submitTx(authorizedTx, paymentAccount)
 
     await expect(p).rejects.toMatchObject({
       section: 'web3Names',
@@ -148,7 +144,7 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should not be possible to remove a w3n by another payment account', async () => {
     const tx = api.tx.web3Names.reclaimDeposit(nick)
-    const p = submitExtrinsic(tx, otherPaymentAccount)
+    const p = submitTx(tx, otherPaymentAccount)
     await expect(p).rejects.toMatchObject({
       section: 'web3Names',
       name: 'NotAuthorized',
@@ -157,28 +153,28 @@ describe('When there is an Web3NameCreator and a payer', () => {
 
   it('should be possible to remove a w3n by the payment account', async () => {
     const tx = api.tx.web3Names.reclaimDeposit(nick)
-    await submitExtrinsic(tx, paymentAccount)
+    await submitTx(tx, paymentAccount)
   }, 30_000)
 
   it('should be possible to remove a w3n by the owner did', async () => {
     // prepare the w3n on chain
     const prepareTx = api.tx.web3Names.claim(differentNick)
-    const prepareAuthorizedTx = await Did.authorizeExtrinsic(
+    const prepareAuthorizedTx = await Did.authorizeTx(
       w3nCreator.uri,
       prepareTx,
       w3nCreatorKey.getSignCallback(w3nCreator),
       paymentAccount.address
     )
-    await submitExtrinsic(prepareAuthorizedTx, paymentAccount)
+    await submitTx(prepareAuthorizedTx, paymentAccount)
 
     const tx = api.tx.web3Names.releaseByOwner()
-    const authorizedTx = await Did.authorizeExtrinsic(
+    const authorizedTx = await Did.authorizeTx(
       w3nCreator.uri,
       tx,
       w3nCreatorKey.getSignCallback(w3nCreator),
       paymentAccount.address
     )
-    await submitExtrinsic(authorizedTx, paymentAccount)
+    await submitTx(authorizedTx, paymentAccount)
   }, 40_000)
 })
 

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -135,7 +135,7 @@ export const driversLicenseCTypeForDeposit = CType.fromSchema({
 })
 
 // Submits resolving when IS_IN_BLOCK
-export async function submitExtrinsic(
+export async function submitTx(
   extrinsic: SubmittableExtrinsic,
   submitter: KeyringPair,
   resolveOn?: SubscriptionPromise.ResultEvaluator
@@ -164,7 +164,7 @@ export async function fundAccount(
 ): Promise<void> {
   const api = ConfigService.get('api')
   const transferTx = api.tx.balances.transfer(address, amount)
-  await submitExtrinsic(transferTx, devFaucet)
+  await submitTx(transferTx, devFaucet)
 }
 
 export async function createEndowedTestAccount(

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -210,7 +210,7 @@ describe('When creating an instance from the chain', () => {
       sign = keyTool.getSignCallback(fullDid)
     })
 
-    describe('.addSingleExtrinsic()', () => {
+    describe('.addSingleTx()', () => {
       it('fails if the extrinsic does not require a DID', async () => {
         const extrinsic = augmentedApi.tx.indices.claim(1)
         await expect(async () =>
@@ -322,13 +322,13 @@ const mockApi = ApiMocks.createAugmentedApi()
 
 describe('When creating an instance from the chain', () => {
   it('Should return correct KeyRelationship for single valid call', () => {
-    const keyRelationship = Did.getKeyRelationshipForExtrinsic(
+    const keyRelationship = Did.getKeyRelationshipForTx(
       mockApi.tx.attestation.add(new Uint8Array(32), new Uint8Array(32), null)
     )
     expect(keyRelationship).toBe('assertionMethod')
   })
   it('Should return correct KeyRelationship for batched call', () => {
-    const keyRelationship = Did.getKeyRelationshipForExtrinsic(
+    const keyRelationship = Did.getKeyRelationshipForTx(
       mockApi.tx.utility.batch([
         mockApi.tx.attestation.add(
           new Uint8Array(32),
@@ -345,7 +345,7 @@ describe('When creating an instance from the chain', () => {
     expect(keyRelationship).toBe('assertionMethod')
   })
   it('Should return correct KeyRelationship for batchAll call', () => {
-    const keyRelationship = Did.getKeyRelationshipForExtrinsic(
+    const keyRelationship = Did.getKeyRelationshipForTx(
       mockApi.tx.utility.batchAll([
         mockApi.tx.attestation.add(
           new Uint8Array(32),
@@ -362,7 +362,7 @@ describe('When creating an instance from the chain', () => {
     expect(keyRelationship).toBe('assertionMethod')
   })
   it('Should return correct KeyRelationship for forceBatch call', () => {
-    const keyRelationship = Did.getKeyRelationshipForExtrinsic(
+    const keyRelationship = Did.getKeyRelationshipForTx(
       mockApi.tx.utility.forceBatch([
         mockApi.tx.attestation.add(
           new Uint8Array(32),
@@ -379,7 +379,7 @@ describe('When creating an instance from the chain', () => {
     expect(keyRelationship).toBe('assertionMethod')
   })
   it('Should return undefined for batch with mixed KeyRelationship calls', () => {
-    const keyRelationship = Did.getKeyRelationshipForExtrinsic(
+    const keyRelationship = Did.getKeyRelationshipForTx(
       mockApi.tx.utility.forceBatch([
         mockApi.tx.attestation.add(
           new Uint8Array(32),

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -117,7 +117,7 @@ function getKeyRelationshipForMethod(
  * @param extrinsic The unsigned extrinsic to inspect.
  * @returns The key relationship.
  */
-export function getKeyRelationshipForExtrinsic(
+export function getKeyRelationshipForTx(
   extrinsic: Extrinsic
 ): VerificationKeyRelationship | undefined {
   return getKeyRelationshipForMethod(extrinsic.method)
@@ -161,7 +161,7 @@ async function getNextNonce(did: DidUri): Promise<BN> {
  * @param signingOptions.txCounter The optional DID nonce to include in the operation signatures. By default, it uses the next value of the nonce stored on chain.
  * @returns The DID-signed submittable extrinsic.
  */
-export async function authorizeExtrinsic(
+export async function authorizeTx(
   did: DidUri,
   extrinsic: Extrinsic,
   sign: SignExtrinsicCallback,
@@ -178,7 +178,7 @@ export async function authorizeExtrinsic(
     )
   }
 
-  const keyRelationship = getKeyRelationshipForExtrinsic(extrinsic)
+  const keyRelationship = getKeyRelationshipForTx(extrinsic)
   if (keyRelationship === undefined) {
     throw new SDKErrors.SDKError('No key relationship found for extrinsic')
   }
@@ -202,7 +202,7 @@ function groupExtrinsicsByKeyRelationship(
   extrinsics: Extrinsic[]
 ): GroupedExtrinsics {
   const [first, ...rest] = extrinsics.map((extrinsic) => {
-    const keyRelationship = getKeyRelationshipForExtrinsic(extrinsic)
+    const keyRelationship = getKeyRelationshipForTx(extrinsic)
     if (!keyRelationship) {
       throw new SDKErrors.DidBatchError(
         'Can only batch extrinsics that require a DID signature'
@@ -274,7 +274,7 @@ export async function authorizeBatch({
   }
 
   if (extrinsics.length === 1) {
-    return authorizeExtrinsic(did, extrinsics[0], sign, submitter, {
+    return authorizeTx(did, extrinsics[0], sign, submitter, {
       txCounter: nonce,
     })
   }

--- a/packages/testing/src/mocks/mockedApi.ts
+++ b/packages/testing/src/mocks/mockedApi.ts
@@ -187,7 +187,7 @@ export function getMockedApi(): MockApiPromise {
     { isFinalized: true }
   )
 
-  function getMockSubmittableExtrinsic(): SubmittableExtrinsic {
+  function getMockSubmittableTx(): SubmittableExtrinsic {
     const result = TxResultsQueue.shift() || defaultTxResult
     return new MockSubmittableExtrinsic(result) as any as SubmittableExtrinsic
   }
@@ -217,33 +217,31 @@ export function getMockedApi(): MockApiPromise {
     },
     tx: {
       attestation: {
-        add: jest.fn((claimHash, _cTypeHash) => getMockSubmittableExtrinsic()),
-        revoke: jest.fn((claimHash: string) => getMockSubmittableExtrinsic()),
-        remove: jest.fn((claimHash: string) => getMockSubmittableExtrinsic()),
-        reclaimDeposit: jest.fn((claimHash: string) =>
-          getMockSubmittableExtrinsic()
-        ),
+        add: jest.fn((claimHash, _cTypeHash) => getMockSubmittableTx()),
+        revoke: jest.fn((claimHash: string) => getMockSubmittableTx()),
+        remove: jest.fn((claimHash: string) => getMockSubmittableTx()),
+        reclaimDeposit: jest.fn((claimHash: string) => getMockSubmittableTx()),
       },
       balances: {
-        transfer: jest.fn(() => getMockSubmittableExtrinsic()),
+        transfer: jest.fn(() => getMockSubmittableTx()),
       },
       ctype: {
-        add: jest.fn((hash, signature) => getMockSubmittableExtrinsic()),
+        add: jest.fn((hash, signature) => getMockSubmittableTx()),
       },
       delegation: {
-        createHierarchy: jest.fn(() => getMockSubmittableExtrinsic()),
-        addDelegation: jest.fn(() => getMockSubmittableExtrinsic()),
-        revokeDelegation: jest.fn(() => getMockSubmittableExtrinsic()),
+        createHierarchy: jest.fn(() => getMockSubmittableTx()),
+        addDelegation: jest.fn(() => getMockSubmittableTx()),
+        revokeDelegation: jest.fn(() => getMockSubmittableTx()),
       },
       did: {
-        add: jest.fn(() => getMockSubmittableExtrinsic()),
-        remove: jest.fn(() => getMockSubmittableExtrinsic()),
+        add: jest.fn(() => getMockSubmittableTx()),
+        remove: jest.fn(() => getMockSubmittableTx()),
       },
       portablegabi: {
         updateAccumulator: jest.fn((_acc) => {
           // change the accumulator for each update
           accumulator.push(accumulator.length)
-          return getMockSubmittableExtrinsic()
+          return getMockSubmittableTx()
         }),
       },
     },

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -231,7 +231,7 @@ async function runAll() {
     throw new Error('DIDs do not match')
   }
 
-  const deleteTx = await Did.authorizeExtrinsic(
+  const deleteTx = await Did.authorizeTx(
     fullDid.uri,
     api.tx.did.delete(BalanceUtils.toFemtoKilt(0)),
     getSignCallback(fullDid),
@@ -263,7 +263,7 @@ async function runAll() {
     type: 'object',
   })
 
-  const cTypeStoreTx = await Did.authorizeExtrinsic(
+  const cTypeStoreTx = await Did.authorizeTx(
     alice.uri,
     api.tx.ctype.add(CType.toChain(DriversLicense)),
     aliceSign(alice),
@@ -328,7 +328,7 @@ async function runAll() {
   Attestation.verifyAgainstCredential(attestation, credential)
   console.info('Attestation Data verified')
 
-  const attestationStoreTx = await Did.authorizeExtrinsic(
+  const attestationStoreTx = await Did.authorizeTx(
     alice.uri,
     api.tx.attestation.add(attestation.claimHash, attestation.cTypeHash, null),
     aliceSign(alice),


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

Renamed `authorizeExtrinsic()` to `authorizeTx()` and applied the same to all the methods with `Extrinsic` in their names. Inconsistent naming is confusing, and even the word "extrinsic" is not the most tongue-friendly.

authorizeExtrinsic -> authorizeTx
submitExtrinsic -> submitTx
getKeyRelationshipForExtrinsic -> getKeyRelationshipForTx
getKeysForExtrinsic -> getKeysForTx


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
