### PR TITLE
fix: selective disclosure

### DIFF
--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -140,9 +140,15 @@ export function verifyAgainstCredential(
   attestation: IAttestation,
   credential: ICredential
 ): boolean {
-  return (
-    credential.claim.cTypeHash === attestation.cTypeHash &&
-    credential.rootHash === attestation.claimHash &&
+  try {
+    if (
+      credential.claim.cTypeHash !== attestation.cTypeHash ||
+      credential.rootHash !== attestation.claimHash
+    )
+      return false
     Credential.verifyDataIntegrity(credential)
-  )
+    return true
+  } catch {
+    return false
+  }
 }

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -140,15 +140,9 @@ export function verifyAgainstCredential(
   attestation: IAttestation,
   credential: ICredential
 ): boolean {
-  try {
-    if (
-      credential.claim.cTypeHash !== attestation.cTypeHash ||
-      credential.rootHash !== attestation.claimHash
-    )
-      return false
+  return (
+    credential.claim.cTypeHash === attestation.cTypeHash &&
+    credential.rootHash === attestation.claimHash &&
     Credential.verifyDataIntegrity(credential)
-    return true
-  } catch {
-    return false
-  }
+  )
 }

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -133,12 +133,12 @@ export function verifyRootHash(input: ICredential): boolean {
 }
 
 /**
- * Verifies the data of the [[Credential]] object; used to check that the data was not tampered with, by checking the data against hashes.
+ * Verifies the data of the [[Credential]] object; used to check that the data was not tampered with,
+ * by checking the data against hashes. Throws if invalid.
  *
  * @param input - The [[Credential]] for which to verify data.
- * @returns Whether the data is valid.
  */
-export function verifyDataIntegrity(input: ICredential): boolean {
+export function verifyDataIntegrity(input: ICredential): void {
   // check claim hash
   if (!verifyRootHash(input)) {
     throw new SDKErrors.RootHashUnverifiableError()
@@ -155,12 +155,8 @@ export function verifyDataIntegrity(input: ICredential): boolean {
 
   // check legitimations
   input.legitimations.forEach((legitimation) => {
-    if (!verifyDataIntegrity(legitimation)) {
-      throw new SDKErrors.LegitimationsUnverifiableError()
-    }
+    verifyDataIntegrity(legitimation)
   })
-
-  return true
 }
 
 /**

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -452,5 +452,5 @@ export async function createPresentation({
     selectedKeyId
   )
 
-  return { ...credential, claimerSignature: { signature, keyUri, challenge } }
+  return { ...presentation, claimerSignature: { signature, keyUri, challenge } }
 }

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -133,12 +133,12 @@ export function verifyRootHash(input: ICredential): boolean {
 }
 
 /**
- * Verifies the data of the [[Credential]] object; used to check that the data was not tampered with,
- * by checking the data against hashes. Throws if invalid.
+ * Verifies the data of the [[Credential]] object; used to check that the data was not tampered with, by checking the data against hashes.
  *
  * @param input - The [[Credential]] for which to verify data.
+ * @returns Whether the data is valid.
  */
-export function verifyDataIntegrity(input: ICredential): void {
+export function verifyDataIntegrity(input: ICredential): boolean {
   // check claim hash
   if (!verifyRootHash(input)) {
     throw new SDKErrors.RootHashUnverifiableError()
@@ -155,8 +155,12 @@ export function verifyDataIntegrity(input: ICredential): void {
 
   // check legitimations
   input.legitimations.forEach((legitimation) => {
-    verifyDataIntegrity(legitimation)
+    if (!verifyDataIntegrity(legitimation)) {
+      throw new SDKErrors.LegitimationsUnverifiableError()
+    }
   })
+
+  return true
 }
 
 /**

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -42,7 +42,7 @@ export async function init<K extends Partial<ConfigService.configOpts>>(
 }
 
 /**
- * Connects to the KILT Blockchain using the api instance set with `init()`.
+ * Connects to the KILT Blockchain and passes the initialized api instance to `init()`, making it available for functions in the sdk.
  *
  * @param blockchainRpcWsUrl WebSocket URL of the RPC endpoint exposed by a node that is part of the Kilt blockchain network you wish to connect to.
  * @returns An instance of ApiPromise.


### PR DESCRIPTION
## rc hotfix

Selective disclosure turned out to be broken in the latest rc.
Additionally to fixing this, the docstring of `Kilt.connect()` was not particularly informative about what it actually does.
