### PR TITLE
feat: Did.uriFromChain and encode replaces type cast

### DIFF
--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -7,9 +7,8 @@
 
 import type { Option } from '@polkadot/types'
 import type { IAttestation, ICredential } from '@kiltprotocol/types'
-import { Crypto, ss58Format } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
-import { Utils as DidUtils } from '@kiltprotocol/did'
+import { Chain as DidChain } from '@kiltprotocol/did'
 import type { AttestationAttestationsAttestationDetails } from '@kiltprotocol/augment-api'
 
 const log = ConfigService.LoggingFactory.getLogger('Attestation')
@@ -32,9 +31,7 @@ export function fromChain(
   const attestation: IAttestation = {
     claimHash,
     cTypeHash: chainAttestation.ctypeHash.toHex(),
-    owner: DidUtils.getFullDidUri(
-      Crypto.encodeAddress(chainAttestation.attester, ss58Format)
-    ),
+    owner: DidChain.uriFromChain(chainAttestation.attester),
     delegationId: delegationId || null,
     revoked: chainAttestation.revoked.valueOf(),
   }

--- a/packages/core/src/attestation/Attestation.chain.ts
+++ b/packages/core/src/attestation/Attestation.chain.ts
@@ -6,11 +6,8 @@
  */
 
 import type { Option } from '@polkadot/types'
-import type {
-  IAttestation,
-  ICredential,
-  KiltAddress,
-} from '@kiltprotocol/types'
+import type { IAttestation, ICredential } from '@kiltprotocol/types'
+import { Crypto, ss58Format } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 import type { AttestationAttestationsAttestationDetails } from '@kiltprotocol/augment-api'
@@ -36,7 +33,7 @@ export function fromChain(
     claimHash,
     cTypeHash: chainAttestation.ctypeHash.toHex(),
     owner: DidUtils.getFullDidUri(
-      chainAttestation.attester.toString() as KiltAddress
+      Crypto.encodeAddress(chainAttestation.attester, ss58Format)
     ),
     delegationId: delegationId || null,
     revoked: chainAttestation.revoked.valueOf(),

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -8,8 +8,8 @@
 import type { Option } from '@polkadot/types'
 import type { AccountId } from '@polkadot/types/interfaces'
 
-import { Crypto } from '@kiltprotocol/utils'
-import type { DidUri, ICType, KiltAddress } from '@kiltprotocol/types'
+import { Crypto, ss58Format } from '@kiltprotocol/utils'
+import type { DidUri, ICType } from '@kiltprotocol/types'
 import { Utils as DidUtils } from '@kiltprotocol/did'
 
 import { getSchemaPropertiesForHash } from './CType.js'
@@ -31,5 +31,7 @@ export function toChain(ctype: ICType): string {
  * @returns The owner DID.
  */
 export function fromChain(encoded: Option<AccountId>): DidUri {
-  return DidUtils.getFullDidUri(encoded.unwrap().toString() as KiltAddress)
+  return DidUtils.getFullDidUri(
+    Crypto.encodeAddress(encoded.unwrap(), ss58Format)
+  )
 }

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -8,9 +8,9 @@
 import type { Option } from '@polkadot/types'
 import type { AccountId } from '@polkadot/types/interfaces'
 
-import { Crypto, ss58Format } from '@kiltprotocol/utils'
+import { Crypto } from '@kiltprotocol/utils'
 import type { DidUri, ICType } from '@kiltprotocol/types'
-import { Utils as DidUtils } from '@kiltprotocol/did'
+import { Chain as DidChain } from '@kiltprotocol/did'
 
 import { getSchemaPropertiesForHash } from './CType.js'
 
@@ -31,7 +31,5 @@ export function toChain(ctype: ICType): string {
  * @returns The owner DID.
  */
 export function fromChain(encoded: Option<AccountId>): DidUri {
-  return DidUtils.getFullDidUri(
-    Crypto.encodeAddress(encoded.unwrap(), ss58Format)
-  )
+  return DidChain.uriFromChain(encoded.unwrap())
 }

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -19,11 +19,10 @@ import type {
   IDelegationNode,
   IDelegationHierarchyDetails,
 } from '@kiltprotocol/types'
-import { Crypto, ss58Format } from '@kiltprotocol/utils'
 import { Permission, PermissionType } from '@kiltprotocol/types'
 import type { Option } from '@polkadot/types'
 import type { Hash } from '@polkadot/types/interfaces/runtime'
-import { Utils as DidUtils } from '@kiltprotocol/did'
+import { Chain as DidChain } from '@kiltprotocol/did'
 import type {
   DelegationDelegationHierarchyDelegationHierarchyDetails,
   DelegationDelegationHierarchyDelegationNode,
@@ -94,9 +93,7 @@ export function delegationNodeFromChain(
       ? delegationNode.parent.toHex()
       : undefined,
     childrenIds: [...delegationNode.children].map((id) => id.toHex()),
-    account: DidUtils.getFullDidUri(
-      Crypto.encodeAddress(delegationNode.details.owner, ss58Format)
-    ),
+    account: DidChain.uriFromChain(delegationNode.details.owner),
     permissions: permissionsFromChain(delegationNode.details.permissions),
     revoked: delegationNode.details.revoked.valueOf(),
   }

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -18,8 +18,8 @@
 import type {
   IDelegationNode,
   IDelegationHierarchyDetails,
-  KiltAddress,
 } from '@kiltprotocol/types'
+import { Crypto, ss58Format } from '@kiltprotocol/utils'
 import { Permission, PermissionType } from '@kiltprotocol/types'
 import type { Option } from '@polkadot/types'
 import type { Hash } from '@polkadot/types/interfaces/runtime'
@@ -95,7 +95,7 @@ export function delegationNodeFromChain(
       : undefined,
     childrenIds: [...delegationNode.children].map((id) => id.toHex()),
     account: DidUtils.getFullDidUri(
-      delegationNode.details.owner.toString() as KiltAddress
+      Crypto.encodeAddress(delegationNode.details.owner, ss58Format)
     ),
     permissions: permissionsFromChain(delegationNode.details.permissions),
     revoked: delegationNode.details.revoked.valueOf(),

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Option } from '@polkadot/types'
-import type { Extrinsic, Hash } from '@polkadot/types/interfaces'
+import type { AccountId32, Extrinsic, Hash } from '@polkadot/types/interfaces'
 import type { AnyNumber } from '@polkadot/types/types'
 import { BN, hexToU8a } from '@polkadot/util'
 import type { ApiPromise } from '@polkadot/api'
@@ -48,6 +48,7 @@ import {
   EncodedSignature,
   EncodedVerificationKey,
   getAddressByKey,
+  getFullDidUri,
   keyTypeForSignatureAlg,
   parseDidUri,
   signatureAlgForKeyType,
@@ -112,6 +113,10 @@ function didPublicKeyDetailsFromChain(
     type: key.type.toLowerCase() as DidKey['type'],
     publicKey: key.value.toU8a(),
   }
+}
+
+export function uriFromChain(encoded: AccountId32): DidUri {
+  return getFullDidUri(Crypto.encodeAddress(encoded, ss58Format))
 }
 
 export function didFromChain(encoded: Option<DidDidDetails>): EncodedDid {

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -71,7 +71,7 @@ export function resourceIdToChain(id: UriFragment): string {
 
 export function depositFromChain(deposit: KiltSupportDeposit): Deposit {
   return {
-    owner: deposit.owner.toString() as KiltAddress,
+    owner: Crypto.encodeAddress(deposit.owner, ss58Format),
     amount: deposit.amount.toBn(),
   }
 }
@@ -139,10 +139,7 @@ export function didFromChain(encoded: Option<DidDidDetails>): EncodedDid {
   const didRecord: EncodedDid = {
     authentication: [authentication],
     lastTxCounter: lastTxCounter.toBn(),
-    deposit: {
-      amount: deposit.amount.toBn(),
-      owner: deposit.owner.toString() as KiltAddress,
-    },
+    deposit: depositFromChain(deposit),
   }
   if (attestationKey.isSome) {
     const key = keys[attestationKey.unwrap().toHex()] as DidVerificationKey

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -26,7 +26,7 @@ import {
 } from '@polkadot/util'
 import { ApiPromise } from '@polkadot/api'
 
-import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
+import { Crypto, SDKErrors, ss58Format } from '@kiltprotocol/utils'
 import type { Deposit, DidUri, KiltAddress } from '@kiltprotocol/types'
 import type { PalletDidLookupConnectionRecord } from '@kiltprotocol/augment-api'
 import { ConfigService } from '@kiltprotocol/config'
@@ -125,7 +125,7 @@ export function connectedDidFromChain(
 } {
   const { did, deposit } = encoded.unwrap()
   return {
-    did: getFullDidUri(did.toString() as KiltAddress),
+    did: getFullDidUri(Crypto.encodeAddress(did, ss58Format)),
     deposit: depositFromChain(deposit),
   }
 }

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -26,14 +26,14 @@ import {
 } from '@polkadot/util'
 import { ApiPromise } from '@polkadot/api'
 
-import { Crypto, SDKErrors, ss58Format } from '@kiltprotocol/utils'
+import { SDKErrors, ss58Format } from '@kiltprotocol/utils'
 import type { Deposit, DidUri, KiltAddress } from '@kiltprotocol/types'
 import type { PalletDidLookupConnectionRecord } from '@kiltprotocol/augment-api'
 import { ConfigService } from '@kiltprotocol/config'
 
-import { EncodedSignature, getFullDidUri } from '../Did.utils.js'
+import { EncodedSignature } from '../Did.utils.js'
 import { Web3Name, web3NameFromChain } from './Web3Names.chain.js'
-import { depositFromChain, didToChain } from '../Did.chain.js'
+import { depositFromChain, didToChain, uriFromChain } from '../Did.chain.js'
 
 /// A chain-agnostic address, which can be encoded using any network prefix.
 export type SubstrateAddress = KeyringPair['address']
@@ -125,7 +125,7 @@ export function connectedDidFromChain(
 } {
   const { did, deposit } = encoded.unwrap()
   return {
-    did: getFullDidUri(Crypto.encodeAddress(did, ss58Format)),
+    did: uriFromChain(did),
     deposit: depositFromChain(deposit),
   }
 }

--- a/packages/did/src/DidLinks/Web3Names.chain.ts
+++ b/packages/did/src/DidLinks/Web3Names.chain.ts
@@ -8,11 +8,8 @@
 import { PalletWeb3NamesWeb3NameWeb3NameOwnership } from '@polkadot/types/lookup'
 import type { Bytes, Option } from '@polkadot/types-codec'
 import type { Deposit, DidUri } from '@kiltprotocol/types'
-import { Crypto, ss58Format } from '@kiltprotocol/utils'
 import type { BN } from '@polkadot/util'
-
-import * as DidUtils from '../Did.utils.js'
-import { depositFromChain } from '../Did.chain.js'
+import { depositFromChain, uriFromChain } from '../Did.chain.js'
 
 /**
  * Web3Name is the type of a nickname for a DID.
@@ -44,7 +41,7 @@ export function web3NameOwnerFromChain(
 } {
   const { owner, deposit, claimedAt } = encoded.unwrap()
   return {
-    owner: DidUtils.getFullDidUri(Crypto.encodeAddress(owner, ss58Format)),
+    owner: uriFromChain(owner),
     deposit: depositFromChain(deposit),
     claimedAt: claimedAt.toBn(),
   }

--- a/packages/did/src/DidLinks/Web3Names.chain.ts
+++ b/packages/did/src/DidLinks/Web3Names.chain.ts
@@ -7,7 +7,8 @@
 
 import { PalletWeb3NamesWeb3NameWeb3NameOwnership } from '@polkadot/types/lookup'
 import type { Bytes, Option } from '@polkadot/types-codec'
-import type { Deposit, DidUri, KiltAddress } from '@kiltprotocol/types'
+import type { Deposit, DidUri } from '@kiltprotocol/types'
+import { Crypto, ss58Format } from '@kiltprotocol/utils'
 import type { BN } from '@polkadot/util'
 
 import * as DidUtils from '../Did.utils.js'
@@ -43,7 +44,7 @@ export function web3NameOwnerFromChain(
 } {
   const { owner, deposit, claimedAt } = encoded.unwrap()
   return {
-    owner: DidUtils.getFullDidUri(owner.toString() as KiltAddress),
+    owner: DidUtils.getFullDidUri(Crypto.encodeAddress(owner, ss58Format)),
     deposit: depositFromChain(deposit),
     claimedAt: claimedAt.toBn(),
   }


### PR DESCRIPTION
This PR replaces the type casting of KILT accounts returned from blockchain with encoding them. Many cases don’t even need that, rather they want to get DidUri from blockchain data using `Did.uriFromChain()`.

Inspired by the [review comment](https://github.com/KILTprotocol/sdk-js/pull/613#discussion_r970700877) 

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
