### PR TITLE
feat: avoid .hash().isEmpty

### DIFF
--- a/packages/core/src/__integrationtests__/AccountLinking.spec.ts
+++ b/packages/core/src/__integrationtests__/AccountLinking.spec.ts
@@ -74,11 +74,11 @@ describe('When there is an on-chain DID', () => {
       ).toStrictEqual([])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             paymentAccountChain
           )
-        ).isEmpty
+        ).isNone
       ).toBe(true)
 
       const associateSenderTx = api.tx.didLookup.associateSender()
@@ -116,12 +116,12 @@ describe('When there is an on-chain DID', () => {
       ])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             paymentAccountChain
           )
-        ).isEmpty
-      ).toBe(false)
+        ).isSome
+      ).toBe(true)
     }, 30_000)
     it('should be possible to associate the tx sender to a new DID', async () => {
       const associateSenderTx = api.tx.didLookup.associateSender()
@@ -155,11 +155,11 @@ describe('When there is an on-chain DID', () => {
       ).toStrictEqual([])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             paymentAccountChain
           )
-        ).isEmpty
+        ).isNone
       ).toBe(true)
       // Check that new DID has the account linked
       const encoded = await api.query.didLookup.connectedAccounts.keys(
@@ -170,12 +170,12 @@ describe('When there is an on-chain DID', () => {
       ])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             newDidChain,
             paymentAccountChain
           )
-        ).isEmpty
-      ).toBe(false)
+        ).isSome
+      ).toBe(true)
     }, 30_000)
     it('should be possible for the sender to remove the link', async () => {
       const removeSenderTx = api.tx.didLookup.removeSenderAssociation()
@@ -199,11 +199,11 @@ describe('When there is an on-chain DID', () => {
       ).toStrictEqual([])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             paymentAccountChain
           )
-        ).isEmpty
+        ).isNone
       ).toBe(true)
     })
   })
@@ -279,20 +279,16 @@ describe('When there is an on-chain DID', () => {
         ])
         expect(
           (
-            await api.query.didLookup.connectedAccounts.hash(
+            await api.query.didLookup.connectedAccounts(
               didChain,
               paymentAccountChain
             )
-          ).isEmpty
+          ).isNone
         ).toBe(true)
         expect(
-          (
-            await api.query.didLookup.connectedAccounts.hash(
-              didChain,
-              keypairChain
-            )
-          ).isEmpty
-        ).toBe(false)
+          (await api.query.didLookup.connectedAccounts(didChain, keypairChain))
+            .isSome
+        ).toBe(true)
       })
       it('should be possible to associate the account to a new DID while the sender pays the deposit', async () => {
         const linkAuthorization =
@@ -332,19 +328,15 @@ describe('When there is an on-chain DID', () => {
         ).toStrictEqual([])
         expect(
           (
-            await api.query.didLookup.connectedAccounts.hash(
+            await api.query.didLookup.connectedAccounts(
               didChain,
               paymentAccountChain
             )
-          ).isEmpty
+          ).isNone
         ).toBe(true)
         expect(
-          (
-            await api.query.didLookup.connectedAccounts.hash(
-              didChain,
-              keypairChain
-            )
-          ).isEmpty
+          (await api.query.didLookup.connectedAccounts(didChain, keypairChain))
+            .isNone
         ).toBe(true)
         // Check that new DID has the account linked
         const encoded = await api.query.didLookup.connectedAccounts.keys(
@@ -355,20 +347,20 @@ describe('When there is an on-chain DID', () => {
         ])
         expect(
           (
-            await api.query.didLookup.connectedAccounts.hash(
+            await api.query.didLookup.connectedAccounts(
               newDidChain,
               paymentAccountChain
             )
-          ).isEmpty
+          ).isNone
         ).toBe(true)
         expect(
           (
-            await api.query.didLookup.connectedAccounts.hash(
+            await api.query.didLookup.connectedAccounts(
               newDidChain,
               keypairChain
             )
-          ).isEmpty
-        ).toBe(false)
+          ).isSome
+        ).toBe(true)
       })
       it('should be possible for the DID to remove the link', async () => {
         const removeLinkTx = await api.tx.didLookup.removeAccountAssociation(
@@ -404,19 +396,15 @@ describe('When there is an on-chain DID', () => {
         ).toStrictEqual([])
         expect(
           (
-            await api.query.didLookup.connectedAccounts.hash(
+            await api.query.didLookup.connectedAccounts(
               didChain,
               paymentAccountChain
             )
-          ).isEmpty
+          ).isNone
         ).toBe(true)
         expect(
-          (
-            await api.query.didLookup.connectedAccounts.hash(
-              didChain,
-              keypairChain
-            )
-          ).isEmpty
+          (await api.query.didLookup.connectedAccounts(didChain, keypairChain))
+            .isNone
         ).toBe(true)
       })
     }
@@ -487,20 +475,20 @@ describe('When there is an on-chain DID', () => {
       ).toStrictEqual([genericAccount.address])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             paymentAccountChain
           )
-        ).isEmpty
+        ).isNone
       ).toBe(true)
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             genericAccountChain
           )
