### PR TITLE
refactor!: verify* throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ts-jest": "^27.1.2",
     "ts-jest-resolver": "^2.0.0",
     "typedoc": "^0.22.15",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "version": "0.30.0-4",
   "packageManager": "yarn@3.0.2"

--- a/packages/augment-api/package.json
+++ b/packages/augment-api/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.1.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.4.0",
-    "typescript": "^4.5.4",
+    "typescript": "^4.8.3",
     "websocket": "^1.0.31",
     "yargs": "^16.2.0"
   }

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -33,7 +33,7 @@
     "@kiltprotocol/testing": "workspace:*",
     "@polkadot/keyring": "^10.0.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/augment-api": "workspace:*",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/KILTprotocol/sdk-js#readme",
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/types": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@types/uuid": "^8.0.0",
     "rimraf": "^3.0.2",
     "testcontainers": "^8.6.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/augment-api": "workspace:*",

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -366,7 +366,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         claimerDid: claimer,
       })
 
-      expect(() => 
+      expect(() =>
         Attestation.verifyAgainstCredential(attestation, fakeCredential)
       ).toThrow()
     }, 15_000)

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -69,7 +69,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     await expect(
       submitExtrinsic(authorizedStoreTx, keypair)
     ).rejects.toThrowError()
-    expect(await CType.verifyStored(ctype)).toBe(false)
+    await expect(CType.verifyStored(ctype)).rejects.toThrow()
   }, 20_000)
 
   it('should be possible to create a claim type', async () => {
@@ -86,10 +86,10 @@ describe('When there is an CtypeCreator and a verifier', () => {
     expect(CType.fromChain(await api.query.ctype.ctypes(ctype.hash))).toBe(
       ctypeCreator.uri
     )
-    expect(await CType.verifyStored(ctype)).toBe(true)
+    await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
 
     ctype.owner = ctypeCreator.uri
-    expect(await CType.verifyStored(ctype)).toBe(true)
+    await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
   }, 40_000)
 
   it('should not be possible to create a claim type that exists', async () => {
@@ -143,13 +143,13 @@ describe('When there is an CtypeCreator and a verifier', () => {
       ctypeCreator.uri
     )
 
-    expect(await CType.verifyStored(iAmNotThere)).toBe(false)
+    await expect(CType.verifyStored(iAmNotThere)).rejects.toThrow()
     expect((await api.query.ctype.ctypes(iAmNotThere.hash)).isNone).toBe(true)
 
     const fakeHash = Crypto.hashStr('abcdefg')
     expect((await api.query.ctype.ctypes(fakeHash)).isNone).toBe(true)
 
-    expect(await CType.verifyStored(iAmNotThereWithOwner)).toBe(false)
+    await expect(CType.verifyStored(iAmNotThereWithOwner)).rejects.toThrow()
   })
 })
 

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -193,7 +193,9 @@ describe('and attestation rights have been delegated', () => {
       claimerDid: claimer,
     })
     expect(() => Credential.verifyDataIntegrity(credential)).not.toThrow()
-    await expect(Credential.verifySignature(presentation)).resolves.not.toThrow()
+    await expect(
+      Credential.verifySignature(presentation)
+    ).resolves.not.toThrow()
     await Credential.verifyPresentation(presentation)
 
     const attestation = Attestation.fromCredentialAndDid(

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -147,8 +147,8 @@ it('should be possible to delegate attestation rights', async () => {
     rootKey.sign,
     attesterKey.sign
   )
-  expect(await rootNode.verify()).toBe(true)
-  expect(await delegatedNode.verify()).toBe(true)
+  await expect(rootNode.verify()).resolves.not.toThrow()
+  await expect(delegatedNode.verify()).resolves.not.toThrow()
 }, 60_000)
 
 describe('and attestation rights have been delegated', () => {
@@ -170,8 +170,8 @@ describe('and attestation rights have been delegated', () => {
       attesterKey.sign
     )
 
-    expect(await rootNode.verify()).toBe(true)
-    expect(await delegatedNode.verify()).toBe(true)
+    await expect(rootNode.verify()).resolves.not.toThrow()
+    await expect(delegatedNode.verify()).resolves.not.toThrow()
   }, 75_000)
 
   it("should be possible to attest a claim in the root's name and revoke it by the root", async () => {
@@ -192,8 +192,8 @@ describe('and attestation rights have been delegated', () => {
       signCallback: claimerKey.sign,
       claimerDid: claimer,
     })
-    expect(Credential.verifyDataIntegrity(credential)).toBe(true)
-    expect(await Credential.verifySignature(presentation)).toBe(true)
+    expect(() => Credential.verifyDataIntegrity(credential)).not.toThrow()
+    await expect(Credential.verifySignature(presentation)).resolves.not.toThrow()
     await Credential.verifyPresentation(presentation)
 
     const attestation = Attestation.fromCredentialAndDid(
@@ -282,7 +282,7 @@ describe('revocation', () => {
       paymentAccount.address
     )
     await submitExtrinsic(authorizedRevokeTx, paymentAccount)
-    expect(await delegationA.verify()).toBe(false)
+    await expect(delegationA.verify()).rejects.toThrow()
 
     // Delegation removal can only be done by either the delegation owner themselves via DID call
     // or the deposit owner as a regular signed call.
@@ -302,7 +302,7 @@ describe('revocation', () => {
     })
 
     // Check that delegation fails to verify but that it is still on the blockchain (i.e., not removed)
-    expect(await delegationA.verify()).toBe(false)
+    await expect(delegationA.verify()).rejects.toThrow()
     expect(await DelegationNode.query(delegationA.id)).not.toBeNull()
   }, 60_000)
 
@@ -333,7 +333,7 @@ describe('revocation', () => {
       section: 'delegation',
       name: 'UnauthorizedRevocation',
     })
-    expect(await delegationRoot.verify()).toBe(true)
+    await expect(delegationRoot.verify()).resolves.not.toThrow()
 
     const revokeTx2 = await delegationA.getRevokeTx(firstDelegate.uri)
     const authorizedRevokeTx2 = await Did.authorizeExtrinsic(
@@ -343,7 +343,7 @@ describe('revocation', () => {
       paymentAccount.address
     )
     await submitExtrinsic(authorizedRevokeTx2, paymentAccount)
-    expect(await delegationA.verify()).toBe(false)
+    await expect(delegationA.verify()).rejects.toThrow()
   }, 60_000)
 
   it('delegator can revoke root, revoking all delegations in tree', async () => {
@@ -378,9 +378,9 @@ describe('revocation', () => {
     )
     await submitExtrinsic(authorizedRevokeTx, paymentAccount)
 
-    expect(await delegationRoot.verify()).toBe(false)
-    expect(await delegationA.verify()).toBe(false)
-    expect(await delegationB.verify()).toBe(false)
+    await expect(delegationRoot.verify()).rejects.toThrow()
+    await expect(delegationA.verify()).rejects.toThrow()
+    await expect(delegationB.verify()).rejects.toThrow()
   }, 60_000)
 })
 

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -531,7 +531,7 @@ describe('DID authorization', () => {
     )
     await submitExtrinsic(tx, paymentAccount)
 
-    expect(await CType.verifyStored(ctype)).toEqual(true)
+    await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
   }, 60_000)
 
   it('no longer authorizes ctype creation after DID deletion', async () => {
@@ -565,7 +565,7 @@ describe('DID authorization', () => {
       name: 'DidNotPresent',
     })
 
-    expect(await CType.verifyStored(ctype)).toEqual(false)
+    await expect(CType.verifyStored(ctype)).rejects.toThrow()
   }, 60_000)
 })
 
