### PR TITLE
feat(message)!: separate verify function

### DIFF
--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -194,6 +194,8 @@ describe('Messaging', () => {
       JSON.stringify(decryptedMessage.body)
     )
 
+    expect(() => Message.verify(decryptedMessage)).not.toThrow()
+
     const encryptedMessageWrongContent = JSON.parse(
       JSON.stringify(encryptedMessage)
     ) as IEncryptedMessage

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -1164,128 +1164,122 @@ describe('Error checking / Verification', () => {
     )
   })
   it('error check should not throw errors on faulty bodies', () => {
+    expect(() => Message.verifyMessageBody(requestTermsBody)).not.toThrowError()
+    expect(() => Message.verifyMessageBody(submitTermsBody)).not.toThrowError()
+    expect(() => Message.verifyMessageBody(rejectTermsBody)).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(requestTermsBody)
+      Message.verifyMessageBody(requestAttestationBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(submitTermsBody)
+      Message.verifyMessageBody(submitAttestationBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(rejectTermsBody)
+      Message.verifyMessageBody(rejectAttestationForClaimBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(requestAttestationBody)
+      Message.verifyMessageBody(requestCredentialBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(submitAttestationBody)
+      Message.verifyMessageBody(submitCredentialBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(rejectAttestationForClaimBody)
+      Message.verifyMessageBody(acceptCredentialBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(requestCredentialBody)
+      Message.verifyMessageBody(rejectCredentialBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(submitCredentialBody)
+      Message.verifyMessageBody(requestAcceptDelegationBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(acceptCredentialBody)
+      Message.verifyMessageBody(submitAcceptDelegationBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(rejectCredentialBody)
+      Message.verifyMessageBody(rejectAcceptDelegationBody)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessageBody(requestAcceptDelegationBody)
-    ).not.toThrowError()
-    expect(() =>
-      Message.errorCheckMessageBody(submitAcceptDelegationBody)
-    ).not.toThrowError()
-    expect(() =>
-      Message.errorCheckMessageBody(rejectAcceptDelegationBody)
-    ).not.toThrowError()
-    expect(() =>
-      Message.errorCheckMessageBody(informCreateDelegationBody)
+      Message.verifyMessageBody(informCreateDelegationBody)
     ).not.toThrowError()
   })
   it('error check should not throw errors on message', () => {
     expect(() =>
-      Message.errorCheckMessage(messageRequestTerms)
+      Message.verifyMessageEnvelope(messageRequestTerms)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageSubmitTerms)
+      Message.verifyMessageEnvelope(messageSubmitTerms)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRejectTerms)
+      Message.verifyMessageEnvelope(messageRejectTerms)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRequestAttestationForClaim)
+      Message.verifyMessageEnvelope(messageRequestAttestationForClaim)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageSubmitAttestationForClaim)
+      Message.verifyMessageEnvelope(messageSubmitAttestationForClaim)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRejectAttestationForClaim)
+      Message.verifyMessageEnvelope(messageRejectAttestationForClaim)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRequestCredential)
+      Message.verifyMessageEnvelope(messageRequestCredential)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageSubmitCredential)
+      Message.verifyMessageEnvelope(messageSubmitCredential)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageAcceptCredential)
+      Message.verifyMessageEnvelope(messageAcceptCredential)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRejectCredential)
+      Message.verifyMessageEnvelope(messageRejectCredential)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRequestAcceptDelegation)
+      Message.verifyMessageEnvelope(messageRequestAcceptDelegation)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageSubmitAcceptDelegation)
+      Message.verifyMessageEnvelope(messageSubmitAcceptDelegation)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageRejectAcceptDelegation)
+      Message.verifyMessageEnvelope(messageRejectAcceptDelegation)
     ).not.toThrowError()
     expect(() =>
-      Message.errorCheckMessage(messageInformCreateDelegation)
+      Message.verifyMessageEnvelope(messageInformCreateDelegation)
     ).not.toThrowError()
   })
   it('error check should throw errors on message', () => {
     messageRequestTerms.receiver =
       'did:kilt:thisisnotareceiveraddress' as DidUri
-    expect(() => Message.errorCheckMessage(messageRequestTerms)).toThrowError(
-      SDKErrors.InvalidDidFormatError
-    )
+    expect(() =>
+      Message.verifyMessageEnvelope(messageRequestTerms)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
     // @ts-ignore
     messageSubmitTerms.sender = 'this is not a sender did'
-    expect(() => Message.errorCheckMessage(messageSubmitTerms)).toThrowError(
-      SDKErrors.InvalidDidFormatError
-    )
+    expect(() =>
+      Message.verifyMessageEnvelope(messageSubmitTerms)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
     // @ts-ignore
     messageRejectTerms.sender = 'this is not a sender address'
-    expect(() => Message.errorCheckMessage(messageRejectTerms)).toThrowError(
-      SDKErrors.InvalidDidFormatError
-    )
+    expect(() =>
+      Message.verifyMessageEnvelope(messageRejectTerms)
+    ).toThrowError(SDKErrors.InvalidDidFormatError)
   })
   it('error check should throw errors on faulty bodies', () => {
     // @ts-ignore
     requestTermsBody.content.cTypeHash = 'this is not a ctype hash'
-    expect(() => Message.errorCheckMessageBody(requestTermsBody)).toThrowError(
+    expect(() => Message.verifyMessageBody(requestTermsBody)).toThrowError(
       SDKErrors.HashMalformedError
     )
     submitTermsBody.content.delegationId = 'this is not a delegation id'
-    expect(() => Message.errorCheckMessageBody(submitTermsBody)).toThrowError(
+    expect(() => Message.verifyMessageBody(submitTermsBody)).toThrowError(
       SDKErrors.HashMalformedError
     )
 
     rejectTermsBody.content.delegationId = 'this is not a delegation id'
-    expect(() => Message.errorCheckMessageBody(rejectTermsBody)).toThrowError(
+    expect(() => Message.verifyMessageBody(rejectTermsBody)).toThrowError(
       SDKErrors.HashMalformedError
     )
     // @ts-expect-error
     delete rejectTermsBody.content.claim.cTypeHash
-    expect(() => Message.errorCheckMessageBody(rejectTermsBody)).toThrowError(
+    expect(() => Message.verifyMessageBody(rejectTermsBody)).toThrowError(
       SDKErrors.CTypeHashMissingError
     )
     requestAttestationBody.content.credential.claimerSignature = {
@@ -1294,66 +1288,66 @@ describe('Error checking / Verification', () => {
       keyUri: 'this is not a key id',
     }
     expect(() =>
-      Message.errorCheckMessageBody(requestAttestationBody)
+      Message.verifyMessageBody(requestAttestationBody)
     ).toThrowError()
     // @ts-ignore
     submitAttestationBody.content.attestation.claimHash =
       'this is not the claim hash'
-    expect(() =>
-      Message.errorCheckMessageBody(submitAttestationBody)
-    ).toThrowError(SDKErrors.HashMalformedError)
+    expect(() => Message.verifyMessageBody(submitAttestationBody)).toThrowError(
+      SDKErrors.HashMalformedError
+    )
     // @ts-ignore
     rejectAttestationForClaimBody.content = 'this is not the root hash'
     expect(() =>
-      Message.errorCheckMessageBody(rejectAttestationForClaimBody)
+      Message.verifyMessageBody(rejectAttestationForClaimBody)
     ).toThrowError(SDKErrors.HashMalformedError)
     // @ts-ignore
     requestCredentialBody.content.cTypes[0].cTypeHash =
       'this is not a cTypeHash'
-    expect(() =>
-      Message.errorCheckMessageBody(requestCredentialBody)
-    ).toThrowError(SDKErrors.HashMalformedError)
+    expect(() => Message.verifyMessageBody(requestCredentialBody)).toThrowError(
+      SDKErrors.HashMalformedError
+    )
     // @ts-ignore
     acceptCredentialBody.content[0] = 'this is not a cTypeHash'
-    expect(() =>
-      Message.errorCheckMessageBody(acceptCredentialBody)
-    ).toThrowError(SDKErrors.HashMalformedError)
+    expect(() => Message.verifyMessageBody(acceptCredentialBody)).toThrowError(
+      SDKErrors.HashMalformedError
+    )
     // @ts-ignore
     rejectCredentialBody.content[0] = 'this is not a cTypeHash'
-    expect(() =>
-      Message.errorCheckMessageBody(rejectCredentialBody)
-    ).toThrowError(SDKErrors.HashMalformedError)
+    expect(() => Message.verifyMessageBody(rejectCredentialBody)).toThrowError(
+      SDKErrors.HashMalformedError
+    )
     delete requestAcceptDelegationBody.content.metaData
     expect(() =>
-      Message.errorCheckMessageBody(requestAcceptDelegationBody)
+      Message.verifyMessageBody(requestAcceptDelegationBody)
     ).toThrowError(SDKErrors.ObjectUnverifiableError)
     requestAcceptDelegationBody.content.signatures.inviter.signature =
       'this is not a signature'
     expect(() =>
-      Message.errorCheckMessageBody(requestAcceptDelegationBody)
+      Message.verifyMessageBody(requestAcceptDelegationBody)
     ).toThrowError(SDKErrors.SignatureMalformedError)
     // @ts-ignore
     submitAcceptDelegationBody.content.signatures.invitee.keyUri =
       'this is not a key id'
     expect(() =>
-      Message.errorCheckMessageBody(submitAcceptDelegationBody)
+      Message.verifyMessageBody(submitAcceptDelegationBody)
     ).toThrowError(SDKErrors.SignatureMalformedError)
     submitAcceptDelegationBody.content.delegationData.parentId =
       'this is not a parent id hash'
     expect(() =>
-      Message.errorCheckMessageBody(submitAcceptDelegationBody)
+      Message.verifyMessageBody(submitAcceptDelegationBody)
     ).toThrowError(SDKErrors.DelegationIdTypeError)
     // @ts-expect-error
     delete rejectAcceptDelegationBody.content.account
     expect(() =>
-      Message.errorCheckMessageBody(rejectAcceptDelegationBody)
+      Message.verifyMessageBody(rejectAcceptDelegationBody)
     ).toThrowError(SDKErrors.OwnerMissingError)
     informCreateDelegationBody.content.delegationId =
       'this is not a delegation id'
     expect(() =>
-      Message.errorCheckMessageBody(informCreateDelegationBody)
+      Message.verifyMessageBody(informCreateDelegationBody)
     ).toThrowError(SDKErrors.HashMalformedError)
-    expect(() => Message.errorCheckMessageBody({} as MessageBody)).toThrowError(
+    expect(() => Message.verifyMessageBody({} as MessageBody)).toThrowError(
       SDKErrors.UnknownMessageBodyTypeError
     )
   })
@@ -1361,27 +1355,27 @@ describe('Error checking / Verification', () => {
     // @ts-expect-error
     delete requestAcceptDelegationBody.content.delegationData.isPCR
     expect(() =>
-      Message.errorCheckDelegationData(
+      Message.verifyDelegationStructure(
         requestAcceptDelegationBody.content.delegationData
       )
     ).toThrowError(TypeError('isPCR is expected to be a boolean'))
     requestAcceptDelegationBody.content.delegationData.id =
       'this is not a delegation id'
     expect(() =>
-      Message.errorCheckDelegationData(
+      Message.verifyDelegationStructure(
         requestAcceptDelegationBody.content.delegationData
       )
     ).toThrowError(SDKErrors.DelegationIdTypeError)
     submitAcceptDelegationBody.content.delegationData.permissions = []
     expect(() =>
-      Message.errorCheckDelegationData(
+      Message.verifyDelegationStructure(
         submitAcceptDelegationBody.content.delegationData
       )
     ).toThrowError(SDKErrors.UnauthorizedError)
     // @ts-expect-error
     delete submitAcceptDelegationBody.content.delegationData.id
     expect(() =>
-      Message.errorCheckDelegationData(
+      Message.verifyDelegationStructure(
         submitAcceptDelegationBody.content.delegationData
       )
     ).toThrowError(SDKErrors.DelegationIdMissingError)

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -233,7 +233,7 @@ describe('Messaging', () => {
         bobLightDid,
         { resolveKey }
       )
-    ).rejects.toThrowError(SDKErrors.ParsingMessageError)
+    ).rejects.toThrowError(SyntaxError)
   })
 
   it('verifies the message with sender is the owner (as full DID)', async () => {

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -383,37 +383,31 @@ export async function decrypt(
 
   const decoded = u8aToString(data)
 
-  try {
-    const {
-      body,
-      createdAt,
-      messageId,
-      inReplyTo,
-      references,
-      sender,
-      receiver,
-    } = JSON.parse(decoded) as IEncryptedMessageContents
-    const decrypted: IMessage = {
-      receiver,
-      sender,
-      createdAt,
-      body,
-      messageId,
-      receivedAt,
-      inReplyTo,
-      references,
-    }
-
-    if (sender !== senderKeyDetails.controller) {
-      throw new SDKErrors.IdentityMismatchError('Encryption key', 'Sender')
-    }
-
-    return decrypted
-  } catch (cause) {
-    throw new SDKErrors.ParsingMessageError(undefined, {
-      cause: cause as Error,
-    })
+  const {
+    body,
+    createdAt,
+    messageId,
+    inReplyTo,
+    references,
+    sender,
+    receiver,
+  } = JSON.parse(decoded) as IEncryptedMessageContents
+  const decrypted: IMessage = {
+    receiver,
+    sender,
+    createdAt,
+    body,
+    messageId,
+    receivedAt,
+    inReplyTo,
+    references,
   }
+
+  if (sender !== senderKeyDetails.controller) {
+    throw new SDKErrors.IdentityMismatchError('Encryption key', 'Sender')
+  }
+
+  return decrypted
 }
 
 /**

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -238,7 +238,6 @@ export function errorCheckMessage(message: IMessage): void {
   if (inReplyTo && typeof inReplyTo !== 'string') {
     throw new TypeError('In reply to is expected to be a string')
   }
-  errorCheckMessageBody(body)
 }
 
 /**

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -313,8 +313,6 @@ export function ensureOwnerIsSender({ body, sender }: IMessage): void {
 /**
  * Symmetrically decrypts the result of [[Message.encrypt]].
  *
- * Checks the message structure and body contents (e.g. Hashes match, ensures the owner is the sender).
- *
  * @param encrypted The encrypted message.
  * @param decryptCallback The callback to decrypt with the secret key.
  * @param receiverDetails The DID details of the receiver.
@@ -410,20 +408,27 @@ export async function decrypt(
       throw new SDKErrors.IdentityMismatchError('Encryption key', 'Sender')
     }
 
-    // checks the message body
-    errorCheckMessageBody(decrypted.body)
-
-    // checks the message structure
-    errorCheckMessage(decrypted)
-    // make sure the sender is the owner of the identity
-    ensureOwnerIsSender(decrypted)
-
     return decrypted
   } catch (cause) {
     throw new SDKErrors.ParsingMessageError(undefined, {
       cause: cause as Error,
     })
   }
+}
+
+/**
+ * Checks the message structure and body contents (e.g. Hashes match, ensures the owner is the sender).
+ * Throws, if a check fails.
+ *
+ * @param decryptedMessage The decrypted message to check.
+ */
+export function verify(decryptedMessage: IMessage): void {
+  // checks the message body
+  errorCheckMessageBody(decryptedMessage.body)
+  // checks the message structure
+  errorCheckMessage(decryptedMessage)
+  // make sure the sender is the owner of the identity
+  ensureOwnerIsSender(decryptedMessage)
 }
 
 /**

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -44,7 +44,7 @@ import {
  *
  * @param delegationData Delegation data to check.
  */
-export function errorCheckDelegationData(
+export function verifyDelegationStructure(
   delegationData: IDelegationData
 ): void {
   const { permissions, id, parentId, isPCR, account } = delegationData
@@ -80,7 +80,7 @@ export function errorCheckDelegationData(
  *
  * @param body The message body.
  */
-export function errorCheckMessageBody(body: MessageBody): void {
+export function verifyMessageBody(body: MessageBody): void {
   switch (body.type) {
     case 'request-terms': {
       Claim.verifyDataStructure(body.content)
@@ -178,7 +178,7 @@ export function errorCheckMessageBody(body: MessageBody): void {
       break
     }
     case 'request-accept-delegation': {
-      errorCheckDelegationData(body.content.delegationData)
+      verifyDelegationStructure(body.content.delegationData)
       Did.isDidSignature(body.content.signatures.inviter)
       if (!isJsonObject(body.content.metaData)) {
         throw new SDKErrors.ObjectUnverifiableError()
@@ -186,14 +186,14 @@ export function errorCheckMessageBody(body: MessageBody): void {
       break
     }
     case 'submit-accept-delegation': {
-      errorCheckDelegationData(body.content.delegationData)
+      verifyDelegationStructure(body.content.delegationData)
       Did.isDidSignature(body.content.signatures.inviter)
       Did.isDidSignature(body.content.signatures.invitee)
       break
     }
 
     case 'reject-accept-delegation': {
-      errorCheckDelegationData(body.content)
+      verifyDelegationStructure(body.content)
       break
     }
     case 'inform-create-delegation': {
@@ -214,16 +214,9 @@ export function errorCheckMessageBody(body: MessageBody): void {
  *
  * @param message The message object.
  */
-export function errorCheckMessage(message: IMessage): void {
-  const {
-    body,
-    messageId,
-    createdAt,
-    receiver,
-    sender,
-    receivedAt,
-    inReplyTo,
-  } = message
+export function verifyMessageEnvelope(message: IMessage): void {
+  const { messageId, createdAt, receiver, sender, receivedAt, inReplyTo } =
+    message
   if (messageId && typeof messageId !== 'string') {
     throw new TypeError('Message id is expected to be a string')
   }
@@ -416,11 +409,8 @@ export async function decrypt(
  * @param decryptedMessage The decrypted message to check.
  */
 export function verify(decryptedMessage: IMessage): void {
-  // checks the message body
-  errorCheckMessageBody(decryptedMessage.body)
-  // checks the message structure
-  errorCheckMessage(decryptedMessage)
-  // make sure the sender is the owner of the identity
+  verifyMessageBody(decryptedMessage.body)
+  verifyMessageEnvelope(decryptedMessage)
   ensureOwnerIsSender(decryptedMessage)
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2064
This PR separates message decryption and content verification.

Breaking change, because people might have relied on message.decrypt to do message verification

## How to test:
- Tests need to run through

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
