### PR TITLE
chore: upgrade CI to use node v18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,26 +35,17 @@ jobs:
 
     needs: check_skip
 
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-
     steps:
-      - uses: actions/checkout@v1
+      - name: Log out node version
+        run: node --version
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-yarn-
+          cache: 'yarn'
+      - name: Log out node version
+        run: node --version
       - name: yarn install
         run: yarn install --immutable
       - name: yarn build
@@ -64,7 +55,7 @@ jobs:
       - name: upload build
         uses: actions/upload-artifact@v2
         with:
-          name: build-${{ matrix.node-version }}
+          name: build
           path: build.zip
 
   lint:
@@ -74,7 +65,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: build-14.x
+          name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: lint
@@ -88,18 +79,23 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14, 16]
         required: ['required']
         include:
-          - node-version: 16.x
+          - node-version: 18
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - uses: actions/download-artifact@v2
         with:
-          name: build-${{ matrix.node-version }}
+          name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: unit tests
@@ -122,18 +118,24 @@ jobs:
 
     strategy:
       matrix:
-        image: ['latest-master']
+        image: ['latest-master', 'latest-develop', 'latest']
         required: ['optional']
-        include:
-          - image: 'latest-develop'
-            required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
+      - name: Log out node version
+        run: node --version
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+      - name: Log out node version
+        run: node --version
       - uses: actions/download-artifact@v2
         with:
-          name: build-14.x
+          name: build
       - name: unzip
         run: unzip build.zip -d .
 
@@ -171,9 +173,14 @@ jobs:
     needs: build
 
     steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
       - uses: actions/download-artifact@v2
         with:
-          name: build-16.x
+          name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: yarn bundle
@@ -198,9 +205,14 @@ jobs:
 
     continue-on-error: ${{ matrix.required == 'optional' }}
     steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
       - uses: actions/download-artifact@v2
         with:
-          name: build-16.x
+          name: build
       - name: unzip
         run: unzip build.zip -d .
       - uses: actions/download-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,14 +88,10 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - name: Log out node version
-        run: node --version
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Log out node version
-        run: node --version
       - uses: actions/download-artifact@v2
         with:
           name: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,16 +36,12 @@ jobs:
     needs: check_skip
 
     steps:
-      - name: Log out node version
-        run: node --version
       - uses: actions/checkout@v3
       - name: Use Node.js 14
         uses: actions/setup-node@v3
         with:
           node-version: 14
           cache: 'yarn'
-      - name: Log out node version
-        run: node --version
       - name: yarn install
         run: yarn install --immutable
       - name: yarn build
@@ -92,10 +88,14 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
+      - name: Log out node version
+        run: node --version
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Log out node version
+        run: node --version
       - uses: actions/download-artifact@v2
         with:
           name: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Log out node version
         run: node --version
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
           cache: 'yarn'
       - name: Log out node version
         run: node --version
@@ -63,6 +63,10 @@ jobs:
     needs: build
 
     steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - uses: actions/download-artifact@v2
         with:
           name: build
@@ -92,7 +96,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
       - uses: actions/download-artifact@v2
         with:
           name: build
@@ -130,7 +133,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
-          cache: 'yarn'
       - name: Log out node version
         run: node --version
       - uses: actions/download-artifact@v2
@@ -177,7 +179,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
-          cache: 'yarn'
       - uses: actions/download-artifact@v2
         with:
           name: build
@@ -209,7 +210,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
-          cache: 'yarn'
       - uses: actions/download-artifact@v2
         with:
           name: build


### PR DESCRIPTION
## fixes NoTicket
This PR introduces tests against node v18.
It also fixes the CI actions, to actually test with the node versions 14, 16 and 18. Before, only the build step would build a package per node versions, but would test all of them with the same node version.

## How to test:
- Tests need to run

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