@@ -1026,7 +1026,7 @@ describe('DID extrinsics batching', () => {
     await submitExtrinsic(tx, paymentAccount)
 
     // The ctype has been created, even though the delegation operations failed.
-    expect(await CType.verifyStored(ctype)).toBe(true)
+    await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
   })
 
   it('batchAll fails if any extrinsics fail', async () => {
@@ -1064,7 +1064,7 @@ describe('DID extrinsics batching', () => {
     })
 
     // The ctype has not been created, since atomicity ensures the whole batch is reverted in case of failure.
-    expect(await CType.verifyStored(ctype)).toBe(false)
+    await expect(CType.verifyStored(ctype)).rejects.toThrow()
   })
 
   it('can batch extrinsics for the same required key type', async () => {
@@ -1157,8 +1157,8 @@ describe('DID extrinsics batching', () => {
     expect(owner).toStrictEqual(fullDid.uri)
 
     // Test correct use of attestation keys
-    expect(await CType.verifyStored(ctype1)).toBe(true)
-    expect(await CType.verifyStored(ctype2)).toBe(true)
+    await expect(CType.verifyStored(ctype1)).resolves.not.toThrow()
+    await expect(CType.verifyStored(ctype2)).resolves.not.toThrow()
 
     // Test correct use of delegation keys
     const node = await DelegationNode.query(rootNode.id)

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -54,7 +54,7 @@ async function getStartedTestContainer(): Promise<StartedTestContainer> {
 
 async function buildConnection(wsEndpoint: string): Promise<ApiPromise> {
   const provider = new WsProvider(wsEndpoint)
-  const api = await ApiPromise.create({ provider })
+  const api = new ApiPromise({ provider })
   await init({ api, submitTxResolveOn: Blockchain.IS_IN_BLOCK })
   return api
 }

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -97,7 +97,12 @@ export function addressFromRandom(): KiltAddress {
 }
 
 export async function isCtypeOnChain(ctype: ICType): Promise<boolean> {
-  return CType.verifyStored(ctype)
+  try {
+    await CType.verifyStored(ctype)
+    return true
+  } catch {
+    return false
+  }
 }
 
 export const driversLicenseCType = CType.fromSchema({

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -56,7 +56,7 @@ async function buildConnection(wsEndpoint: string): Promise<ApiPromise> {
   const provider = new WsProvider(wsEndpoint)
   const api = new ApiPromise({ provider })
   await init({ api, submitTxResolveOn: Blockchain.IS_IN_BLOCK })
-  return api
+  return api.isReadyOrError
 }
 
 export async function initializeApi(): Promise<ApiPromise> {

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -134,21 +134,18 @@ export function isIAttestation(input: unknown): input is IAttestation {
  *
  * @param attestation - The attestation to verify.
  * @param credential - The credential to verify against.
- * @returns Whether the data is valid.
  */
 export function verifyAgainstCredential(
   attestation: IAttestation,
   credential: ICredential
-): boolean {
-  try {
-    if (
-      credential.claim.cTypeHash !== attestation.cTypeHash ||
-      credential.rootHash !== attestation.claimHash
+): void {
+  if (
+    credential.claim.cTypeHash !== attestation.cTypeHash ||
+    credential.rootHash !== attestation.claimHash
+  ) {
+    throw new SDKErrors.CredentialUnverifiableError(
+      'Attestation does not match credential'
     )
-      return false
-    Credential.verifyDataIntegrity(credential)
-    return true
-  } catch {
-    return false
   }
+  Credential.verifyDataIntegrity(credential)
 }

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -140,9 +140,15 @@ export function verifyAgainstCredential(
   attestation: IAttestation,
   credential: ICredential
 ): boolean {
-  return (
-    credential.claim.cTypeHash === attestation.cTypeHash &&
-    credential.rootHash === attestation.claimHash &&
+  try {
+    if (
+      credential.claim.cTypeHash !== attestation.cTypeHash ||
+      credential.rootHash !== attestation.claimHash
+    )
+      return false
     Credential.verifyDataIntegrity(credential)
-  )
+    return true
+  } catch {
+    return false
+  }
 }

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -36,12 +36,12 @@ export function verifyDataStructure(input: IAttestation): void {
   if (!input.cTypeHash) {
     throw new SDKErrors.CTypeHashMissingError()
   }
-  DataUtils.verifyIsHex(input.cTypeHash, 32)
+  DataUtils.verifyIsHex(input.cTypeHash, 256)
 
   if (!input.claimHash) {
     throw new SDKErrors.ClaimHashMissingError()
   }
-  DataUtils.verifyIsHex(input.claimHash, 32)
+  DataUtils.verifyIsHex(input.claimHash, 256)
 
   if (typeof input.delegationId !== 'string' && input.delegationId !== null) {
     throw new SDKErrors.DelegationIdTypeError()

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -36,12 +36,12 @@ export function verifyDataStructure(input: IAttestation): void {
   if (!input.cTypeHash) {
     throw new SDKErrors.CTypeHashMissingError()
   }
-  DataUtils.validateHash(input.cTypeHash, 'CType')
+  DataUtils.verifyIsHex(input.cTypeHash, 32)
 
   if (!input.claimHash) {
     throw new SDKErrors.ClaimHashMissingError()
   }
-  DataUtils.validateHash(input.claimHash, 'Claim')
+  DataUtils.verifyIsHex(input.claimHash, 32)
 
   if (typeof input.delegationId !== 'string' && input.delegationId !== null) {
     throw new SDKErrors.DelegationIdTypeError()

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -212,7 +212,7 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
       }
     })
   }
-  DataUtils.validateHash(input.cTypeHash, 'Claim CType')
+  DataUtils.verifyIsHex(input.cTypeHash, 32)
 }
 
 function verifyAgainstCType(

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -22,12 +22,7 @@ import type { HexString } from '@polkadot/util/types'
 import type { DidUri, IClaim, ICType, PartialClaim } from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
-import {
-  getIdForCTypeHash,
-  isICType,
-  verifyClaimAgainstNestedSchemas,
-  verifyClaimAgainstSchema,
-} from '../ctype/index.js'
+import * as CType from '../ctype/index.js'
 
 const VC_VOCAB = 'https://www.w3.org/2018/credentials#'
 
@@ -45,7 +40,7 @@ function jsonLDcontents(
 ): Record<string, unknown> {
   const { cTypeHash, contents, owner } = claim
   if (!cTypeHash) throw new SDKErrors.CTypeHashMissingError()
-  const vocabulary = `${getIdForCTypeHash(cTypeHash)}#`
+  const vocabulary = `${CType.getIdForCTypeHash(cTypeHash)}#`
   const result: Record<string, unknown> = {}
   if (owner) result['@id'] = owner
   if (!expanded) {
@@ -79,7 +74,7 @@ export function toJsonLD(
     [`${prefix}credentialSubject`]: credentialSubject,
   }
   result[`${prefix}credentialSchema`] = {
-    '@id': getIdForCTypeHash(claim.cTypeHash),
+    '@id': CType.getIdForCTypeHash(claim.cTypeHash),
   }
   if (!expanded) result['@context'] = { '@vocab': VC_VOCAB }
   return result
@@ -143,7 +138,6 @@ export function hashClaimContents(
  * @param options Object containing optional parameters.
  * @param options.canonicalisation Canonicalisation routine that produces an array of statement strings from the [IClaim]. Default produces individual `{"key":"value"}` JSON representations where keys are transformed to expanded JSON-LD.
  * @param options.hasher The hasher to be used. Required but defaults to 256 bit blake2 over `${nonce}${statement}`.
- * @returns `verified` is a boolean indicating whether the proof is valid. `errors` is an array of all errors in case it is not.
  */
 export function verifyDisclosedAttributes(
   claim: PartialClaim,
@@ -154,7 +148,7 @@ export function verifyDisclosedAttributes(
   options: Pick<Crypto.HashingOptions, 'hasher'> & {
     canonicalisation?: (claim: PartialClaim) => string[]
   } = {}
-): { verified: boolean; errors: Error[] } {
+): void {
   // apply defaults
   const defaults = { canonicalisation: makeStatementsJsonLD }
   const canonicalisation = options.canonicalisation || defaults.canonicalisation
@@ -165,7 +159,10 @@ export function verifyDisclosedAttributes(
   const hashed = Crypto.hashStatements(statements, { ...options, nonces })
   // check resulting hashes
   const digestsInProof = Object.keys(nonces)
-  return hashed.reduce<{ verified: boolean; errors: Error[] }>(
+  const { verified, errors } = hashed.reduce<{
+    verified: boolean
+    errors: Error[]
+  }>(
     (status, { saltedHash, statement, digest, nonce }) => {
       // check if the statement digest was contained in the proof and mapped it to a nonce
       if (!digestsInProof.includes(digest) || !nonce) {
@@ -183,6 +180,12 @@ export function verifyDisclosedAttributes(
     },
     { verified: true, errors: [] }
   )
+  if (verified !== true) {
+    throw new SDKErrors.ClaimUnverifiableError(
+      'One or more statements in the claim could not be verified',
+      { cause: errors }
+    )
+  }
 }
 
 /**
@@ -215,8 +218,8 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
 function verifyAgainstCType(
   claimContents: IClaim['contents'],
   cTypeSchema: ICType['schema']
-): boolean {
-  return verifyClaimAgainstSchema(claimContents, cTypeSchema)
+): void {
+  CType.verifyClaimAgainstSchema(claimContents, cTypeSchema)
 }
 
 /**
@@ -229,10 +232,7 @@ export function verify(
   claimInput: IClaim,
   cTypeSchema: ICType['schema']
 ): void {
-  if (!verifyAgainstCType(claimInput.contents, cTypeSchema)) {
-    throw new SDKErrors.ClaimUnverifiableError()
-  }
-
+  verifyAgainstCType(claimInput.contents, cTypeSchema)
   verifyDataStructure(claimInput)
 }
 
@@ -252,15 +252,12 @@ export function fromNestedCTypeClaim(
   claimContents: IClaim['contents'],
   claimOwner: DidUri
 ): IClaim {
-  if (
-    !verifyClaimAgainstNestedSchemas(
-      cTypeInput.schema,
-      nestedCType,
-      claimContents
-    )
-  ) {
-    throw new SDKErrors.NestedClaimUnverifiableError()
-  }
+  CType.verifyClaimAgainstNestedSchemas(
+    cTypeInput.schema,
+    nestedCType,
+    claimContents
+  )
+
   const claim = {
     cTypeHash: cTypeInput.hash,
     contents: claimContents,
@@ -283,12 +280,8 @@ export function fromCTypeAndClaimContents(
   claimContents: IClaim['contents'],
   claimOwner: DidUri
 ): IClaim {
-  if (
-    !isICType(ctypeInput) ||
-    !verifyAgainstCType(claimContents, ctypeInput.schema)
-  ) {
-    throw new SDKErrors.ClaimUnverifiableError()
-  }
+  CType.verifyDataStructure(ctypeInput)
+  verifyAgainstCType(claimContents, ctypeInput.schema)
   const claim = {
     cTypeHash: ctypeInput.hash,
     contents: claimContents,

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -212,7 +212,7 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
       }
     })
   }
-  DataUtils.verifyIsHex(input.cTypeHash, 32)
+  DataUtils.verifyIsHex(input.cTypeHash, 256)
 }
 
 function verifyAgainstCType(

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -92,7 +92,7 @@ describe('Credential', () => {
       [legitimation]
     )
     // check proof on complete data
-    expect(Credential.verifyDataIntegrity(credential)).toBe(true)
+    expect(() => Credential.verifyDataIntegrity(credential)).not.toThrow()
     const testCType = CType.fromSchema(rawCType)
     await Credential.verifyCredential(credential, {
       ctype: testCType,
@@ -101,7 +101,7 @@ describe('Credential', () => {
     // just deleting a field will result in a wrong proof
     delete credential.claimNonceMap[Object.keys(credential.claimNonceMap)[0]]
     expect(() => Credential.verifyDataIntegrity(credential)).toThrowError(
-      SDKErrors.NoProofForStatementError
+      SDKErrors.ClaimUnverifiableError
     )
   })
 
@@ -131,8 +131,8 @@ describe('Credential', () => {
       newCredential.claimHashes.length - 1
     )
     expect((newCredential.claim.contents as any).b).toBe('b')
-    expect(Credential.verifyDataIntegrity(newCredential)).toBe(true)
-    expect(Credential.verifyRootHash(newCredential)).toBe(true)
+    expect(() => Credential.verifyDataIntegrity(newCredential)).not.toThrow()
+    expect(() => Credential.verifyRootHash(newCredential)).not.toThrow()
   })
 
   it('should throw error on faulty constructor input', async () => {
@@ -256,13 +256,13 @@ describe('Credential', () => {
     ).toThrowError(SDKErrors.RootHashUnverifiableError)
     expect(() =>
       Credential.verifyDataIntegrity(builtCredentialIncompleteClaimHashTree)
-    ).toThrowError(SDKErrors.NoProofForStatementError)
+    ).toThrowError(SDKErrors.ClaimUnverifiableError)
     expect(Credential.isPresentation(builtCredentialMalformedSignature)).toBe(
       false
     )
     expect(() =>
       Credential.verifyDataIntegrity(builtCredentialMalformedHashes)
-    ).toThrowError(SDKErrors.NoProofForStatementError)
+    ).toThrowError(SDKErrors.ClaimUnverifiableError)
     expect(() => Credential.verifyDataStructure(builtCredential)).not.toThrow()
     expect(() => {
       Credential.verifyDataStructure(builtCredentialWithLegitimation)
@@ -296,11 +296,13 @@ describe('Credential', () => {
       },
       []
     )
-    expect(Credential.verifyAgainstCType(builtCredential, testCType)).toBe(true)
+    expect(() =>
+      Credential.verifyAgainstCType(builtCredential, testCType)
+    ).not.toThrow()
     builtCredential.claim.contents.name = 123
-    expect(Credential.verifyAgainstCType(builtCredential, testCType)).toBe(
-      false
-    )
+    expect(() =>
+      Credential.verifyAgainstCType(builtCredential, testCType)
+    ).toThrow()
   })
 })
 
@@ -424,7 +426,7 @@ describe('Credential', () => {
     )
 
     // check proof on complete data
-    expect(Credential.verifyDataIntegrity(presentation)).toBe(true)
+    expect(() => Credential.verifyDataIntegrity(presentation)).not.toThrow()
     await Credential.verifyPresentation(presentation, {
       didResolve: mockResolve,
     })
@@ -448,7 +450,7 @@ describe('Credential', () => {
     )
 
     // check proof on complete data
-    expect(Credential.verifyDataIntegrity(presentation)).toBe(true)
+    expect(() => Credential.verifyDataIntegrity(presentation)).not.toThrow()
     await Credential.verifyPresentation(presentation, {
       didResolve: mockResolve,
     })
@@ -496,7 +498,7 @@ describe('Credential', () => {
     )
 
     // check proof on complete data
-    expect(Credential.verifyDataIntegrity(presentation)).toBe(true)
+    expect(() => Credential.verifyDataIntegrity(presentation)).not.toThrow()
     await expect(
       Credential.verifyPresentation(presentation, {
         didResolve: mockResolve,
@@ -525,9 +527,9 @@ describe('Credential', () => {
       [],
       keyAlice.sign
     )
-    expect(Attestation.verifyAgainstCredential(attestation, credential)).toBe(
-      true
-    )
+    expect(() =>
+      Attestation.verifyAgainstCredential(attestation, credential)
+    ).not.toThrow()
     const { cTypeHash } = attestation
     // @ts-ignore
     attestation.cTypeHash = [
@@ -535,9 +537,9 @@ describe('Credential', () => {
       ((parseInt(cTypeHash.charAt(15), 16) + 1) % 16).toString(16),
       cTypeHash.slice(16),
     ].join('')
-    expect(Attestation.verifyAgainstCredential(attestation, credential)).toBe(
-      false
-    )
+    expect(() =>
+      Attestation.verifyAgainstCredential(attestation, credential)
+    ).toThrow()
   })
   it('returns Claim Hash of the attestation', async () => {
     const [credential, attestation] = await buildPresentation(
@@ -804,9 +806,9 @@ describe('create presentation', () => {
   })
 
   it('should verify the credential claims structure against the ctype', () => {
-    expect(Credential.verifyAgainstCType(credential, ctype)).toBe(true)
+    expect(() => Credential.verifyAgainstCType(credential, ctype)).not.toThrow()
     credential.claim.contents.name = 123
 
-    expect(Credential.verifyAgainstCType(credential, ctype)).toBe(false)
+    expect(() => Credential.verifyAgainstCType(credential, ctype)).toThrow()
   })
 })

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -133,12 +133,12 @@ export function verifyRootHash(input: ICredential): boolean {
 }
 
 /**
- * Verifies the data of the [[Credential]] object; used to check that the data was not tampered with, by checking the data against hashes.
+ * Verifies the data of the [[Credential]] object; used to check that the data was not tampered with,
+ * by checking the data against hashes. Throws if invalid.
  *
  * @param input - The [[Credential]] for which to verify data.
- * @returns Whether the data is valid.
  */
-export function verifyDataIntegrity(input: ICredential): boolean {
+export function verifyDataIntegrity(input: ICredential): void {
   // check claim hash
   if (!verifyRootHash(input)) {
     throw new SDKErrors.RootHashUnverifiableError()
@@ -155,12 +155,8 @@ export function verifyDataIntegrity(input: ICredential): boolean {
 
   // check legitimations
   input.legitimations.forEach((legitimation) => {
-    if (!verifyDataIntegrity(legitimation)) {
-      throw new SDKErrors.LegitimationsUnverifiableError()
-    }
+    verifyDataIntegrity(legitimation)
   })
-
-  return true
 }
 
 /**

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -180,7 +180,7 @@ export function verifyDataStructure(input: ICredential): void {
   if (typeof input.claimNonceMap !== 'object')
     throw new SDKErrors.ClaimNonceMapMalformedError()
   Object.entries(input.claimNonceMap).forEach(([digest, nonce]) => {
-    DataUtils.validateHash(digest, 'statement digest')
+    DataUtils.verifyIsHex(digest, 32)
     if (!digest || typeof nonce !== 'string' || !nonce)
       throw new SDKErrors.ClaimNonceMapMalformedError()
   })

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -178,7 +178,7 @@ export function verifyDataStructure(input: ICredential): void {
   if (typeof input.claimNonceMap !== 'object')
     throw new SDKErrors.ClaimNonceMapMalformedError()
   Object.entries(input.claimNonceMap).forEach(([digest, nonce]) => {
-    DataUtils.verifyIsHex(digest, 32)
+    DataUtils.verifyIsHex(digest, 256)
     if (!digest || typeof nonce !== 'string' || !nonce)
       throw new SDKErrors.ClaimNonceMapMalformedError()
   })

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -126,10 +126,10 @@ export function makeSigningData(
  * Verifies if the credential hash matches the contents of it.
  *
  * @param input - The credential to check.
- * @returns Whether they match or not.
  */
-export function verifyRootHash(input: ICredential): boolean {
-  return input.rootHash === calculateRootHash(input)
+export function verifyRootHash(input: ICredential): void {
+  if (input.rootHash !== calculateRootHash(input))
+    throw new SDKErrors.RootHashUnverifiableError()
 }
 
 /**
@@ -140,18 +140,13 @@ export function verifyRootHash(input: ICredential): boolean {
  */
 export function verifyDataIntegrity(input: ICredential): void {
   // check claim hash
-  if (!verifyRootHash(input)) {
-    throw new SDKErrors.RootHashUnverifiableError()
-  }
+  verifyRootHash(input)
 
   // verify properties against selective disclosure proof
-  const { errors, verified } = Claim.verifyDisclosedAttributes(input.claim, {
+  Claim.verifyDisclosedAttributes(input.claim, {
     nonces: input.claimNonceMap,
     hashes: input.claimHashes,
   })
-  // TODO: how do we want to deal with multiple errors during claim verification?
-  if (!verified)
-    throw errors.length > 0 ? errors[0] : new SDKErrors.ClaimUnverifiableError()
 
   // check legitimations
   input.legitimations.forEach((legitimation) => {
@@ -182,18 +177,13 @@ export function verifyDataStructure(input: ICredential): void {
   if (!('claimNonceMap' in input)) {
     throw new SDKErrors.ClaimNonceMapMissingError()
   }
-  if (
-    typeof input.claimNonceMap !== 'object' ||
-    Object.entries(input.claimNonceMap).some(
-      ([digest, nonce]) =>
-        !digest ||
-        !DataUtils.validateHash(digest, 'statement digest') ||
-        typeof nonce !== 'string' ||
-        !nonce
-    )
-  ) {
+  if (typeof input.claimNonceMap !== 'object')
     throw new SDKErrors.ClaimNonceMapMalformedError()
-  }
+  Object.entries(input.claimNonceMap).forEach(([digest, nonce]) => {
+    DataUtils.validateHash(digest, 'statement digest')
+    if (!digest || typeof nonce !== 'string' || !nonce)
+      throw new SDKErrors.ClaimNonceMapMalformedError()
+  })
 
   if (!('claimHashes' in input)) {
     throw new SDKErrors.DataStructureError('claim hashes not provided')
@@ -209,19 +199,13 @@ export function verifyDataStructure(input: ICredential): void {
  *
  * @param credential A [[Credential]] for the attester.
  * @param ctype A [[CType]] to verify the [[Claim]] structure.
- *
- * @returns A boolean if the [[Claim]] structure in the [[Credential]] is valid.
  */
 export function verifyAgainstCType(
   credential: ICredential,
   ctype: ICType
-): boolean {
-  try {
-    verifyDataStructure(credential)
-  } catch {
-    return false
-  }
-  return verifyClaimAgainstSchema(credential.claim.contents, ctype.schema)
+): void {
+  verifyDataStructure(credential)
+  verifyClaimAgainstSchema(credential.claim.contents, ctype.schema)
 }
 
 /**
@@ -234,7 +218,6 @@ export function verifyAgainstCType(
  * @param verificationOpts Additional verification options.
  * @param verificationOpts.didResolve - The function used to resolve the claimer's identity. Defaults to [[resolve]].
  * @param verificationOpts.challenge - The expected value of the challenge. Verification will fail in case of a mismatch.
- * @returns Whether the signature is correct.
  */
 export async function verifySignature(
   input: ICredentialPresentation,
@@ -245,18 +228,19 @@ export async function verifySignature(
     challenge?: string
     didResolve?: DidResolve
   } = {}
-): Promise<boolean> {
+): Promise<void> {
   const { claimerSignature } = input
-  if (!isDidSignature(claimerSignature)) return false
-  if (challenge && challenge !== claimerSignature.challenge) return false
+  if (challenge && challenge !== claimerSignature.challenge)
+    throw new SDKErrors.SignatureUnverifiableError(
+      'Challenge differs from expected'
+    )
   const signingData = makeSigningData(input, claimerSignature.challenge)
-  const { verified } = await verifyDidSignature({
+  await verifyDidSignature({
     signature: claimerSignature,
     message: signingData,
     expectedVerificationMethod: 'authentication',
     didResolve,
   })
-  return verified
 }
 
 export type Options = {
@@ -319,11 +303,7 @@ export async function verifyCredential(
   verifyDataIntegrity(credential)
 
   if (ctype) {
-    const isSchemaValid = verifyAgainstCType(credential, ctype)
-    if (!isSchemaValid)
-      throw new SDKErrors.CredentialUnverifiableError(
-        'CType verification failed'
-      )
+    verifyAgainstCType(credential, ctype)
   }
 }
 
@@ -343,12 +323,10 @@ export async function verifyPresentation(
   { ctype, challenge, didResolve = resolve }: VerifyOptions = {}
 ): Promise<void> {
   await verifyCredential(presentation, { ctype })
-  const isSignatureCorrect = await verifySignature(presentation, {
+  await verifySignature(presentation, {
     challenge,
     didResolve,
   })
-  if (!isSignatureCorrect)
-    throw new SDKErrors.CredentialUnverifiableError('Signature not verifiable')
 }
 
 /**

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -149,9 +149,7 @@ export function verifyDataIntegrity(input: ICredential): void {
   })
 
   // check legitimations
-  input.legitimations.forEach((legitimation) => {
-    verifyDataIntegrity(legitimation)
-  })
+  input.legitimations.forEach(verifyDataIntegrity)
 }
 
 /**

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -52,10 +52,12 @@ describe('CType', () => {
   it('verifies the metadata of a ctype', async () => {
     expect(() => CType.verifyCTypeMetadata(metadata)).not.toThrow()
     expect(metadata.ctypeHash).not.toHaveLength(0)
-    expect(CType.verifyObjectAgainstSchema(metadata, MetadataModel)).toBe(true)
-    expect(CType.verifyObjectAgainstSchema(ctypeMetadata, MetadataModel)).toBe(
-      false
-    )
+    expect(() =>
+      CType.verifyObjectAgainstSchema(metadata, MetadataModel)
+    ).not.toThrow()
+    expect(() =>
+      CType.verifyObjectAgainstSchema(ctypeMetadata, MetadataModel)
+    ).toThrow()
   })
   it('checks if the metadata matches corresponding ctype hash', async () => {
     expect(metadata.ctypeHash).toEqual(ctype.hash)

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -83,7 +83,7 @@ describe('CType', () => {
       CType.verifyClaimAgainstSchema(claim.contents, claimCtype.schema)
     ).not.toThrow()
     claim.contents.name = 123
-    expect(() => 
+    expect(() =>
       CType.verifyClaimAgainstSchema(claim.contents, claimCtype.schema)
     ).toThrow()
   })

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -25,7 +25,6 @@ import { Crypto, SDKErrors, JsonSchema } from '@kiltprotocol/utils'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import { ConfigService } from '@kiltprotocol/config'
 import type { HexString } from '@polkadot/util/types'
-import { fromChain } from './CType.chain.js'
 import {
   CTypeModel,
   CTypeWrapperModel,
@@ -96,24 +95,28 @@ export function getIdForSchema(
  * @param object Data to be verified against schema.
  * @param schema Schema to verify against.
  * @param messages Optional empty array. If passed, this receives all verification errors.
- * @returns Whether or not verification was successful.
  */
 export function verifyObjectAgainstSchema(
   object: Record<string, any>,
   schema: Record<string, any>,
   messages?: string[]
-): boolean {
+): void {
   const validator = new JsonSchema.Validator(schema, '7', false)
   if (schema.$id !== CTypeModel.$id) {
     validator.addSchema(CTypeModel)
   }
   const result = validator.validate(object)
-  if (!result.valid && messages) {
-    result.errors.forEach((error) => {
-      messages.push(error.error)
-    })
+  if (!result.valid) {
+    if (messages) {
+      result.errors.forEach((error) => {
+        messages.push(error.error)
+      })
+    }
+    throw new SDKErrors.ObjectUnverifiableError(
+      'JSON schema verification failed for object',
+      { cause: result.errors }
+    )
   }
-  return result.valid
 }
 
 /**
@@ -122,41 +125,28 @@ export function verifyObjectAgainstSchema(
  * @param claimContents IClaim['contents'] to be verified against the schema.
  * @param schema ICType['schema'] to be verified against the [CTypeModel].
  * @param messages An array, which will be filled by schema errors.
- * @returns Boolean whether both claimContents and schema could be verified.
  */
 export function verifyClaimAgainstSchema(
   claimContents: IClaim['contents'],
   schema: ICType['schema'],
   messages?: string[]
-): boolean {
-  if (!verifyObjectAgainstSchema(schema, CTypeModel)) {
-    throw new SDKErrors.ObjectUnverifiableError()
-  }
-  return verifyObjectAgainstSchema(claimContents, schema, messages)
+): void {
+  verifyObjectAgainstSchema(schema, CTypeModel)
+  verifyObjectAgainstSchema(claimContents, schema, messages)
 }
 
 /**
  * Checks on the KILT blockchain whether a CType is registered.
  *
  * @param ctype CType data.
- * @returns Whether or not the CType is registered on-chain.
  */
-export async function verifyStored(ctype: ICType): Promise<boolean> {
+export async function verifyStored(ctype: ICType): Promise<void> {
   const api = ConfigService.get('api')
   const encoded = await api.query.ctype.ctypes(ctype.hash)
-  return encoded.isSome
-}
-
-/**
- * Checks on the KILT blockchain whether a CType is registered to the owner listed in the CType record.
- *
- * @param ctype CType data.
- * @returns Whether or not the CType is registered on-chain to `ctype.owner`.
- */
-export async function verifyOwner(ctype: ICType): Promise<boolean> {
-  const api = ConfigService.get('api')
-  const encoded = await api.query.ctype.ctypes(ctype.hash)
-  return encoded.isSome ? fromChain(encoded) === ctype.owner : false
+  if (encoded.isNone)
+    throw new SDKErrors.CTypeHashMissingError(
+      `CType with hash ${ctype.hash} is not registered on chain`
+    )
 }
 
 /**
@@ -166,9 +156,7 @@ export async function verifyOwner(ctype: ICType): Promise<boolean> {
  * @param input The potentially only partial ICType.
  */
 export function verifyDataStructure(input: ICType): void {
-  if (!verifyObjectAgainstSchema(input, CTypeWrapperModel)) {
-    throw new SDKErrors.ObjectUnverifiableError()
-  }
+  verifyObjectAgainstSchema(input, CTypeWrapperModel)
   if (!('schema' in input) || getHashForSchema(input.schema) !== input.hash) {
     throw new SDKErrors.HashMalformedError(input.hash, 'CType')
   }
@@ -190,27 +178,29 @@ export function verifyDataStructure(input: ICType): void {
  * @param nestedCTypes - An array of [[CType]] schemas.
  * @param claimContents - The contents of a [[Claim]] to be validated.
  * @param messages - Optional empty array. If passed, this receives all verification errors.
- *
- * @returns Whether the contents is valid.
  */
 export function verifyClaimAgainstNestedSchemas(
   cType: ICType['schema'],
   nestedCTypes: Array<ICType['schema']>,
   claimContents: Record<string, any>,
   messages?: string[]
-): boolean {
+): void {
   const validator = new JsonSchema.Validator(cType, '7', false)
   nestedCTypes.forEach((ctype) => {
     validator.addSchema(ctype)
   })
   validator.addSchema(CTypeModel)
   const result = validator.validate(claimContents)
-  if (!result.valid && messages) {
-    result.errors.forEach((error) => {
-      messages.push(error.error)
+  if (!result.valid) {
+    if (messages) {
+      result.errors.forEach((error) => {
+        messages.push(error.error)
+      })
+    }
+    throw new SDKErrors.NestedClaimUnverifiableError(undefined, {
+      cause: result.errors,
     })
   }
-  return result.valid
 }
 
 /**
@@ -219,9 +209,7 @@ export function verifyClaimAgainstNestedSchemas(
  * @param metadata [[ICTypeMetadata]] that is to be instantiated.
  */
 export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
-  if (!verifyObjectAgainstSchema(metadata, MetadataModel)) {
-    throw new SDKErrors.ObjectUnverifiableError()
-  }
+  verifyObjectAgainstSchema(metadata, MetadataModel)
 }
 
 /**

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -105,18 +105,17 @@ export function verifyObjectAgainstSchema(
   if (schema.$id !== CTypeModel.$id) {
     validator.addSchema(CTypeModel)
   }
-  const result = validator.validate(object)
-  if (!result.valid) {
-    if (messages) {
-      result.errors.forEach((error) => {
-        messages.push(error.error)
-      })
-    }
-    throw new SDKErrors.ObjectUnverifiableError(
-      'JSON schema verification failed for object',
-      { cause: result.errors }
-    )
+  const { valid, errors } = validator.validate(object)
+  if (valid === true) return
+  if (messages) {
+    errors.forEach((error) => {
+      messages.push(error.error)
+    })
   }
+  throw new SDKErrors.ObjectUnverifiableError(
+    'JSON schema verification failed for object',
+    { cause: errors }
+  )
 }
 
 /**
@@ -190,17 +189,16 @@ export function verifyClaimAgainstNestedSchemas(
     validator.addSchema(ctype)
   })
   validator.addSchema(CTypeModel)
-  const result = validator.validate(claimContents)
-  if (!result.valid) {
-    if (messages) {
-      result.errors.forEach((error) => {
-        messages.push(error.error)
-      })
-    }
-    throw new SDKErrors.NestedClaimUnverifiableError(undefined, {
-      cause: result.errors,
+  const { valid, errors } = validator.validate(claimContents)
+  if (valid === true) return
+  if (messages) {
+    errors.forEach((error) => {
+      messages.push(error.error)
     })
   }
+  throw new SDKErrors.NestedClaimUnverifiableError(undefined, {
+    cause: errors,
+  })
 }
 
 /**

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -153,7 +153,7 @@ describe('Nested CTypes', () => {
   })
 
   it('verify json-schema validator', () => {
-    expect(() => 
+    expect(() =>
       CType.verifyClaimAgainstNestedSchemas(
         nestedCType.schema,
         [passport.schema, kyc.schema],
@@ -170,7 +170,7 @@ describe('Nested CTypes', () => {
         didAlice
       )
     ).toThrowError(SDKErrors.NestedClaimUnverifiableError)
-    expect(() => 
+    expect(() =>
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType.schema,
         [passport.schema, kyc.schema],
@@ -178,7 +178,7 @@ describe('Nested CTypes', () => {
       )
     ).not.toThrow()
     ;(claimDeepContents.passport as Record<string, unknown>).fullName = {}
-    expect(()=> 
+    expect(() =>
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType.schema,
         [passport.schema, kyc.schema],

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -153,13 +153,13 @@ describe('Nested CTypes', () => {
   })
 
   it('verify json-schema validator', () => {
-    expect(
+    expect(() => 
       CType.verifyClaimAgainstNestedSchemas(
         nestedCType.schema,
         [passport.schema, kyc.schema],
         claimContents
       )
-    ).toBe(true)
+    ).not.toThrow()
 
     claimContents.fullName = {}
     expect(() =>
@@ -170,21 +170,21 @@ describe('Nested CTypes', () => {
         didAlice
       )
     ).toThrowError(SDKErrors.NestedClaimUnverifiableError)
-    expect(
+    expect(() => 
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType.schema,
         [passport.schema, kyc.schema],
         claimDeepContents
       )
-    ).toBe(true)
+    ).not.toThrow()
     ;(claimDeepContents.passport as Record<string, unknown>).fullName = {}
-    expect(
+    expect(()=> 
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType.schema,
         [passport.schema, kyc.schema],
         claimDeepContents
       )
-    ).toBe(false)
+    ).toThrow()
   })
 
   it('verify claim from a nested ctype', () => {

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -145,8 +145,8 @@ describe('DelegationNode', () => {
         } as DelegationNode,
       }
 
-      expect(
-        await new DelegationNode({
+      await expect(
+        new DelegationNode({
           id: successId,
           hierarchyId,
           account: didAlice,
@@ -155,10 +155,10 @@ describe('DelegationNode', () => {
           parentId: undefined,
           revoked: false,
         }).verify()
-      ).toBe(true)
+      ).resolves.not.toThrow()
 
-      expect(
-        await new DelegationNode({
+      await expect(
+        new DelegationNode({
           id: failureId,
           hierarchyId,
           account: didAlice,
@@ -167,7 +167,7 @@ describe('DelegationNode', () => {
           parentId: undefined,
           revoked: false,
         }).verify()
-      ).toBe(false)
+      ).rejects.toThrow()
     })
 
     it('get delegation root', async () => {

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -323,12 +323,14 @@ export class DelegationNode implements IDelegationNode {
 
   /**
    * Verifies the delegation node by querying it from chain and checking its revocation status.
-   *
-   * @returns Promise containing a boolean flag.
    */
-  public async verify(): Promise<boolean> {
+  public async verify(): Promise<void> {
     const node = await query(this.id)
-    return node !== null && !node.revoked
+    if (!node || node.revoked !== false) {
+      throw new SDKErrors.InvalidDelegationNodeError(
+        'Delegation node not found or revoked'
+      )
+    }
   }
 
   /**

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -168,7 +168,7 @@ describe('Quote', () => {
       validAttesterSignedQuote.attesterSignature.keyUri
     )
 
-    expect(
+    expect(() =>
       Crypto.verify(
         Crypto.hashObjectAsStr({
           attesterDid: validQuoteData.attesterDid,
@@ -184,7 +184,7 @@ describe('Quote', () => {
             new Uint8Array()
         )
       )
-    ).toBe(true)
+    ).not.toThrow()
     await Quote.verifyAttesterSignedQuote(validAttesterSignedQuote, {
       didResolve: mockResolve,
     })

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -108,17 +108,12 @@ export async function verifyAttesterSignedQuote(
   } = {}
 ): Promise<void> {
   const { attesterSignature, ...basicQuote } = quote
-  const result = await verifyDidSignature({
+  await verifyDidSignature({
     signature: attesterSignature,
     message: Crypto.hashObjectAsStr(basicQuote),
     expectedVerificationMethod: 'authentication',
     didResolve,
   })
-
-  if (!result.verified) {
-    // TODO: should throw a "signature not verifiable" error, with the reason attached.
-    throw new SDKErrors.QuoteUnverifiableError()
-  }
 
   const messages: string[] = []
   if (!validateQuoteSchema(QuoteSchema, basicQuote, messages)) {
@@ -158,15 +153,12 @@ export async function createQuoteAgreement(
       attesterSignedQuote.attesterDid
     )
 
-  const { verified, reason } = await verifyDidSignature({
+  await verifyDidSignature({
     signature: attesterSignature,
     message: Crypto.hashObjectAsStr(basicQuote),
     expectedVerificationMethod: 'authentication',
     didResolve,
   })
-  if (!verified && reason) {
-    throw new SDKErrors.SignatureUnverifiableError(reason)
-  }
 
   const signature = await Did.signPayload(
     claimerIdentity,

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@kiltprotocol/testing": "workspace:*",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/augment-api": "workspace:*",

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -26,11 +26,7 @@ import {
 import { ss58Format } from '@kiltprotocol/utils'
 import { makeSigningKeyTool } from '@kiltprotocol/testing'
 import * as Did from './index.js'
-import {
-  VerificationResult,
-  verifyDidSignature,
-  isDidSignature,
-} from './Did.signature'
+import { verifyDidSignature, isDidSignature } from './Did.signature'
 import { resolve } from './DidResolver'
 
 jest.mock('./DidResolver')
@@ -72,17 +68,13 @@ describe('light DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: true,
-      did,
-      key: did.authentication[0],
-    })
+    ).resolves.not.toThrow()
   })
 
   it('verifies old did signature (with `keyId` property) over string', async () => {
@@ -110,11 +102,7 @@ describe('light DID', () => {
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).resolves.toMatchObject<VerificationResult>({
-      verified: true,
-      did,
-      key: did.authentication[0],
-    })
+    ).resolves.not.toThrow()
   })
 
   it('verifies did signature over bytes', async () => {
@@ -125,17 +113,13 @@ describe('light DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(
+      verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: true,
-      did,
-      key: did.authentication[0],
-    })
+    ).resolves.not.toThrow()
   })
 
   it('fails if relationship does not match', async () => {
@@ -146,16 +130,13 @@ describe('light DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'assertionMethod',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/verification method/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('fails if key id does not match', async () => {
@@ -167,16 +148,13 @@ describe('light DID', () => {
       did.authentication[0].id
     )
     signature.keyUri += '1a'
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/no key with id/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('fails if signature does not match', async () => {
@@ -187,16 +165,13 @@ describe('light DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING.substring(1),
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/invalid signature/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('fails if key id malformed', async () => {
@@ -209,16 +184,13 @@ describe('light DID', () => {
     )
     // @ts-expect-error
     signature.keyUri = signature.keyUri.replace('#', '?')
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/Signature key URI .+ invalid/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('does not verify if migrated to Full DID', async () => {
@@ -236,16 +208,13 @@ describe('light DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/migrated/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('typeguard accepts legal signature objects', () => {
@@ -302,17 +271,13 @@ describe('full DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: true,
-      did,
-      key: did.authentication[0],
-    })
+    ).resolves.not.toThrow()
   })
 
   it('verifies did signature over bytes', async () => {
@@ -323,17 +288,13 @@ describe('full DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(
+      verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: true,
-      did,
-      key: did.authentication[0],
-    })
+    ).resolves.not.toThrow()
   })
 
   it('does not verify if deactivated', async () => {
@@ -350,16 +311,13 @@ describe('full DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/deactivated/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('does not verify if not on chain', async () => {
@@ -371,16 +329,13 @@ describe('full DID', () => {
       sign,
       did.authentication[0].id
     )
-    expect(
-      await verifyDidSignature({
+    await expect(() =>
+      verifyDidSignature({
         message: SIGNED_STRING,
         signature,
         expectedVerificationMethod: 'authentication',
       })
-    ).toMatchObject<VerificationResult>({
-      verified: false,
-      reason: expect.stringMatching(/no result/i),
-    })
+    ).rejects.toThrow()
   })
 
   it('typeguard accepts legal signature objects', () => {

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -28,13 +28,19 @@ export type DidSignatureVerificationInput = {
   didResolve?: DidResolve
 }
 
+// Used solely for retro-compatibility with previously-generated DID signatures.
+// It is reasonable to think that it will be removed at some point in the future.
+type OldDidSignature = Pick<DidSignature, 'signature'> & {
+  keyId: DidSignature['keyUri']
+}
+
 /**
  * Checks whether the input is a valid DidSignature object, consisting of a signature as hex and the uri of the signing key.
  * Does not cryptographically verify the signature itself!
  *
  * @param input Arbitrary input.
  */
- export function verifyDidSignatureDataStructure(
+export function verifyDidSignatureDataStructure(
   input: DidSignature | OldDidSignature
 ): void {
   const keyUri = 'keyUri' in input ? input.keyUri : input.keyId
@@ -115,12 +121,6 @@ export async function verifyDidSignature({
     )
   }
   Crypto.verify(message, signature.signature, u8aToHex(key.publicKey))
-}
-
-// Used solely for retro-compatibility with previously-generated DID signatures.
-// It is reasonable to think that it will be removed at some point in the future.
-type OldDidSignature = Pick<DidSignature, 'signature'> & {
-  keyId: DidSignature['keyUri']
 }
 
 /**

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -12,78 +12,38 @@ import {
   DidResolve,
   DidResourceUri,
   DidSignature,
-  DidVerificationKey,
   UriFragment,
   VerificationKeyRelationship,
 } from '@kiltprotocol/types'
-import { Crypto } from '@kiltprotocol/utils'
+import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 
 import { resolve } from './DidResolver/index.js'
-import { parseDidUri, isKiltDidUri } from './Did.utils.js'
+import { parseDidUri, validateKiltDidUri } from './Did.utils.js'
 import * as Did from './index.js'
-
-type DidSignatureVerificationFromDetailsInput = {
-  message: string | Uint8Array
-  signature: string
-  keyId: DidVerificationKey['id']
-  expectedVerificationMethod?: VerificationKeyRelationship
-  did: DidDocument
-}
-
-export type VerificationResult = {
-  verified: boolean
-  reason?: string
-  did?: DidDocument
-  key?: DidVerificationKey
-}
-
-function verifyDidSignatureFromDetails({
-  message,
-  signature,
-  keyId,
-  expectedVerificationMethod,
-  did,
-}: DidSignatureVerificationFromDetailsInput): VerificationResult {
-  const key = Did.getKey(did, keyId)
-  if (!key) {
-    return {
-      verified: false,
-      reason: `No key with ID "${keyId}" for the DID ${did.uri}`,
-    }
-  }
-  // Check whether the provided key ID is within the keys for a given verification relationship, if provided.
-  if (
-    expectedVerificationMethod &&
-    !did[expectedVerificationMethod]?.map((verKey) => verKey.id).includes(keyId)
-  ) {
-    return {
-      verified: false,
-      reason: `No key with ID "${keyId}" for the verification method "${expectedVerificationMethod}"`,
-    }
-  }
-  const isSignatureValid = Crypto.verify(
-    message,
-    signature,
-    u8aToHex(key.publicKey)
-  )
-  if (!isSignatureValid) {
-    return {
-      verified: false,
-      reason: 'Invalid signature',
-    }
-  }
-  return {
-    verified: true,
-    did,
-    key: key as DidVerificationKey,
-  }
-}
 
 export type DidSignatureVerificationInput = {
   message: string | Uint8Array
   signature: DidSignature
   expectedVerificationMethod?: VerificationKeyRelationship
   didResolve?: DidResolve
+}
+
+/**
+ * Checks whether the input is a valid DidSignature object, consisting of a signature as hex and the uri of the signing key.
+ * Does not cryptographically verify the signature itself!
+ *
+ * @param input Arbitrary input.
+ */
+ export function verifyDidSignatureDataStructure(
+  input: DidSignature | OldDidSignature
+): void {
+  const keyUri = 'keyUri' in input ? input.keyUri : input.keyId
+  if (!isHex(input.signature)) {
+    throw new SDKErrors.SignatureMalformedError(
+      `Expected signature as a hex string, got ${input.signature}`
+    )
+  }
+  validateKiltDidUri(keyUri, 'ResourceUri')
 }
 
 /**
@@ -95,53 +55,43 @@ export type DidSignatureVerificationInput = {
  * @param input.signature An object containing signature and signer key.
  * @param input.expectedVerificationMethod Which relationship to the signer DID the key must have.
  * @param input.didResolve Allows specifying a custom DID resolve. Defaults to the built-in [[resolve]].
- * @returns Object indicating verification result and optionally reason for failure.
  */
 export async function verifyDidSignature({
   message,
   signature,
   expectedVerificationMethod,
   didResolve = resolve,
-}: DidSignatureVerificationInput): Promise<VerificationResult> {
-  let keyId: UriFragment
-  let keyUri: DidResourceUri
-  try {
-    // Add support for old signatures that had the `keyId` instead of the `keyUri`
-    const inputUri = signature.keyUri || (signature as any).keyId
-    // Verification fails if the signature key URI is not valid
-    const { fragment } = parseDidUri(inputUri)
-    if (!fragment) throw new Error()
+}: DidSignatureVerificationInput): Promise<void> {
+  verifyDidSignatureDataStructure(signature)
+  // Add support for old signatures that had the `keyId` instead of the `keyUri`
+  const inputUri = signature.keyUri || (signature as any).keyId
+  // Verification fails if the signature key URI is not valid
+  const { fragment } = parseDidUri(inputUri)
+  if (!fragment)
+    throw new SDKErrors.SignatureMalformedError(
+      `Signature key URI "${signature.keyUri}" invalid`
+    )
 
-    keyId = fragment
-    keyUri = inputUri
-  } catch {
-    return {
-      verified: false,
-      reason: `Signature key URI "${signature.keyUri}" invalid`,
-    }
-  }
+  const keyId: UriFragment = fragment
+  const keyUri: DidResourceUri = inputUri
+
   const resolutionDetails = await didResolve(keyUri)
   // Verification fails if the DID does not exist at all.
   if (!resolutionDetails) {
-    return {
-      verified: false,
-      reason: `No result for provided key URI "${keyUri}"`,
-    }
+    throw new SDKErrors.DidError(`No result for provided key URI "${keyUri}"`)
   }
+
   // Verification also fails if the DID has been deleted.
   if (resolutionDetails.metadata.deactivated) {
-    return {
-      verified: false,
-      reason: 'DID for provided key is deactivated',
-    }
+    throw new SDKErrors.DidError('DID for provided key is deactivated')
   }
   // Verification also fails if the signer is a migrated light DID.
   if (resolutionDetails.metadata.canonicalId) {
-    return {
-      verified: false,
-      reason: 'DID for provided key has been migrated and not usable anymore',
-    }
+    throw new SDKErrors.DidError(
+      'DID for provided key has been migrated and not usable anymore'
+    )
   }
+
   // Otherwise, the document used is either the migrated full DID document or the light DID document.
   const did = (
     resolutionDetails.metadata.canonicalId !== undefined
@@ -149,13 +99,22 @@ export async function verifyDidSignature({
       : resolutionDetails.document
   ) as DidDocument
 
-  return verifyDidSignatureFromDetails({
-    message,
-    signature: signature.signature,
-    keyId,
-    expectedVerificationMethod,
-    did,
-  })
+  const key = Did.getKey(did, keyId)
+  if (!key) {
+    throw new SDKErrors.DidError(
+      `No key with ID "${keyId}" for the DID ${did.uri}`
+    )
+  }
+  // Check whether the provided key ID is within the keys for a given verification relationship, if provided.
+  if (
+    expectedVerificationMethod &&
+    !did[expectedVerificationMethod]?.map((verKey) => verKey.id).includes(keyId)
+  ) {
+    throw new SDKErrors.DidError(
+      `No key with ID "${keyId}" for the verification method "${expectedVerificationMethod}"`
+    )
+  }
+  Crypto.verify(message, signature.signature, u8aToHex(key.publicKey))
 }
 
 // Used solely for retro-compatibility with previously-generated DID signatures.
@@ -174,12 +133,8 @@ type OldDidSignature = Pick<DidSignature, 'signature'> & {
 export function isDidSignature(
   input: unknown
 ): input is DidSignature | OldDidSignature {
-  const signature = input as DidSignature | OldDidSignature
   try {
-    const keyUri = 'keyUri' in signature ? signature.keyUri : signature.keyId
-    if (!isHex(signature.signature) || !isKiltDidUri(keyUri, 'ResourceUri')) {
-      return false
-    }
+    verifyDidSignatureDataStructure(input as DidSignature)
     return true
   } catch (cause) {
     return false

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -325,12 +325,12 @@ export function checkServiceEndpointSizeConstraints(
     maxServiceTypeLength,
     maxServiceUrlLength,
   ] = [
-      api.consts.did.maxServiceIdLength.toNumber(),
-      api.consts.did.maxNumberOfTypesPerService.toNumber(),
-      api.consts.did.maxNumberOfUrlsPerService.toNumber(),
-      api.consts.did.maxServiceTypeLength.toNumber(),
-      api.consts.did.maxServiceUrlLength.toNumber(),
-    ]
+    api.consts.did.maxServiceIdLength.toNumber(),
+    api.consts.did.maxNumberOfTypesPerService.toNumber(),
+    api.consts.did.maxNumberOfUrlsPerService.toNumber(),
+    api.consts.did.maxServiceTypeLength.toNumber(),
+    api.consts.did.maxServiceUrlLength.toNumber(),
+  ]
   const errors: Error[] = []
 
   const idEncodedLength = stringToU8a(stripFragment(endpoint.id)).length

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -196,7 +196,7 @@ export function validateKiltDidUri(
       break
   }
 
-  DataUtils.validateAddress(address, 'DID')
+  DataUtils.verifyKiltAddress(address)
 }
 
 export function isKiltDidUri(

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@kiltprotocol/testing": "workspace:*",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/core": "workspace:*",

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -92,7 +92,7 @@ export function verifyMessageBody(body: MessageBody): void {
         Credential.verifyDataStructure(credential)
       )
       if (body.content.delegationId) {
-        DataUtils.verifyIsHex(body.content.delegationId, 32)
+        DataUtils.verifyIsHex(body.content.delegationId)
       }
       if (body.content.quote) {
         Quote.validateQuoteSchema(Quote.QuoteSchema, body.content.quote)
@@ -105,7 +105,7 @@ export function verifyMessageBody(body: MessageBody): void {
     case 'reject-terms': {
       Claim.verifyDataStructure(body.content.claim)
       if (body.content.delegationId) {
-        DataUtils.verifyIsHex(body.content.delegationId, 32)
+        DataUtils.verifyIsHex(body.content.delegationId)
       }
       body.content.legitimations.forEach((val) =>
         Credential.verifyDataStructure(val)
@@ -132,7 +132,7 @@ export function verifyMessageBody(body: MessageBody): void {
     case 'request-credential': {
       body.content.cTypes.forEach(
         ({ cTypeHash, trustedAttesters, requiredProperties }): void => {
-          DataUtils.verifyIsHex(cTypeHash, 32)
+          DataUtils.verifyIsHex(cTypeHash)
           trustedAttesters?.forEach((did) =>
             Did.Utils.validateKiltDidUri(did, 'Did')
           )
@@ -156,11 +156,11 @@ export function verifyMessageBody(body: MessageBody): void {
       break
     }
     case 'accept-credential': {
-      body.content.forEach((cTypeHash) => DataUtils.verifyIsHex(cTypeHash, 32))
+      body.content.forEach((cTypeHash) => DataUtils.verifyIsHex(cTypeHash))
       break
     }
     case 'reject-credential': {
-      body.content.forEach((cTypeHash) => DataUtils.verifyIsHex(cTypeHash, 32))
+      body.content.forEach((cTypeHash) => DataUtils.verifyIsHex(cTypeHash))
       break
     }
     case 'request-accept-delegation': {
@@ -189,7 +189,7 @@ export function verifyMessageBody(body: MessageBody): void {
       break
     }
     case 'inform-create-delegation': {
-      DataUtils.verifyIsHex(body.content.delegationId, 32)
+      DataUtils.verifyIsHex(body.content.delegationId)
       break
     }
 

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -92,10 +92,7 @@ export function verifyMessageBody(body: MessageBody): void {
         Credential.verifyDataStructure(credential)
       )
       if (body.content.delegationId) {
-        DataUtils.validateHash(
-          body.content.delegationId,
-          'Submit terms delegation id hash invalid'
-        )
+        DataUtils.verifyIsHex(body.content.delegationId, 32)
       }
       if (body.content.quote) {
         Quote.validateQuoteSchema(Quote.QuoteSchema, body.content.quote)
@@ -108,10 +105,7 @@ export function verifyMessageBody(body: MessageBody): void {
     case 'reject-terms': {
       Claim.verifyDataStructure(body.content.claim)
       if (body.content.delegationId) {
-        DataUtils.validateHash(
-          body.content.delegationId,
-          'Reject terms delegation id hash'
-        )
+        DataUtils.verifyIsHex(body.content.delegationId, 32)
       }
       body.content.legitimations.forEach((val) =>
         Credential.verifyDataStructure(val)
@@ -138,10 +132,7 @@ export function verifyMessageBody(body: MessageBody): void {
     case 'request-credential': {
       body.content.cTypes.forEach(
         ({ cTypeHash, trustedAttesters, requiredProperties }): void => {
-          DataUtils.validateHash(
-            cTypeHash,
-            'request credential cTypeHash invalid'
-          )
+          DataUtils.verifyIsHex(cTypeHash, 32)
           trustedAttesters?.forEach((did) =>
             Did.Utils.validateKiltDidUri(did, 'Did')
           )
@@ -165,21 +156,11 @@ export function verifyMessageBody(body: MessageBody): void {
       break
     }
     case 'accept-credential': {
-      body.content.forEach((cTypeHash) =>
-        DataUtils.validateHash(
-          cTypeHash,
-          'accept credential message ctype hash invalid'
-        )
-      )
+      body.content.forEach((cTypeHash) => DataUtils.verifyIsHex(cTypeHash, 32))
       break
     }
     case 'reject-credential': {
-      body.content.forEach((cTypeHash) =>
-        DataUtils.validateHash(
-          cTypeHash,
-          'rejected credential ctype hashes invalid'
-        )
-      )
+      body.content.forEach((cTypeHash) => DataUtils.verifyIsHex(cTypeHash, 32))
       break
     }
     case 'request-accept-delegation': {
@@ -208,10 +189,7 @@ export function verifyMessageBody(body: MessageBody): void {
       break
     }
     case 'inform-create-delegation': {
-      DataUtils.validateHash(
-        body.content.delegationId,
-        'inform create delegation message delegation id invalid'
-      )
+      DataUtils.verifyIsHex(body.content.delegationId, 32)
       break
     }
 

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -38,7 +38,7 @@
     "rimraf": "^3.0.2",
     "stream-browserify": "^3.0.0",
     "terser-webpack-plugin": "^5.1.1",
-    "typescript": "^4.5.4",
+    "typescript": "^4.8.3",
     "url": "^0.11.0",
     "util": "^0.12.4",
     "webpack": "^5.70.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -44,6 +44,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,6 +39,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/KILTprotocol/sdk-js#readme",
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/types": "workspace:*",

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -32,6 +32,7 @@ import nacl from 'tweetnacl'
 import { v4 as uuid } from 'uuid'
 import type { HexString } from '@polkadot/util/types'
 import jsonabc from './jsonabc.js'
+import * as SDKErrors from './SDKErrors.js'
 
 export { naclBoxPairFromSecret } from '@polkadot/util-crypto'
 
@@ -105,14 +106,14 @@ export function signStr(
  * @param message Original signed message to be verified.
  * @param signature Signature as hex string or byte array.
  * @param address Substrate address or public key of the signer.
- * @returns Whether the signature could be verified.
  */
 export function verify(
   message: CryptoInput,
   signature: CryptoInput,
   address: Address
-): boolean {
-  return signatureVerify(message, signature, address).isValid === true
+): void {
+  if (signatureVerify(message, signature, address).isValid !== true)
+    throw new SDKErrors.SignatureUnverifiableError()
 }
 
 export type BitLength = 64 | 128 | 256 | 384 | 512

--- a/packages/utils/src/DataUtils.spec.ts
+++ b/packages/utils/src/DataUtils.spec.ts
@@ -19,13 +19,12 @@ const key = Buffer.from([0, 0, 7, 0])
 
 it('validates address with prefix 38', () => {
   expect(() => verifyKiltAddress(encodeAddress(key, ss58Format))).not.toThrow()
-  expect(verifyKiltAddress(encodeAddress(key, ss58Format))).toBe(true)
 })
 
 it('throws on address with other prefix', () => {
   expect(() =>
     verifyKiltAddress(encodeAddress(key, 42) as KiltAddress)
-  ).toThrow('test')
+  ).toThrow()
 })
 
 it('throws for random strings', () => {
@@ -52,7 +51,7 @@ it('throws if address is no string', () => {
 it('validates hash', () => {
   ;['wurst', 'a', '1'].forEach((value) => {
     const hash = Crypto.hashStr(value)
-    expect(verifyIsHex(hash)).toBe(true)
+    expect(() => verifyIsHex(hash)).not.toThrow()
   })
 })
 

--- a/packages/utils/src/DataUtils.spec.ts
+++ b/packages/utils/src/DataUtils.spec.ts
@@ -10,122 +10,73 @@
  */
 
 import { encodeAddress } from '@polkadot/keyring'
-import type { KiltAddress, KiltKeyringPair } from '@kiltprotocol/types'
-import { Keyring, SDKErrors, ss58Format } from './index'
-import { validateAddress, validateHash, validateSignature } from './DataUtils'
+import type { KiltAddress } from '@kiltprotocol/types'
+import { SDKErrors, ss58Format } from './index'
+import { verifyKiltAddress, verifyIsHex } from './DataUtils'
 import * as Crypto from './Crypto'
 
 const key = Buffer.from([0, 0, 7, 0])
 
 it('validates address with prefix 38', () => {
-  expect(() =>
-    validateAddress(encodeAddress(key, ss58Format), 'test')
-  ).not.toThrow()
-  expect(validateAddress(encodeAddress(key, ss58Format), 'test')).toBe(true)
+  expect(() => verifyKiltAddress(encodeAddress(key, ss58Format))).not.toThrow()
+  expect(verifyKiltAddress(encodeAddress(key, ss58Format))).toBe(true)
 })
 
 it('throws on address with other prefix', () => {
   expect(() =>
-    validateAddress(encodeAddress(key, 42) as KiltAddress, 'test')
+    verifyKiltAddress(encodeAddress(key, 42) as KiltAddress)
   ).toThrow('test')
 })
 
 it('throws for random strings', () => {
-  expect(() => validateAddress('' as KiltAddress, 'test')).toThrowError(
+  expect(() => verifyKiltAddress('' as KiltAddress)).toThrowError(
     SDKErrors.AddressInvalidError
   )
-  expect(() => validateAddress('0x123' as KiltAddress, 'test')).toThrowError(
+  expect(() => verifyKiltAddress('0x123' as KiltAddress)).toThrowError(
+    SDKErrors.AddressInvalidError
+  )
+  expect(() => verifyKiltAddress('bananenbabara' as KiltAddress)).toThrowError(
     SDKErrors.AddressInvalidError
   )
   expect(() =>
-    validateAddress('bananenbabara' as KiltAddress, 'test')
-  ).toThrowError(SDKErrors.AddressInvalidError)
-  expect(() =>
-    validateAddress('ax843zoidsfho38290rdusa' as KiltAddress, 'test')
+    verifyKiltAddress('ax843zoidsfho38290rdusa' as KiltAddress)
   ).toThrowError(SDKErrors.AddressInvalidError)
 })
 
 it('throws if address is no string', () => {
-  expect(() =>
-    validateAddress(Buffer.from([0, 0, 7]) as any, 'test')
-  ).toThrowError(SDKErrors.AddressTypeError)
+  expect(() => verifyKiltAddress(Buffer.from([0, 0, 7]) as any)).toThrowError(
+    SDKErrors.AddressTypeError
+  )
 })
 
 it('validates hash', () => {
   ;['wurst', 'a', '1'].forEach((value) => {
     const hash = Crypto.hashStr(value)
-    expect(validateHash(hash, 'test')).toBe(true)
+    expect(verifyIsHex(hash)).toBe(true)
   })
 })
 
 it('throws on broken hashes', () => {
   const hash = Crypto.hashStr('test')
   expect(() => {
-    validateHash(hash.substr(2), 'test')
+    verifyIsHex(hash.substr(2))
   }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
-    validateHash(hash.substr(0, 60), 'test')
+    verifyIsHex(hash.substr(0, 60))
   }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
-    validateHash(hash.replace('0', 'O'), 'test')
+    verifyIsHex(hash.replace('0', 'O'))
   }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
-    validateHash(`${hash.substr(0, hash.length - 1)}ß`, 'test')
+    verifyIsHex(`${hash.substr(0, hash.length - 1)}ß`)
   }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
-    validateHash(hash.replace(/\w/i, 'P'), 'test')
+    verifyIsHex(hash.replace(/\w/i, 'P'))
   }).toThrowError(SDKErrors.HashMalformedError)
 })
 
 it('throws if hash is no string', () => {
-  expect(() =>
-    validateHash(Buffer.from([0, 0, 7]) as any, 'test')
-  ).toThrowError(SDKErrors.HashTypeError)
-})
-
-describe('validate signature util', () => {
-  const data = 'data'
-  const keyring = new Keyring({
-    type: 'ed25519',
-    ss58Format,
-  })
-  const signer = keyring.addFromUri('//Alice') as KiltKeyringPair
-  const signature = Crypto.signStr('data', signer)
-
-  it('verifies when inputs are strings and signature checks out', () => {
-    expect(validateSignature(data, signature, signer.address)).toBe(true)
-  })
-
-  it('throws when signature does not check out', () => {
-    expect(() =>
-      validateSignature('dörte', signature, signer.address)
-    ).toThrowError(SDKErrors.SignatureUnverifiableError)
-  })
-
-  it('throws non-sdk error if input is bogus', () => {
-    expect(() =>
-      validateSignature('dörte', 'signature', 'signer' as KiltAddress)
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid signature length, expected [64..66] bytes, found 9"`
-    )
-  })
-
-  it('throws when input is incomplete', () => {
-    expect(() =>
-      validateSignature('data', null as any, 'signer' as KiltAddress)
-    ).toThrowError(SDKErrors.SignatureMalformedError)
-    expect(() =>
-      validateSignature('data', 'signature', undefined as any)
-    ).toThrowError(SDKErrors.SignatureMalformedError)
-    expect(() =>
-      validateSignature(
-        { key: ['value'] } as any,
-        'signature',
-        'signer' as KiltAddress
-      )
-    ).toThrowError(SDKErrors.SignatureMalformedError)
-    expect(() => (validateSignature as any)()).toThrowError(
-      SDKErrors.SignatureMalformedError
-    )
-  })
+  expect(() => verifyIsHex(Buffer.from([0, 0, 7]) as any)).toThrowError(
+    SDKErrors.HashTypeError
+  )
 })

--- a/packages/utils/src/DataUtils.spec.ts
+++ b/packages/utils/src/DataUtils.spec.ts
@@ -61,7 +61,7 @@ it('throws on broken hashes', () => {
     verifyIsHex(hash.substr(2))
   }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
-    verifyIsHex(hash.substr(0, 60))
+    verifyIsHex(hash.substr(0, 60), 256)
   }).toThrowError(SDKErrors.HashMalformedError)
   expect(() => {
     verifyIsHex(hash.replace('0', 'O'))
@@ -76,6 +76,6 @@ it('throws on broken hashes', () => {
 
 it('throws if hash is no string', () => {
   expect(() => verifyIsHex(Buffer.from([0, 0, 7]) as any)).toThrowError(
-    SDKErrors.HashTypeError
+    SDKErrors.HashMalformedError
   )
 })

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -47,10 +47,10 @@ export { isHex } from '@polkadot/util'
  * Validates the format of a hex string via regex.
  *
  * @param input Hex string to validate for correct format.
- * @param byteLength Expected length of hex in bytes. Defaults to 32.
+ * @param bitLength Expected length of hex in bits.
  */
-export function verifyIsHex(input: unknown, byteLength = 32): void {
-  if (!isHex(input, byteLength * 8)) {
+export function verifyIsHex(input: unknown, bitLength?: number): void {
+  if (!isHex(input, bitLength)) {
     throw new SDKErrors.HashMalformedError(`${input}`)
   }
 }

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -51,6 +51,8 @@ export { isHex } from '@polkadot/util'
  */
 export function verifyIsHex(input: unknown, bitLength?: number): void {
   if (!isHex(input, bitLength)) {
-    throw new SDKErrors.HashMalformedError(`${input}`)
+    throw new SDKErrors.HashMalformedError(
+      typeof input === 'string' ? input : undefined
+    )
   }
 }

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -8,24 +8,36 @@
 import type { KiltAddress } from '@kiltprotocol/types'
 import { checkAddress } from '@polkadot/util-crypto'
 import * as SDKErrors from './SDKErrors.js'
-import { verify } from './Crypto.js'
 import { ss58Format } from './ss58Format.js'
 
 /**
  * Validates a given address string against the External Address Format (SS58) with our Prefix of 38.
  *
- * @param address Address string to validate for correct Format.
+ * @param input Address string to validate for correct Format.
  * @param name Contextual name of the address, e.g. "claim owner".
- * @returns Boolean whether the given address string checks out against the Format.
  */
-export function validateAddress(address: KiltAddress, name: string): boolean {
-  if (typeof address !== 'string') {
+export function validateAddress(input: unknown, name?: string): void {
+  if (typeof input !== 'string') {
     throw new SDKErrors.AddressTypeError()
   }
-  if (!checkAddress(address, ss58Format)[0]) {
-    throw new SDKErrors.AddressInvalidError(address, name)
+  if (!checkAddress(input, ss58Format)[0]) {
+    throw new SDKErrors.AddressInvalidError(input, name)
   }
-  return true
+}
+
+/**
+ * Type guard to check whether input is an SS58 address with our prefix of 38.
+ *
+ * @param input Address string to validate for correct format.
+ * @returns True if input is a KiltAddress, false otherwise.
+ */
+export function isKiltAddress(input: unknown): input is KiltAddress {
+  try {
+    validateAddress(input)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -33,9 +45,8 @@ export function validateAddress(address: KiltAddress, name: string): boolean {
  *
  * @param hash Hash string to validate for correct Format.
  * @param name Contextual name of the address, e.g. "claim owner".
- * @returns Boolean whether the given hash string checks out against the Format.
  */
-export function validateHash(hash: string, name: string): boolean {
+export function validateHash(hash: string, name: string): void {
   if (typeof hash !== 'string') {
     throw new SDKErrors.HashTypeError()
   }
@@ -43,31 +54,4 @@ export function validateHash(hash: string, name: string): boolean {
   if (!hash.match(blake2bPattern)) {
     throw new SDKErrors.HashMalformedError(hash, name)
   }
-  return true
-}
-
-/**
- * Validates the signature of the given signer address against the signed data.
- *
- * @param data The signed string of data.
- * @param signature The signature of the data to be validated.
- * @param signer Address of the signer identity.
- * @returns Boolean whether the signature is valid for the given data.
- */
-export function validateSignature(
-  data: string,
-  signature: string,
-  signer: KiltAddress
-): boolean {
-  if (
-    typeof data !== 'string' ||
-    typeof signature !== 'string' ||
-    typeof signer !== 'string'
-  ) {
-    throw new SDKErrors.SignatureMalformedError()
-  }
-  if (!verify(data, signature, signer)) {
-    throw new SDKErrors.SignatureUnverifiableError()
-  }
-  return true
 }

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -5,6 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import { isHex } from '@polkadot/util'
 import type { KiltAddress } from '@kiltprotocol/types'
 import { checkAddress } from '@polkadot/util-crypto'
 import * as SDKErrors from './SDKErrors.js'
@@ -39,26 +40,17 @@ export function isKiltAddress(input: unknown): input is KiltAddress {
   }
 }
 
+// re-exporting isHex
+export { isHex } from '@polkadot/util'
+
 /**
  * Validates the format of a hex string via regex.
  *
  * @param input Hex string to validate for correct format.
  * @param byteLength Expected length of hex in bytes. Defaults to 32.
- * @param prefixed Whether the hex string is expected to be prefixed with '0x'. Defaults to true.
  */
-export function verifyIsHex(
-  input: unknown,
-  byteLength = 32,
-  prefixed = true
-): void {
-  if (typeof input !== 'string') {
-    throw new SDKErrors.HashTypeError()
-  }
-  const hexStringPattern = new RegExp(
-    `^${prefixed ? '0x' : ''}[A-F0-9]{${Math.round(byteLength) * 2}}$`,
-    'i'
-  )
-  if (!input.match(hexStringPattern)) {
-    throw new SDKErrors.HashMalformedError(input)
+export function verifyIsHex(input: unknown, byteLength = 32): void {
+  if (!isHex(input, byteLength * 8)) {
+    throw new SDKErrors.HashMalformedError(`${input}`)
   }
 }

--- a/packages/utils/src/DataUtils.ts
+++ b/packages/utils/src/DataUtils.ts
@@ -11,17 +11,16 @@ import * as SDKErrors from './SDKErrors.js'
 import { ss58Format } from './ss58Format.js'
 
 /**
- * Validates a given address string against the External Address Format (SS58) with our Prefix of 38.
+ * Verifies a given address string against the External Address Format (SS58) with our Prefix of 38.
  *
  * @param input Address string to validate for correct Format.
- * @param name Contextual name of the address, e.g. "claim owner".
  */
-export function validateAddress(input: unknown, name?: string): void {
+export function verifyKiltAddress(input: unknown): void {
   if (typeof input !== 'string') {
     throw new SDKErrors.AddressTypeError()
   }
   if (!checkAddress(input, ss58Format)[0]) {
-    throw new SDKErrors.AddressInvalidError(input, name)
+    throw new SDKErrors.AddressInvalidError(input)
   }
 }
 
@@ -33,7 +32,7 @@ export function validateAddress(input: unknown, name?: string): void {
  */
 export function isKiltAddress(input: unknown): input is KiltAddress {
   try {
-    validateAddress(input)
+    verifyKiltAddress(input)
     return true
   } catch {
     return false
@@ -41,17 +40,25 @@ export function isKiltAddress(input: unknown): input is KiltAddress {
 }
 
 /**
- * Validates the format of the given blake2b hash via regex.
+ * Validates the format of a hex string via regex.
  *
- * @param hash Hash string to validate for correct Format.
- * @param name Contextual name of the address, e.g. "claim owner".
+ * @param input Hex string to validate for correct format.
+ * @param byteLength Expected length of hex in bytes. Defaults to 32.
+ * @param prefixed Whether the hex string is expected to be prefixed with '0x'. Defaults to true.
  */
-export function validateHash(hash: string, name: string): void {
-  if (typeof hash !== 'string') {
+export function verifyIsHex(
+  input: unknown,
+  byteLength = 32,
+  prefixed = true
+): void {
+  if (typeof input !== 'string') {
     throw new SDKErrors.HashTypeError()
   }
-  const blake2bPattern = new RegExp('(0x)[A-F0-9]{64}', 'i')
-  if (!hash.match(blake2bPattern)) {
-    throw new SDKErrors.HashMalformedError(hash, name)
+  const hexStringPattern = new RegExp(
+    `^${prefixed ? '0x' : ''}[A-F0-9]{${Math.round(byteLength) * 2}}$`,
+    'i'
+  )
+  if (!input.match(hexStringPattern)) {
+    throw new SDKErrors.HashMalformedError(input)
   }
 }

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -33,7 +33,7 @@
     "@kiltprotocol/testing": "workspace:*",
     "@types/jsonld": "1.5.1",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "@kiltprotocol/augment-api": "workspace:*",

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -268,22 +268,8 @@ async function runAll() {
   )
   await Blockchain.signAndSubmitTx(cTypeStoreTx, payer)
 
-  const stored = await CType.verifyStored(DriversLicense)
-  if (stored) {
-    console.info('CType successfully stored on chain')
-  } else {
-    throw new Error('CType not stored')
-  }
-
-  const result = await CType.verifyOwner({
-    ...DriversLicense,
-    owner: alice.uri,
-  })
-  if (result) {
-    console.info('Owner verified')
-  } else {
-    throw new Error('CType owner does not match ctype creator DID')
-  }
+  await CType.verifyStored(DriversLicense)
+  console.info('CType successfully stored on chain')
 
   // Attestation workflow
   console.log('Attestation workflow started')
@@ -296,9 +282,8 @@ async function runAll() {
   const credential = Credential.fromClaim(claim)
   if (!Credential.isICredential(credential))
     throw new Error('Not a valid Credential')
-  if (Credential.verifyDataIntegrity(credential))
-    console.info('Credential data verified')
-  else throw new Error('Credential not verifiable')
+  Credential.verifyDataIntegrity(credential)
+  console.info('Credential data verified')
   if (credential.claim.contents !== content)
     throw new Error('Claim content inside Credential mismatching')
 
@@ -309,9 +294,8 @@ async function runAll() {
   })
   if (!Credential.isPresentation(presentation))
     throw new Error('Not a valid Presentation')
-  if (await Credential.verifySignature(presentation))
-    console.info('Presentation signature verified')
-  else throw new Error('Credential Signature mismatch')
+  await Credential.verifySignature(presentation)
+  console.info('Presentation signature verified')
 
   console.log('Test Messaging with encryption + decryption')
   const message = Message.fromBody(
@@ -342,9 +326,8 @@ async function runAll() {
   }
 
   const attestation = Attestation.fromCredentialAndDid(credential, alice.uri)
-  if (Attestation.verifyAgainstCredential(attestation, credential))
-    console.info('Attestation Data verified')
-  else throw new Error('Attestation Claim data not verifiable')
+  Attestation.verifyAgainstCredential(attestation, credential)
+  console.info('Attestation Data verified')
 
   const attestationStoreTx = await Did.authorizeExtrinsic(
     alice,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,7 +1240,7 @@ __metadata:
     glob: ^7.1.1
     rimraf: ^3.0.2
     ts-node: ^10.4.0
-    typescript: ^4.5.4
+    typescript: ^4.8.3
     websocket: ^1.0.31
     yargs: ^16.2.0
   languageName: unknown
@@ -1259,7 +1259,7 @@ __metadata:
     "@polkadot/keyring": ^10.0.0
     "@polkadot/types": ^9.0.0
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -1271,7 +1271,7 @@ __metadata:
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/api": ^9.0.0
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
     typescript-logging: ^0.6.4
   languageName: unknown
   linkType: soft
@@ -1295,7 +1295,7 @@ __metadata:
     "@types/uuid": ^8.0.0
     rimraf: ^3.0.2
     testcontainers: ^8.6.1
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -1316,7 +1316,7 @@ __metadata:
     "@polkadot/util-crypto": ^10.0.0
     cbor: ^8.0.2
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -1331,7 +1331,7 @@ __metadata:
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/util": ^10.0.0
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -1352,7 +1352,7 @@ __metadata:
     rimraf: ^3.0.2
     stream-browserify: ^3.0.0
     terser-webpack-plugin: ^5.1.1
-    typescript: ^4.5.4
+    typescript: ^4.8.3
     url: ^0.11.0
     util: ^0.12.4
     webpack: ^5.70.0
@@ -1375,7 +1375,7 @@ __metadata:
     "@polkadot/util": ^10.0.0
     "@polkadot/util-crypto": ^10.0.0
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -1390,7 +1390,7 @@ __metadata:
     "@polkadot/util": ^10.0.0
     "@polkadot/util-crypto": ^10.0.0
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -1404,7 +1404,7 @@ __metadata:
     "@polkadot/util-crypto": ^10.0.0
     rimraf: ^3.0.2
     tweetnacl: ^1.0.3
-    typescript: ^4.5.4
+    typescript: ^4.8.3
     uuid: ^9.0.0
   languageName: unknown
   linkType: soft
@@ -1428,7 +1428,7 @@ __metadata:
     jsonld: ^2.0.2
     jsonld-signatures: ^5.0.0
     rimraf: ^3.0.2
-    typescript: ^4.5.4
+    typescript: ^4.8.3
     vc-js: ^0.6.4
   languageName: unknown
   linkType: soft
@@ -8719,7 +8719,7 @@ fsevents@^2.3.2:
     ts-jest: ^27.1.2
     ts-jest-resolver: ^2.0.0
     typedoc: ^0.22.15
-    typescript: ^4.5.4
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 
@@ -9870,23 +9870,23 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-typescript@^4.5.4:
-  version: 4.6.2
-  resolution: "typescript@npm:4.6.2"
+typescript@^4.8.3:
+  version: 4.8.3
+  resolution: "typescript@npm:4.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 8a44ed7e6f6c4cb1ebe8cf236ecda2fb119d84dcf0fbd77e707b2dfea1bbcfc4e366493a143513ce7f57203c75da9d4e20af6fe46de89749366351046be7577c
+  checksum: 8286a5edcaf3d68e65c451aa1e7150ad1cf53ee0813c07ec35b7abdfdb10f355ecaa13c6a226a694ae7a67785fd7eeebf89f845da0b4f7e4a35561ddc459aba0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.5.4#~builtin<compat/typescript>":
-  version: 4.6.2
-  resolution: "typescript@patch:typescript@npm%3A4.6.2#~builtin<compat/typescript>::version=4.6.2&hash=32657b"
+"typescript@patch:typescript@^4.8.3#~builtin<compat/typescript>":
+  version: 4.8.3
+  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=32657b"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4b15830bdbd391a66f9f3bcc2dc81fdcaa8143adbf3f9e47dc67ab2d971646a1caf19b89c677afea066e22d3d111f3c1b7b137e3d9a7e8663a6bf9497d428041
+  checksum: 57acee3231cdd759173b2e2783ba06da7a730437c7962db89ae8b6d7149adc6d36eb35225d082600b592982e245f7bdf861a745ba5aa1cecc1c9718945cdd6e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2207

It could be nice if functions that are called `verify*` would follow a consistent pattern with regards to their error and return value behaviour.
In this PR, I explored what this could look like.

## How to test:

Tests are included

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
