### PR TITLE
chore!: type guards should not throw

### DIFF
--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -111,6 +111,7 @@ export function unset<K extends keyof configOpts>(key: K): void {
  * Indicates whether a configuration option is set.
  *
  * @param key Key identifying the configuration option.
+ * @returns True if this value is set, false otherwise.
  */
 export function isSet<K extends keyof configOpts>(key: K): boolean {
   return typeof configuration[key] !== 'undefined'

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -51,9 +51,7 @@ export function verifyDataStructure(input: IAttestation): void {
   if (!input.owner) {
     throw new SDKErrors.OwnerMissingError()
   }
-  if (!DidUtils.isKiltDidUri(input.owner)) {
-    throw new SDKErrors.InvalidDidFormatError(input.owner)
-  }
+  DidUtils.validateKiltDidUri(input.owner, 'Did')
 
   if (typeof input.revoked !== 'boolean') {
     throw new SDKErrors.RevokedTypeError()

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -51,7 +51,9 @@ export function verifyDataStructure(input: IAttestation): void {
   if (!input.owner) {
     throw new SDKErrors.OwnerMissingError()
   }
-  DidUtils.validateKiltDidUri(input.owner)
+  if (!DidUtils.isKiltDidUri(input.owner)) {
+    throw new TypeError('Attestation owner is expected to be a Kilt Did')
+  }
 
   if (typeof input.revoked !== 'boolean') {
     throw new SDKErrors.RevokedTypeError()

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -52,7 +52,7 @@ export function verifyDataStructure(input: IAttestation): void {
     throw new SDKErrors.OwnerMissingError()
   }
   if (!DidUtils.isKiltDidUri(input.owner)) {
-    throw new TypeError('Attestation owner is expected to be a Kilt Did')
+    throw new SDKErrors.InvalidDidFormatError(input.owner)
   }
 
   if (typeof input.revoked !== 'boolean') {

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -234,7 +234,7 @@ describe('Claim', () => {
     )
 
     expect(() => Claim.verifyDataStructure(malformedAddress)).toThrowError(
-      SDKErrors.InvalidDidFormatError
+      SDKErrors.AddressInvalidError
     )
   })
 })

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -234,7 +234,7 @@ describe('Claim', () => {
     )
 
     expect(() => Claim.verifyDataStructure(malformedAddress)).toThrowError(
-      SDKErrors.AddressInvalidError
+      SDKErrors.InvalidDidFormatError
     )
   })
 })

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -195,8 +195,8 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
   if (!input.cTypeHash) {
     throw new SDKErrors.CTypeHashMissingError()
   }
-  if (input.owner && !DidUtils.isKiltDidUri(input.owner, 'Did')) {
-    throw new SDKErrors.InvalidDidFormatError(input.owner)
+  if (input.owner) {
+    DidUtils.validateKiltDidUri(input.owner, 'Did')
   }
   if (input.contents !== undefined) {
     Object.entries(input.contents).forEach(([key, value]) => {

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -195,8 +195,8 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
   if (!input.cTypeHash) {
     throw new SDKErrors.CTypeHashMissingError()
   }
-  if (input.owner) {
-    DidUtils.validateKiltDidUri(input.owner)
+  if (input.owner && !DidUtils.isKiltDidUri(input.owner, 'Did')) {
+    throw new TypeError('Claim owner is expected to be a Kilt Did')
   }
   if (input.contents !== undefined) {
     Object.entries(input.contents).forEach(([key, value]) => {

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -196,7 +196,7 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
     throw new SDKErrors.CTypeHashMissingError()
   }
   if (input.owner && !DidUtils.isKiltDidUri(input.owner, 'Did')) {
-    throw new TypeError('Claim owner is expected to be a Kilt Did')
+    throw new SDKErrors.InvalidDidFormatError(input.owner)
   }
   if (input.contents !== undefined) {
     Object.entries(input.contents).forEach(([key, value]) => {

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -261,7 +261,9 @@ export function verifyDataStructure(input: ICredential): void {
   if (typeof input.delegationId !== 'string' && input.delegationId !== null) {
     throw new SDKErrors.DelegationIdTypeError()
   }
-  if (input.claimerSignature) isDidSignature(input.claimerSignature)
+  if (input.claimerSignature && !isDidSignature(input.claimerSignature)) {
+    throw new SDKErrors.SignatureMalformedError()
+  }
 }
 
 /**

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -174,7 +174,7 @@ export function verifyDataStructure(input: ICType): void {
       input.schema.$id
     )
   }
-  if (!(input.owner === null || DidUtils.validateKiltDidUri(input.owner))) {
+  if (!(input.owner === null || DidUtils.isKiltDidUri(input.owner, 'Did'))) {
     throw new SDKErrors.CTypeOwnerTypeError()
   }
 }

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -174,8 +174,8 @@ export function verifyDataStructure(input: ICType): void {
       input.schema.$id
     )
   }
-  if (!(input.owner === null || DidUtils.isKiltDidUri(input.owner, 'Did'))) {
-    throw new SDKErrors.CTypeOwnerTypeError()
+  if (input.owner !== null && !DidUtils.isKiltDidUri(input.owner, 'Did')) {
+    throw new SDKErrors.InvalidDidFormatError(input.owner)
   }
 }
 

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -174,8 +174,8 @@ export function verifyDataStructure(input: ICType): void {
       input.schema.$id
     )
   }
-  if (input.owner !== null && !DidUtils.isKiltDidUri(input.owner, 'Did')) {
-    throw new SDKErrors.InvalidDidFormatError(input.owner)
+  if (input.owner !== null) {
+    DidUtils.validateKiltDidUri(input.owner, 'Did')
   }
 }
 

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -406,31 +406,31 @@ describe('type guard', () => {
       keyUri: `did:kilt:${keypair.address}?mykey`,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: `kilt:did:${keypair.address}#mykey`,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: `kilt:did:${keypair.address}`,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: keypair.address,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: '',
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
   })
 
   it('rejects unexpected signature type', () => {
@@ -438,12 +438,12 @@ describe('type guard', () => {
       keyUri: `did:kilt:${keypair.address}#mykey` as DidResourceUri,
       signature: '',
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     signature.signature = randomAsHex(32).substring(2)
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature.signature = randomAsU8a(32)
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
   })
 
   it('rejects incomplete objects', () => {
@@ -452,28 +452,28 @@ describe('type guard', () => {
       // @ts-expect-error
       signature: undefined,
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: undefined,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = {
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = {
       keyUri: `did:kilt:${keypair.address}#mykey` as DidResourceUri,
     }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = {}
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = { keyUri: null, signature: null }
-    expect(() => isDidSignature(signature)).toBe(false)
+    expect(isDidSignature(signature)).toBe(false)
   })
 })

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -23,7 +23,7 @@ import {
   randomAsHex,
   randomAsU8a,
 } from '@polkadot/util-crypto'
-import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
+import { ss58Format } from '@kiltprotocol/utils'
 import { makeSigningKeyTool } from '@kiltprotocol/testing'
 import * as Did from './index.js'
 import {
@@ -406,41 +406,31 @@ describe('type guard', () => {
       keyUri: `did:kilt:${keypair.address}?mykey`,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: `kilt:did:${keypair.address}#mykey`,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: `kilt:did:${keypair.address}`,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: keypair.address,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: '',
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
   })
 
   it('rejects unexpected signature type', () => {
@@ -448,18 +438,12 @@ describe('type guard', () => {
       keyUri: `did:kilt:${keypair.address}#mykey` as DidResourceUri,
       signature: '',
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     signature.signature = randomAsHex(32).substring(2)
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature.signature = randomAsU8a(32)
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
   })
 
   it('rejects incomplete objects', () => {
@@ -468,40 +452,28 @@ describe('type guard', () => {
       // @ts-expect-error
       signature: undefined,
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     signature = {
       // @ts-expect-error
       keyUri: undefined,
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = {
       signature: randomAsHex(32),
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = {
       keyUri: `did:kilt:${keypair.address}#mykey` as DidResourceUri,
     }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = {}
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
     // @ts-expect-error
     signature = { keyUri: null, signature: null }
-    expect(() => isDidSignature(signature)).toThrow(
-      SDKErrors.SignatureMalformedError
-    )
+    expect(() => isDidSignature(signature)).toBe(false)
   })
 })

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -16,7 +16,7 @@ import {
   UriFragment,
   VerificationKeyRelationship,
 } from '@kiltprotocol/types'
-import { Crypto, SDKErrors } from '@kiltprotocol/utils'
+import { Crypto } from '@kiltprotocol/utils'
 
 import { resolve } from './DidResolver/index.js'
 import { parseDidUri, validateKiltDidUri } from './Did.utils.js'
@@ -178,13 +178,10 @@ export function isDidSignature(
   try {
     const keyUri = 'keyUri' in signature ? signature.keyUri : signature.keyId
     if (!isHex(signature.signature) || !validateKiltDidUri(keyUri, true)) {
-      throw new SDKErrors.SignatureMalformedError()
+      return false
     }
     return true
   } catch (cause) {
-    // TODO: type guards shouldn't throw
-    throw new SDKErrors.SignatureMalformedError(undefined, {
-      cause: cause as Error,
-    })
+    return false
   }
 }

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -19,7 +19,7 @@ import {
 import { Crypto } from '@kiltprotocol/utils'
 
 import { resolve } from './DidResolver/index.js'
-import { parseDidUri, validateKiltDidUri } from './Did.utils.js'
+import { parseDidUri, isKiltDidUri } from './Did.utils.js'
 import * as Did from './index.js'
 
 type DidSignatureVerificationFromDetailsInput = {
@@ -177,7 +177,7 @@ export function isDidSignature(
   const signature = input as DidSignature | OldDidSignature
   try {
     const keyUri = 'keyUri' in signature ? signature.keyUri : signature.keyId
-    if (!isHex(signature.signature) || !validateKiltDidUri(keyUri, true)) {
+    if (!isHex(signature.signature) || !isKiltDidUri(keyUri, 'ResourceUri')) {
       return false
     }
     return true

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -59,7 +59,7 @@ export function verifyDelegationStructure(
     throw new SDKErrors.OwnerMissingError()
   }
   if (!Did.Utils.isKiltDidUri(account, 'Did')) {
-    throw new TypeError('account is expected to be a Kilt Did')
+    throw new SDKErrors.InvalidDidFormatError(account)
   }
 
   if (typeof isPCR !== 'boolean') {
@@ -239,12 +239,11 @@ export function verifyMessageEnvelope(message: IMessage): void {
   if (receivedAt !== undefined && typeof receivedAt !== 'number') {
     throw new TypeError('Received at is expected to be a number')
   }
-  if (
-    !Did.Utils.isKiltDidUri(receiver, 'Did') ||
-    !Did.Utils.isKiltDidUri(sender, 'Did')
-  ) {
-    throw new TypeError('receiver & sender are expected to be Kilt Dids')
-  }
+  ;[receiver, sender].forEach((did) => {
+    if (!Did.Utils.isKiltDidUri(did, 'Did')) {
+      throw new SDKErrors.InvalidDidFormatError(did)
+    }
+  })
   if (inReplyTo && typeof inReplyTo !== 'string') {
     throw new TypeError('In reply to is expected to be a string')
   }

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -58,9 +58,7 @@ export function verifyDelegationStructure(
   if (!account) {
     throw new SDKErrors.OwnerMissingError()
   }
-  if (!Did.Utils.isKiltDidUri(account, 'Did')) {
-    throw new SDKErrors.InvalidDidFormatError(account)
-  }
+  Did.Utils.validateKiltDidUri(account, 'Did')
 
   if (typeof isPCR !== 'boolean') {
     throw new TypeError('isPCR is expected to be a boolean')
@@ -144,12 +142,9 @@ export function verifyMessageBody(body: MessageBody): void {
             cTypeHash,
             'request credential cTypeHash invalid'
           )
-          trustedAttesters?.forEach((did) => {
-            if (!Did.Utils.isKiltDidUri(did, 'Did'))
-              throw new TypeError(
-                'requested attesters is expected to be an array of Kilt Dids'
-              )
-          })
+          trustedAttesters?.forEach((did) =>
+            Did.Utils.validateKiltDidUri(did, 'Did')
+          )
           requiredProperties?.forEach((requiredProps) => {
             if (typeof requiredProps !== 'string')
               throw new TypeError(
@@ -239,11 +234,8 @@ export function verifyMessageEnvelope(message: IMessage): void {
   if (receivedAt !== undefined && typeof receivedAt !== 'number') {
     throw new TypeError('Received at is expected to be a number')
   }
-  ;[receiver, sender].forEach((did) => {
-    if (!Did.Utils.isKiltDidUri(did, 'Did')) {
-      throw new SDKErrors.InvalidDidFormatError(did)
-    }
-  })
+  Did.Utils.validateKiltDidUri(sender, 'Did')
+  Did.Utils.validateKiltDidUri(receiver, 'Did')
   if (inReplyTo && typeof inReplyTo !== 'string') {
     throw new TypeError('In reply to is expected to be a string')
   }

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -179,7 +179,9 @@ export function verifyMessageBody(body: MessageBody): void {
     }
     case 'request-accept-delegation': {
       verifyDelegationStructure(body.content.delegationData)
-      Did.isDidSignature(body.content.signatures.inviter)
+      if (!Did.isDidSignature(body.content.signatures.inviter)) {
+        throw new SDKErrors.SignatureMalformedError()
+      }
       if (!isJsonObject(body.content.metaData)) {
         throw new SDKErrors.ObjectUnverifiableError()
       }
@@ -187,8 +189,12 @@ export function verifyMessageBody(body: MessageBody): void {
     }
     case 'submit-accept-delegation': {
       verifyDelegationStructure(body.content.delegationData)
-      Did.isDidSignature(body.content.signatures.inviter)
-      Did.isDidSignature(body.content.signatures.invitee)
+      if (
+        !Did.isDidSignature(body.content.signatures.inviter) ||
+        !Did.isDidSignature(body.content.signatures.invitee)
+      ) {
+        throw new SDKErrors.SignatureMalformedError()
+      }
       break
     }
 

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -58,7 +58,9 @@ export function verifyDelegationStructure(
   if (!account) {
     throw new SDKErrors.OwnerMissingError()
   }
-  Did.Utils.validateKiltDidUri(account)
+  if (!Did.Utils.isKiltDidUri(account, 'Did')) {
+    throw new TypeError('account is expected to be a Kilt Did')
+  }
 
   if (typeof isPCR !== 'boolean') {
     throw new TypeError('isPCR is expected to be a boolean')
@@ -142,7 +144,12 @@ export function verifyMessageBody(body: MessageBody): void {
             cTypeHash,
             'request credential cTypeHash invalid'
           )
-          trustedAttesters?.forEach((did) => Did.Utils.validateKiltDidUri(did))
+          trustedAttesters?.forEach((did) => {
+            if (!Did.Utils.isKiltDidUri(did, 'Did'))
+              throw new TypeError(
+                'requested attesters is expected to be an array of Kilt Dids'
+              )
+          })
           requiredProperties?.forEach((requiredProps) => {
             if (typeof requiredProps !== 'string')
               throw new TypeError(
@@ -232,8 +239,12 @@ export function verifyMessageEnvelope(message: IMessage): void {
   if (receivedAt !== undefined && typeof receivedAt !== 'number') {
     throw new TypeError('Received at is expected to be a number')
   }
-  Did.Utils.validateKiltDidUri(receiver)
-  Did.Utils.validateKiltDidUri(sender)
+  if (
+    !Did.Utils.isKiltDidUri(receiver, 'Did') ||
+    !Did.Utils.isKiltDidUri(sender, 'Did')
+  ) {
+    throw new TypeError('receiver & sender are expected to be Kilt Dids')
+  }
   if (inReplyTo && typeof inReplyTo !== 'string') {
     throw new TypeError('In reply to is expected to be a string')
   }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -96,8 +96,6 @@ export class ClaimContentsMalformedError extends SDKError {}
 
 export class ObjectUnverifiableError extends SDKError {}
 
-export class CTypeOwnerTypeError extends SDKError {}
-
 export class QuoteUnverifiableError extends SDKError {}
 
 export class ClaimNonceMapMalformedError extends SDKError {
@@ -131,12 +129,6 @@ export class HierarchyQueryError extends SDKError {
 export class InvalidDidFormatError extends SDKError {
   constructor(did: string, options?: ErrorOptions) {
     super(`Not a valid KILT DID "${did}"`, options)
-  }
-}
-
-export class UnsupportedDidError extends SDKError {
-  constructor(input: string) {
-    super(`The DID "${input}" is not supported`)
   }
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2187

Refactors functions that were typed as type guards such that they do not throw, but always return a boolean.
This is the expected behaviour of a type guard.
Also enforces a naming convention where type guards must begin with `is...`.

Also removed 2 errors that have become or were already obsolete (unused in the sdk).

## How to test:

Tests are included.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