-        ).isEmpty
-      ).toBe(false)
+        ).isSome
+      ).toBe(true)
     })
 
     it('should be possible to add a Web3 name for the linked DID and retrieve it starting from the linked account', async () => {
@@ -551,19 +539,19 @@ describe('When there is an on-chain DID', () => {
       ).toStrictEqual([])
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             paymentAccountChain
           )
-        ).isEmpty
+        ).isNone
       ).toBe(true)
       expect(
         (
-          await api.query.didLookup.connectedAccounts.hash(
+          await api.query.didLookup.connectedAccounts(
             didChain,
             genericAccountChain
           )
-        ).isEmpty
+        ).isNone
       ).toBe(true)
     })
   })

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -213,18 +213,14 @@ describe('write and didDeleteTx', () => {
     )
 
     // Check that DID is not blacklisted.
-    expect((await api.query.did.didBlacklist.hash(encodedDid)).isEmpty).toBe(
-      true
-    )
+    expect((await api.query.did.didBlacklist(encodedDid)).isNone).toBe(true)
 
     await submitExtrinsic(submittable, paymentAccount)
 
     expect((await api.query.did.did(encodedDid)).isNone).toBe(true)
 
     // Check that DID is now blacklisted.
-    expect((await api.query.did.didBlacklist.hash(encodedDid)).isEmpty).toBe(
-      false
-    )
+    expect((await api.query.did.didBlacklist(encodedDid)).isSome).toBe(true)
   }, 60_000)
 })
 
@@ -486,9 +482,7 @@ describe('DID migration', () => {
     expect(
       await Did.Chain.queryServiceEndpoints(migratedFullDid.uri)
     ).toStrictEqual([])
-    expect((await api.query.did.didBlacklist.hash(encodedDid)).isEmpty).toBe(
-      false
-    )
+    expect((await api.query.did.didBlacklist(encodedDid)).isSome).toBe(true)
   }, 60_000)
 })
 

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -339,7 +339,7 @@ describe('When resolving a full DID', () => {
 
   it('correctly resolves a deleted DID', async () => {
     mockedApi.query.did.did.mockReturnValueOnce(didNotFound)
-    mockedApi.query.did.didBlacklist.hash.mockReturnValueOnce(didIsBlacklisted)
+    mockedApi.query.did.didBlacklist.mockReturnValueOnce(didIsBlacklisted)
 
     const { document, metadata } = (await resolve(
       deletedDid
@@ -472,7 +472,7 @@ describe('When resolving a light DID', () => {
   })
 
   it('correctly resolves a migrated and deleted DID', async () => {
-    mockedApi.query.did.didBlacklist.hash.mockReturnValueOnce(didIsBlacklisted)
+    mockedApi.query.did.didBlacklist.mockReturnValueOnce(didIsBlacklisted)
 
     const migratedDid: DidUri = `did:kilt:light:00${deletedAddress}`
     const { document, metadata } = (await resolve(

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -50,9 +50,8 @@ export async function resolve(
 
   // If the full DID has been deleted (or the light DID was upgraded and deleted),
   // return the info in the resolution metadata.
-  const isFullDidDeleted = !(
-    await api.query.did.didBlacklist.hash(didToChain(did))
-  ).isEmpty
+  const isFullDidDeleted = (await api.query.did.didBlacklist(didToChain(did)))
+    .isSome
   if (isFullDidDeleted) {
     return {
       // No canonicalId and no details are returned as we consider this DID deactivated/deleted.

--- a/packages/testing/src/mocks/mockedApi.ts
+++ b/packages/testing/src/mocks/mockedApi.ts
@@ -349,11 +349,9 @@ export function getMockedApi(): MockApiPromise {
         serviceEndpoints: jest.fn(async () =>
           mockChainQueryReturn('did', 'serviceEndpoints')
         ),
-        didBlacklist: {
-          hash: jest
-            .fn()
-            .mockReturnValue(mockChainQueryReturn('did', 'didBlacklist')),
-        },
+        didBlacklist: jest
+          .fn()
+          .mockReturnValue(mockChainQueryReturn('did', 'didBlacklist')),
       },
       portablegabi: {
         accumulatorList: jest.fn((address: string, index: number) =>


### PR DESCRIPTION
This PR uses a more clear and readable call instead of another one, performance benefits of which have apparently failed to materialize.

Inspired by a [review comment](https://github.com/KILTprotocol/sdk-js/pull/613#discussion_r970741095)

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
