### PR TITLE
feat: default tx subscription resolution config

### DIFF
--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -115,6 +115,29 @@ describe('Blockchain', () => {
       ).toHaveProperty('status.isReady', true)
     })
 
+    it('uses default resolution config', async () => {
+      api.__setDefaultResult({ isReady: true })
+      ConfigService.set({ submitTxResolveOn: IS_READY })
+      let tx = api.tx.balances.transfer('abcdef', 50)
+      expect(await signAndSubmitTx(tx, pair)).toHaveProperty(
+        'status.isReady',
+        true
+      )
+
+      api.__setDefaultResult({ isInBlock: true })
+      ConfigService.set({ submitTxResolveOn: IS_IN_BLOCK })
+      tx = api.tx.balances.transfer('abcdef', 50)
+      expect(await signAndSubmitTx(tx, pair)).toHaveProperty('isInBlock', true)
+
+      api.__setDefaultResult({ isFinalized: true })
+      ConfigService.set({ submitTxResolveOn: IS_FINALIZED })
+      tx = api.tx.balances.transfer('abcdef', 50)
+      expect(await signAndSubmitTx(tx, pair)).toHaveProperty(
+        'isFinalized',
+        true
+      )
+    })
+
     it('rejects on error condition', async () => {
       api.__setDefaultResult({ isInvalid: true })
       const tx = api.tx.balances.transfer('abcdef', 50)

--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -20,7 +20,6 @@ import {
   IS_FINALIZED,
   IS_IN_BLOCK,
   IS_READY,
-  parseSubscriptionOptions,
   signAndSubmitTx,
 } from './Blockchain'
 
@@ -32,58 +31,6 @@ beforeEach(() => {
 })
 
 describe('Blockchain', () => {
-  describe('parseSubscriptionOptions', () => {
-    it('takes incomplete SubscriptionPromiseOptions and sets default values where needed', async () => {
-      function testFunction() {
-        return true
-      }
-
-      expect(parseSubscriptionOptions()).toEqual({
-        resolveOn: IS_FINALIZED,
-        rejectOn: expect.any(Function),
-        timeout: undefined,
-      })
-
-      expect(parseSubscriptionOptions({ resolveOn: testFunction })).toEqual({
-        resolveOn: testFunction,
-        rejectOn: expect.any(Function),
-        timeout: undefined,
-      })
-
-      expect(
-        parseSubscriptionOptions({
-          resolveOn: testFunction,
-          rejectOn: testFunction,
-        })
-      ).toEqual({
-        resolveOn: testFunction,
-        rejectOn: testFunction,
-        timeout: undefined,
-      })
-
-      expect(
-        parseSubscriptionOptions({
-          resolveOn: testFunction,
-          timeout: 10,
-        })
-      ).toEqual({
-        resolveOn: testFunction,
-        rejectOn: expect.any(Function),
-        timeout: 10,
-      })
-
-      expect(
-        parseSubscriptionOptions({
-          timeout: 10,
-        })
-      ).toEqual({
-        resolveOn: IS_FINALIZED,
-        rejectOn: expect.any(Function),
-        timeout: 10,
-      })
-    })
-  })
-
   describe('submitSignedTx', () => {
     let pair: KeyringPair
 

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -98,7 +98,9 @@ export function parseSubscriptionOptions(
   opts?: Partial<SubscriptionPromise.Options>
 ): SubscriptionPromise.Options {
   const {
-    resolveOn = IS_FINALIZED,
+    resolveOn = ConfigService.isSet('submitTxResolveOn')
+      ? ConfigService.get('submitTxResolveOn')
+      : IS_FINALIZED,
     rejectOn = (result: ISubmittableResult) =>
       EXTRINSIC_FAILED(result) || IS_ERROR(result),
     timeout,

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -97,12 +97,12 @@ function defaultResolveOn(): SubscriptionPromise.ResultEvaluator {
 /**
  * Submits a signed SubmittableExtrinsic and attaches a callback to monitor the inclusion status of the transaction
  * and possible errors in the execution of extrinsics. Returns a promise to that end which by default resolves upon
- * finalization and rejects any errors occur during submission or execution of extrinsics. This behavior can be adjusted via optional parameters.
+ * finalization or rejects if any errors occur during submission or execution of extrinsics. This behavior can be adjusted via optional parameters or via the [[ConfigService]].
  *
  * Transaction fees will apply whenever a transaction fee makes it into a block, even if extrinsics fail to execute correctly!
  *
  * @param tx The SubmittableExtrinsic to be submitted. Most transactions need to be signed, this must be done beforehand.
- * @param opts Partial optional [[SubscriptionPromise]]to be parsed: Criteria for resolving/rejecting the promise.
+ * @param opts Allows overwriting criteria for resolving/rejecting the transaction result subscription promise. These options take precedent over configuration via the ConfigService.
  * @returns A promise which can be used to track transaction status.
  * If resolved, this promise returns ISubmittableResult that has led to its resolution.
  */

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -34,6 +34,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
+    "@kiltprotocol/types": "workspace:*",
     "@kiltprotocol/utils": "workspace:*",
     "@polkadot/api": "^9.0.0",
     "typescript-logging": "^0.6.4"

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -23,6 +23,7 @@ import {
   LogGroupControlSettings,
 } from 'typescript-logging'
 import { SDKErrors } from '@kiltprotocol/utils'
+import { SubscriptionPromise } from '@kiltprotocol/types'
 
 const DEFAULT_DEBUG_LEVEL =
   typeof process !== 'undefined' &&
@@ -34,6 +35,7 @@ const DEFAULT_DEBUG_LEVEL =
 export type configOpts = {
   api: ApiPromise
   logLevel: LogLevel
+  submitTxResolveOn: SubscriptionPromise.ResultEvaluator
 } & { [key: string]: any }
 
 /**

--- a/packages/core/src/__integrationtests__/Blockchain.spec.ts
+++ b/packages/core/src/__integrationtests__/Blockchain.spec.ts
@@ -10,10 +10,12 @@
  */
 
 import { BN } from '@polkadot/util'
-import type { KeyringPair } from '@kiltprotocol/types'
 import { ApiPromise } from '@polkadot/api'
+
+import type { KeyringPair } from '@kiltprotocol/types'
 import { Blockchain } from '@kiltprotocol/chain-helpers'
 import { makeSigningKeyTool } from '@kiltprotocol/testing'
+
 import { getTransferTx } from '../balance/Balance.chain'
 import { devCharlie, devFaucet, initializeApi, submitExtrinsic } from './utils'
 import { disconnect } from '../kilt'
@@ -24,7 +26,6 @@ beforeAll(async () => {
 }, 30_000)
 
 describe('Chain returns specific errors, that we check for', () => {
-  const resolveOn = Blockchain.IS_IN_BLOCK
   let faucet: KeyringPair
   let testIdentity: KeyringPair
   let charlie: KeyringPair
@@ -76,10 +77,7 @@ describe('Chain returns specific errors, that we check for', () => {
       runtimeVersion: api.runtimeVersion,
       version: api.extrinsicVersion,
     })
-    await Blockchain.dispatchTx(
-      tx,
-      Blockchain.parseSubscriptionOptions({ resolveOn })
-    )
+    await Blockchain.dispatchTx(tx)
 
     const { signature: errorSignature } = api
       .createType('ExtrinsicPayload', errorSigner.toPayload(), {
@@ -92,12 +90,9 @@ describe('Chain returns specific errors, that we check for', () => {
       errorSigner.toPayload()
     )
 
-    await expect(
-      Blockchain.dispatchTx(
-        errorTx,
-        Blockchain.parseSubscriptionOptions({ resolveOn })
-      )
-    ).rejects.toThrow(Blockchain.TxOutdated)
+    await expect(Blockchain.dispatchTx(errorTx)).rejects.toThrow(
+      Blockchain.TxOutdated
+    )
   }, 40000)
 
   it(`throws 'ERROR_TRANSACTION_USURPED' error if separate Tx was imported with identical nonce but higher priority while Tx is in pool`, async () => {
@@ -148,14 +143,8 @@ describe('Chain returns specific errors, that we check for', () => {
       errorSigner.toPayload()
     )
 
-    const promiseToFail = Blockchain.dispatchTx(
-      tx,
-      Blockchain.parseSubscriptionOptions({ resolveOn })
-    )
-    const promiseToUsurp = Blockchain.dispatchTx(
-      errorTx,
-      Blockchain.parseSubscriptionOptions({ resolveOn })
-    )
+    const promiseToFail = Blockchain.dispatchTx(tx)
+    const promiseToUsurp = Blockchain.dispatchTx(errorTx)
     await Promise.all([
       expect(promiseToFail).rejects.toHaveProperty('status.isUsurped', true),
       promiseToUsurp,

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -17,7 +17,6 @@ import { makeSigningKeyTool } from '@kiltprotocol/testing'
 import { Blockchain } from '@kiltprotocol/chain-helpers'
 import type {
   ICType,
-  ISubmittableResult,
   KeyringPair,
   KiltAddress,
   KiltKeyringPair,
@@ -57,7 +56,7 @@ async function getStartedTestContainer(): Promise<StartedTestContainer> {
 async function buildConnection(wsEndpoint: string): Promise<ApiPromise> {
   const provider = new WsProvider(wsEndpoint)
   const api = await ApiPromise.create({ provider })
-  await init({ api })
+  await init({ api, submitTxResolveOn: Blockchain.IS_IN_BLOCK })
   return api
 }
 
@@ -137,7 +136,7 @@ export const driversLicenseCTypeForDeposit = CType.fromSchema({
 export async function submitExtrinsic(
   extrinsic: SubmittableExtrinsic,
   submitter: KeyringPair,
-  resolveOn: SubscriptionPromise.ResultEvaluator = Blockchain.IS_IN_BLOCK
+  resolveOn?: SubscriptionPromise.ResultEvaluator
 ): Promise<void> {
   await Blockchain.signAndSubmitTx(extrinsic, submitter, {
     resolveOn,
@@ -147,7 +146,7 @@ export async function submitExtrinsic(
 export async function endowAccounts(
   faucet: KeyringPair,
   addresses: string[],
-  resolveOn: SubscriptionPromise.Evaluator<ISubmittableResult> = Blockchain.IS_FINALIZED
+  resolveOn?: SubscriptionPromise.ResultEvaluator
 ): Promise<void> {
   const api = ConfigService.get('api')
   const transactions = await Promise.all(

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -306,9 +306,7 @@ export async function createFullDidFromLightDid(
     payer.address,
     sign
   )
-  await Blockchain.signAndSubmitTx(tx, payer, {
-    resolveOn: Blockchain.IS_IN_BLOCK,
-  })
+  await Blockchain.signAndSubmitTx(tx, payer)
   const fullDid = await Did.query(Did.Utils.getFullDidUri(uri))
   if (!fullDid) throw new Error('Could not fetch created DID document')
   return fullDid

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -36,7 +36,7 @@ const {
   BalanceUtils,
 } = kilt
 
-const resolveOn = Blockchain.IS_IN_BLOCK
+kilt.config({ submitTxResolveOn: Blockchain.IS_IN_BLOCK })
 
 function makeSignCallback(keypair: KeyringPair): SignCallback {
   return async function sign<A extends SigningAlgorithms>({
@@ -139,7 +139,7 @@ async function createFullDidFromKeypair(
     payer.address,
     sign
   )
-  await Blockchain.signAndSubmitTx(storeTx, payer, { resolveOn })
+  await Blockchain.signAndSubmitTx(storeTx, payer)
 
   const fullDid = await Did.query(Did.Utils.getFullDidUriFromKey(keypair))
   if (!fullDid) throw new Error('Cannot query created DID')
@@ -211,7 +211,7 @@ async function runAll() {
     payer.address,
     sign
   )
-  await Blockchain.signAndSubmitTx(didStoreTx, payer, { resolveOn })
+  await Blockchain.signAndSubmitTx(didStoreTx, payer)
 
   const fullDid = await Did.query(Did.Utils.getFullDidUriFromKey(keypair))
   if (!fullDid) throw new Error('Could not fetch created DID document')
@@ -234,7 +234,7 @@ async function runAll() {
     sign,
     payer.address
   )
-  await Blockchain.signAndSubmitTx(deleteTx, payer, { resolveOn })
+  await Blockchain.signAndSubmitTx(deleteTx, payer)
 
   const resolvedAgain = await Did.resolve(fullDid.uri)
   if (!resolvedAgain || resolvedAgain.metadata.deactivated) {
@@ -266,7 +266,7 @@ async function runAll() {
     aliceSign,
     payer.address
   )
-  await Blockchain.signAndSubmitTx(cTypeStoreTx, payer, { resolveOn })
+  await Blockchain.signAndSubmitTx(cTypeStoreTx, payer)
 
   const stored = await CType.verifyStored(DriversLicense)
   if (stored) {
@@ -347,7 +347,7 @@ async function runAll() {
     aliceSign,
     payer.address
   )
-  await Blockchain.signAndSubmitTx(attestationStoreTx, payer, { resolveOn })
+  await Blockchain.signAndSubmitTx(attestationStoreTx, payer)
   const storedAttestation = await Attestation.query(credential.rootHash)
   if (storedAttestation?.revoked === false) {
     console.info('Attestation verified with chain')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,6 +1267,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kiltprotocol/config@workspace:packages/config"
   dependencies:
+    "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/api": ^9.0.0
     rimraf: ^3.0.2


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2185

Adding a config service option to set a default for the resolveOn parameter on `submitTx`, which will be used whenever this parameter is not set.
Also inlining the `parseSubscriptionOption` function which had little to no purpose at this point

## How to test:

Tests

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
