### PR TITLE
style: use the base tsconfig for eslint type info

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',
-    project: './tsconfig.build.json'
+    project: './tsconfig.json',
   },
   plugins: [
     '@typescript-eslint',
@@ -74,11 +74,14 @@ module.exports = {
       },
     ],
     '@typescript-eslint/ban-ts-comment': 'warn',
-    '@typescript-eslint/strict-boolean-expressions': ['error', {
-      allowNumber: false,
-      allowNullableString: true,
-      allowNullableBoolean: true,
-    }],
+    '@typescript-eslint/strict-boolean-expressions': [
+      'error',
+      {
+        allowNumber: false,
+        allowNullableString: true,
+        allowNullableBoolean: true,
+      },
+    ],
     'jsdoc/require-description': 'warn',
     'jsdoc/require-description-complete-sentence': 'warn',
     'jsdoc/no-types': 'warn',


### PR DESCRIPTION
This PR changes the eslint tsconfig option to use the one used by the IDE.

## How to test:
- Try to generate a problem for strict-boolean-checks

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
