### PR TITLE
refactor!: remove more chain wrappers

### DIFF
--- a/packages/core/src/__integrationtests__/AccountLinking.spec.ts
+++ b/packages/core/src/__integrationtests__/AccountLinking.spec.ts
@@ -235,15 +235,14 @@ describe('When there is an on-chain DID', () => {
       }, 40_000)
 
       it('should be possible to associate the account while the sender pays the deposit', async () => {
-        const linkAuthorization =
-          await AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
-            keypair.address,
-            did.uri,
-            sign
-          )
+        const args = await AccountLinks.associateAccountToChainArgs(
+          keypair.address,
+          did.uri,
+          sign
+        )
         const signedTx = await Did.authorizeExtrinsic(
           did,
-          linkAuthorization,
+          api.tx.didLookup.associateAccount(...args),
           didKey.sign,
           paymentAccount.address
         )
@@ -291,15 +290,14 @@ describe('When there is an on-chain DID', () => {
         ).toBe(true)
       })
       it('should be possible to associate the account to a new DID while the sender pays the deposit', async () => {
-        const linkAuthorization =
-          await AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
-            keypair.address,
-            newDid.uri,
-            sign
-          )
+        const args = await AccountLinks.associateAccountToChainArgs(
+          keypair.address,
+          newDid.uri,
+          sign
+        )
         const signedTx = await Did.authorizeExtrinsic(
           newDid,
-          linkAuthorization,
+          api.tx.didLookup.associateAccount(...args),
           newDidKey.sign,
           paymentAccount.address
         )
@@ -363,9 +361,8 @@ describe('When there is an on-chain DID', () => {
         ).toBe(true)
       })
       it('should be possible for the DID to remove the link', async () => {
-        const removeLinkTx = await api.tx.didLookup.removeAccountAssociation(
-          keypairChain
-        )
+        const removeLinkTx =
+          api.tx.didLookup.removeAccountAssociation(keypairChain)
         const signedTx = await Did.authorizeExtrinsic(
           newDid,
           removeLinkTx,
@@ -432,15 +429,14 @@ describe('When there is an on-chain DID', () => {
     }, 40_000)
 
     it('should be possible to associate the account while the sender pays the deposit', async () => {
-      const linkAuthorization =
-        await AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
-          genericAccount.address,
-          did.uri,
-          sign
-        )
+      const args = await AccountLinks.associateAccountToChainArgs(
+        genericAccount.address,
+        did.uri,
+        sign
+      )
       const signedTx = await Did.authorizeExtrinsic(
         did,
-        linkAuthorization,
+        api.tx.didLookup.associateAccount(...args),
         didKey.sign,
         paymentAccount.address
       )

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -278,9 +278,7 @@ it('creates and updates DID, and then reclaims the deposit back', async () => {
     Did.Chain.didToChain(fullDid.uri),
     Did.Chain.resourceIdToChain(newEndpoint.id)
   )
-  expect(Did.Chain.serviceEndpointFromChain(encoded.unwrap())).toStrictEqual(
-    newEndpoint
-  )
+  expect(Did.Chain.serviceEndpointFromChain(encoded)).toStrictEqual(newEndpoint)
 
   // Delete the added service endpoint
   const removeEndpointCall = api.tx.did.removeServiceEndpoint(

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1249,282 +1249,35 @@ describe('Runtime constraints', () => {
     }, 30_000)
 
     it('should not be possible to create a DID with a service endpoint that is too long', async () => {
-      await Did.Chain.getStoreTx(
-        {
-          authentication: [testAuthKey],
-          service: [
-            {
-              // Maximum is 50
-              id: '#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              type: ['type-a'],
-              serviceEndpoint: ['x:url-a'],
-            },
-          ],
-        },
-        paymentAccount.address,
-        sign
-      )
-      await expect(
-        Did.Chain.getStoreTx(
-          {
-            authentication: [testAuthKey],
-            service: [
-              {
-                // One more than the maximum
-                id: '#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-                type: ['type-a'],
-                serviceEndpoint: ['x:url-a'],
-              },
-            ],
-          },
-
-          paymentAccount.address,
-          sign
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service ID \\"#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
-      )
-    }, 30_000)
+      const serviceId = '#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const limit = api.consts.did.maxServiceIdLength.toNumber()
+      expect(serviceId.length).toBeGreaterThan(limit)
+    })
 
     it('should not be possible to create a DID with a service endpoint that has too many types', async () => {
-      const newEndpoint: DidServiceEndpoint = {
-        id: '#id-1',
-        // Maximum is 1
-        type: Array(1).map((_, index): string => `type-${index}`),
-        serviceEndpoint: ['x:url-1'],
-      }
-      await Did.Chain.getStoreTx(
-        {
-          authentication: [testAuthKey],
-          service: [newEndpoint],
-        },
-        paymentAccount.address,
-        sign
-      )
-      // One more than the maximum
-      newEndpoint.type.push('new-type')
-      await expect(
-        Did.Chain.getStoreTx(
-          {
-            authentication: [testAuthKey],
-            service: [newEndpoint],
-          },
-          paymentAccount.address,
-          sign
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has too many types (2). Max number of types allowed per service is 1."`
-      )
-    }, 30_000)
+      const types = ['type-1', 'type-2']
+      const limit = api.consts.did.maxNumberOfTypesPerService.toNumber()
+      expect(types.length).toBeGreaterThan(limit)
+    })
 
     it('should not be possible to create a DID with a service endpoint that has too many URIs', async () => {
-      const newEndpoint: DidServiceEndpoint = {
-        id: '#id-1',
-        // Maximum is 1
-        type: ['type-1'],
-        serviceEndpoint: Array(1).map((_, index): string => `x:url-${index}`),
-      }
-      await Did.Chain.getStoreTx(
-        {
-          authentication: [testAuthKey],
-          service: [newEndpoint],
-        },
-        paymentAccount.address,
-        sign
-      )
-      // One more than the maximum
-      newEndpoint.serviceEndpoint.push('x:new-url')
-      await expect(
-        Did.Chain.getStoreTx(
-          {
-            authentication: [testAuthKey],
-            service: [newEndpoint],
-          },
-
-          paymentAccount.address,
-          sign
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has too many URIs (2). Max number of URIs allowed per service is 1."`
-      )
-    }, 30_000)
+      const uris = ['x:url-1', 'x:url-2']
+      const limit = api.consts.did.maxNumberOfUrlsPerService.toNumber()
+      expect(uris.length).toBeGreaterThan(limit)
+    })
 
     it('should not be possible to create a DID with a service endpoint that has a type that is too long', async () => {
-      await Did.Chain.getStoreTx(
-        {
-          authentication: [testAuthKey],
-          service: [
-            {
-              id: '#id-1',
-              // Maximum is 50
-              type: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-              serviceEndpoint: ['x:url-1'],
-            },
-          ],
-        },
-        paymentAccount.address,
-        sign
-      )
-      await expect(
-        Did.Chain.getStoreTx(
-          {
-            authentication: [testAuthKey],
-            service: [
-              {
-                id: '#id-1',
-                // One more than the maximum
-                type: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-                serviceEndpoint: ['x:url-1'],
-              },
-            ],
-          },
-
-          paymentAccount.address,
-          sign
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has the type \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
-      )
-    }, 30_000)
+      const type = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const limit = api.consts.did.maxServiceTypeLength.toNumber()
+      expect(type.length).toBeGreaterThan(limit)
+    })
 
     it('should not be possible to create a DID with a service endpoint that has a URI that is too long', async () => {
-      await Did.Chain.getStoreTx(
-        {
-          authentication: [testAuthKey],
-          service: [
-            {
-              id: '#id-1',
-              type: ['type-1'],
-              // Maximum is 200
-              serviceEndpoint: [
-                'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              ],
-            },
-          ],
-        },
-        paymentAccount.address,
-        sign
-      )
-      await expect(
-        Did.Chain.getStoreTx(
-          {
-            authentication: [testAuthKey],
-            service: [
-              {
-                id: '#id-1',
-                type: ['type-1'],
-                // One more than the maximum
-                serviceEndpoint: [
-                  'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-                ],
-              },
-            ],
-          },
-
-          paymentAccount.address,
-          sign
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has the URI \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (202 bytes). Max number of bytes allowed for a service URI is 200."`
-      )
-    }, 30_000)
-  })
-
-  describe('Service endpoint addition', () => {
-    it('should not be possible to add a service endpoint that is too long', async () => {
-      Did.Chain.serviceToChain({
-        // Maximum is 50
-        id: '#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        type: ['type-a'],
-        serviceEndpoint: ['x:url-a'],
-      })
-      expect(
-        Did.Chain.serviceToChain({
-          // One more than maximum
-          id: '#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          type: ['type-a'],
-          serviceEndpoint: ['x:url-a'],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The service ID \\"#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" is too long (51 bytes). Max number of bytes allowed for a service ID is 50."`
-      )
-    }, 30_000)
-
-    it('should not be possible to add a service endpoint that has too many types', async () => {
-      const newEndpoint: DidServiceEndpoint = {
-        id: '#id-1',
-        // Maximum is 1
-        type: Array(1).map((_, index): string => `type-${index}`),
-        serviceEndpoint: ['x:url-1'],
-      }
-      Did.Chain.serviceToChain(newEndpoint)
-      // One more than the maximum
-      newEndpoint.type.push('new-type')
-      expect(
-        Did.Chain.serviceToChain(newEndpoint)
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has too many types (2). Max number of types allowed per service is 1."`
-      )
-    }, 30_000)
-
-    it('should not be possible to add a service endpoint that has too many URIs', async () => {
-      const newEndpoint: DidServiceEndpoint = {
-        id: '#id-1',
-        // Maximum is 1
-        type: ['type-1'],
-        serviceEndpoint: Array(1).map((_, index): string => `x:url-${index}`),
-      }
-      Did.Chain.serviceToChain(newEndpoint)
-      // One more than the maximum
-      newEndpoint.serviceEndpoint.push('x:new-url')
-      expect(
-        Did.Chain.serviceToChain(newEndpoint)
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has too many URIs (2). Max number of URIs allowed per service is 1."`
-      )
-    }, 30_000)
-
-    it('should not be possible to add a service endpoint that has a type that is too long', async () => {
-      Did.Chain.serviceToChain({
-        id: '#id-1',
-        // Maximum is 50
-        type: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        serviceEndpoint: ['x:url-1'],
-      })
-      expect(
-        Did.Chain.serviceToChain({
-          id: '#id-1',
-          // One more than the maximum
-          type: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-          serviceEndpoint: ['x:url-1'],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has the type \\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (51 bytes). Max number of bytes allowed for a service type is 50."`
-      )
-    }, 30_000)
-
-    it('should not be possible to add a service endpoint that has a URI that is too long', async () => {
-      Did.Chain.serviceToChain({
-        id: '#id-1',
-        type: ['type-1'],
-        // Maximum is 200
-        serviceEndpoint: [
-          'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        ],
-      })
-      expect(
-        Did.Chain.serviceToChain({
-          id: '#id-1',
-          type: ['type-1'],
-          // One more than the maximum
-          serviceEndpoint: [
-            'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          ],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The service with ID \\"#id-1\\" has the URI \\"a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\" that is too long (201 bytes). Max number of bytes allowed for a service URI is 200."`
-      )
-    }, 30_000)
+      const uri =
+        'a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const limit = api.consts.did.maxServiceUrlLength.toNumber()
+      expect(uri.length).toBeGreaterThan(limit)
+    })
   })
 })
 

--- a/packages/did/src/Did.chain.spec.ts
+++ b/packages/did/src/Did.chain.spec.ts
@@ -83,7 +83,7 @@ describe('services validation', () => {
   it.each(invalidTestIds)(
     'disallows adding services with invalid id "%s"',
     (id) => {
-      expect(
+      expect(() =>
         serviceToChain({
           id: `#${id}`,
           type: [],
@@ -96,7 +96,7 @@ describe('services validation', () => {
   it.each([...malformedTestUris, ...unencodedTestUris])(
     'disallows adding services with invalid URI "%s"',
     (uri) => {
-      expect(
+      expect(() =>
         serviceToChain({
           id: '#service_1',
           type: [],

--- a/packages/did/src/Did.chain.spec.ts
+++ b/packages/did/src/Did.chain.spec.ts
@@ -12,7 +12,7 @@
 import { ConfigService } from '@kiltprotocol/config'
 import { ApiMocks } from '@kiltprotocol/testing'
 
-import { getAddEndpointExtrinsic } from './Did.chain'
+import { serviceToChain } from './Did.chain'
 
 let api: any
 
@@ -56,9 +56,9 @@ describe('services validation', () => {
 
   it.each([...validTestURIs, ...unencodedTestUris.map(encodeURI)])(
     'allows adding services with valid URI "%s"',
-    async (uri) => {
+    (uri) => {
       expect(
-        await getAddEndpointExtrinsic({
+        serviceToChain({
           id: '#service_1',
           type: [],
           serviceEndpoint: [uri],
@@ -69,9 +69,9 @@ describe('services validation', () => {
 
   it.each([...validTestIds, ...invalidTestIds.map(encodeURIComponent)])(
     'allows adding services with valid id "%s"',
-    async (id) => {
+    (id) => {
       expect(
-        await getAddEndpointExtrinsic({
+        serviceToChain({
           id: `#${id}`,
           type: [],
           serviceEndpoint: [],
@@ -82,27 +82,27 @@ describe('services validation', () => {
 
   it.each(invalidTestIds)(
     'disallows adding services with invalid id "%s"',
-    async (id) => {
-      await expect(
-        getAddEndpointExtrinsic({
+    (id) => {
+      expect(
+        serviceToChain({
           id: `#${id}`,
           type: [],
           serviceEndpoint: [],
         })
-      ).rejects.toThrow('ID')
+      ).toThrow('ID')
     }
   )
 
   it.each([...malformedTestUris, ...unencodedTestUris])(
     'disallows adding services with invalid URI "%s"',
-    async (uri) => {
-      await expect(
-        getAddEndpointExtrinsic({
+    (uri) => {
+      expect(
+        serviceToChain({
           id: '#service_1',
           type: [],
           serviceEndpoint: [uri],
         })
-      ).rejects.toThrow('URI')
+      ).toThrow('URI')
     }
   )
 })

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -210,22 +210,6 @@ export function servicesFromChain(
   )
 }
 
-/**
- * Query service endpoint records associated with the full DID from the KILT blockchain.
- *
- * @param did Full DID.
- * @returns An array of service endpoint data or an empty array if the full DID does not exist or has no service endpoints associated with it.
- */
-export async function queryServiceEndpoints(
-  did: DidUri
-): Promise<DidServiceEndpoint[]> {
-  const api = ConfigService.get('api')
-  const encodedEndpoints = await api.query.did.serviceEndpoints.entries(
-    didToChain(did)
-  )
-  return servicesFromChain(encodedEndpoints)
-}
-
 // ### EXTRINSICS types
 
 export type AuthorizeCallInput = {

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -159,7 +159,9 @@ interface BlockchainEndpoint {
   urls: DidServiceEndpoint['serviceEndpoint']
 }
 
-function serviceToChain(endpoint: DidServiceEndpoint): BlockchainEndpoint {
+export function serviceToChain(
+  endpoint: DidServiceEndpoint
+): BlockchainEndpoint {
   checkServiceEndpointSyntax(endpoint)
   const { id, type, serviceEndpoint } = endpoint
   return {
@@ -336,23 +338,6 @@ export async function getStoreTx(
   })
   const encodedSignature = { [type]: signature.data } as EncodedSignature
   return api.tx.did.create(encoded, encodedSignature)
-}
-
-/**
- * Generate an extrinsic to add the provided [[DidServiceEndpoint]] to the authorizing DID.
- *
- * @param endpoint The new service endpoint to include in the extrinsic.
- * The service endpoint must respect the following conditions:
- *     - The service endpoint ID is at most 50 ASCII characters long and is a valid URI fragment according to RFC#3986.
- *     - The service endpoint has at most 1 service type, with a value that is at most 50 ASCII characters long.
- *     - The service endpoint has at most 1 URI, with a value that is at most 200 ASCII characters long, and which is a valid URI according to RFC#3986.
- * @returns An extrinsic that must be authorized (signed) by the full DID with which the service endpoint should be associated.
- */
-export async function getAddEndpointExtrinsic(
-  endpoint: DidServiceEndpoint
-): Promise<Extrinsic> {
-  const api = ConfigService.get('api')
-  return api.tx.did.addServiceEndpoint(serviceToChain(endpoint))
 }
 
 /**

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -41,7 +41,6 @@ import type {
 } from '@kiltprotocol/augment-api'
 
 import {
-  checkServiceEndpointSizeConstraints,
   checkServiceEndpointSyntax,
   EncodedEncryptionKey,
   EncodedKey,
@@ -245,8 +244,6 @@ function checkServiceEndpointInput(
   endpoint: DidServiceEndpoint
 ): void {
   checkServiceEndpointSyntax(endpoint)
-  const [, sizeErrors] = checkServiceEndpointSizeConstraints(api, endpoint)
-  if (sizeErrors && sizeErrors.length > 0) throw sizeErrors[0]
 }
 
 interface GetStoreTxInput {

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -159,11 +159,11 @@ interface BlockchainEndpoint {
   urls: DidServiceEndpoint['serviceEndpoint']
 }
 
-function endpointToBlockchainEndpoint({
-  id,
-  type,
-  serviceEndpoint,
-}: DidServiceEndpoint): BlockchainEndpoint {
+function endpointToBlockchainEndpoint(
+  endpoint: DidServiceEndpoint
+): BlockchainEndpoint {
+  checkServiceEndpointSyntax(endpoint)
+  const { id, type, serviceEndpoint } = endpoint
   return {
     id: resourceIdToChain(id),
     serviceTypes: type,
@@ -314,10 +314,6 @@ export async function getStoreTx(
     )
   }
 
-  service.forEach((endpoint) => {
-    checkServiceEndpointSyntax(endpoint)
-  })
-
   const [authenticationKey] = authentication
   const did = getAddressByKey(authenticationKey)
 
@@ -372,7 +368,6 @@ export async function getAddEndpointExtrinsic(
   endpoint: DidServiceEndpoint
 ): Promise<Extrinsic> {
   const api = ConfigService.get('api')
-  checkServiceEndpointSyntax(endpoint)
   return api.tx.did.addServiceEndpoint(endpointToBlockchainEndpoint(endpoint))
 }
 

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -9,7 +9,6 @@ import type { Option } from '@polkadot/types'
 import type { AccountId32, Extrinsic, Hash } from '@polkadot/types/interfaces'
 import type { AnyNumber } from '@polkadot/types/types'
 import { BN, hexToU8a } from '@polkadot/util'
-import type { ApiPromise } from '@polkadot/api'
 
 import type {
   Deposit,
@@ -239,13 +238,6 @@ export function publicKeyToChain(
   return { [key.type]: key.publicKey } as EncodedKey
 }
 
-function checkServiceEndpointInput(
-  api: ApiPromise,
-  endpoint: DidServiceEndpoint
-): void {
-  checkServiceEndpointSyntax(endpoint)
-}
-
 interface GetStoreTxInput {
   authentication: [NewDidVerificationKey]
   assertionMethod?: [NewDidVerificationKey]
@@ -323,7 +315,7 @@ export async function getStoreTx(
   }
 
   service.forEach((endpoint) => {
-    checkServiceEndpointInput(api, endpoint)
+    checkServiceEndpointSyntax(endpoint)
   })
 
   const [authenticationKey] = authentication
@@ -380,7 +372,7 @@ export async function getAddEndpointExtrinsic(
   endpoint: DidServiceEndpoint
 ): Promise<Extrinsic> {
   const api = ConfigService.get('api')
-  checkServiceEndpointInput(api, endpoint)
+  checkServiceEndpointSyntax(endpoint)
   return api.tx.did.addServiceEndpoint(endpointToBlockchainEndpoint(endpoint))
 }
 

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -244,8 +244,7 @@ function checkServiceEndpointInput(
   api: ApiPromise,
   endpoint: DidServiceEndpoint
 ): void {
-  const [, syntaxErrors] = checkServiceEndpointSyntax(endpoint)
-  if (syntaxErrors && syntaxErrors.length > 0) throw syntaxErrors[0]
+  checkServiceEndpointSyntax(endpoint)
   const [, sizeErrors] = checkServiceEndpointSizeConstraints(api, endpoint)
   if (sizeErrors && sizeErrors.length > 0) throw sizeErrors[0]
 }

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -278,36 +278,26 @@ export function stripFragment(id: UriFragment): string {
  *   - If the `uris` property contains one or more strings, they must be valid URIs according to RFC#3986.
  *
  * @param endpoint A service endpoint object to check.
- * @returns Validation result and errors, if any.
  */
-export function checkServiceEndpointSyntax(
-  endpoint: DidServiceEndpoint
-): [boolean, Error[] | undefined] {
-  const errors: Error[] = []
-  if (endpoint.id.startsWith('did:kilt')) {
-    errors.push(
-      new SDKErrors.DidError(
-        `This function requires only the URI fragment part (following '#') of the service ID, not the full DID URI, which is violated by id "${endpoint.id}"`
-      )
+export function checkServiceEndpointSyntax(endpoint: DidServiceEndpoint): void {
+  const { id, serviceEndpoint } = endpoint
+  if (id.startsWith('did:kilt')) {
+    throw new SDKErrors.DidError(
+      `This function requires only the URI fragment part (following '#') of the service ID, not the full DID URI, which is violated by id "${id}"`
     )
   }
-  if (!isUriFragment(stripFragment(endpoint.id))) {
-    errors.push(
-      new SDKErrors.DidError(
-        `The service ID must be valid as a URI fragment according to RFC#3986, which "${endpoint.id}" is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding the desired id.`
-      )
+  if (!isUriFragment(stripFragment(id))) {
+    throw new SDKErrors.DidError(
+      `The service ID must be valid as a URI fragment according to RFC#3986, which "${id}" is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding the desired id.`
     )
   }
-  endpoint.serviceEndpoint.forEach((uri) => {
+  serviceEndpoint.forEach((uri) => {
     if (!isUri(uri)) {
-      errors.push(
-        new SDKErrors.DidError(
-          `A service URI must be a URI according to RFC#3986, which "${uri}" (service id "${endpoint.id}") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.`
-        )
+      throw new SDKErrors.DidError(
+        `A service URI must be a URI according to RFC#3986, which "${uri}" (service id "${id}") is not. Make sure not to use disallowed characters (e.g. whitespace) or consider URL-encoding resource locators beforehand.`
       )
     }
   })
-  return errors.length > 0 ? [false, errors] : [true, undefined]
 }
 
 /**

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -6,8 +6,6 @@
  */
 
 import { blake2AsU8a, checkAddress, encodeAddress } from '@polkadot/util-crypto'
-import { stringToU8a } from '@polkadot/util'
-import type { ApiPromise } from '@polkadot/api'
 
 import {
   DidResourceUri,
@@ -298,80 +296,6 @@ export function checkServiceEndpointSyntax(endpoint: DidServiceEndpoint): void {
       )
     }
   })
-}
-
-/**
- * Performs size checks on service endpoint data, making sure that the following conditions are met:
- *   - The `endpoint.id` is at most 50 ASCII characters long.
- *   - The `endpoint.types` array has at most 1 service type, with a value that is at most 50 ASCII characters long.
- *   - The `endpoint.uris` array has at most 1 URI, with a value that is at most 200 ASCII characters long.
- *
- * @param api An api instance required for reading up-to-date size constraints from the blockchain runtime.
- * @param endpoint A service endpoint object to check.
- * @returns Validation result and errors, if any.
- */
-export function checkServiceEndpointSizeConstraints(
-  api: ApiPromise,
-  endpoint: DidServiceEndpoint
-): [boolean, Error[] | undefined] {
-  const [
-    maxServiceIdLength,
-    maxNumberOfTypesPerService,
-    maxNumberOfUrlsPerService,
-    maxServiceTypeLength,
-    maxServiceUrlLength,
-  ] = [
-    api.consts.did.maxServiceIdLength.toNumber(),
-    api.consts.did.maxNumberOfTypesPerService.toNumber(),
-    api.consts.did.maxNumberOfUrlsPerService.toNumber(),
-    api.consts.did.maxServiceTypeLength.toNumber(),
-    api.consts.did.maxServiceUrlLength.toNumber(),
-  ]
-  const errors: Error[] = []
-
-  const idEncodedLength = stringToU8a(stripFragment(endpoint.id)).length
-  if (idEncodedLength > maxServiceIdLength) {
-    errors.push(
-      new SDKErrors.DidError(
-        `The service ID "${endpoint.id}" is too long (${idEncodedLength} bytes). Max number of bytes allowed for a service ID is ${maxServiceIdLength}.`
-      )
-    )
-  }
-  if (endpoint.type.length > maxNumberOfTypesPerService) {
-    errors.push(
-      new SDKErrors.DidError(
-        `The service with ID "${endpoint.id}" has too many types (${endpoint.type.length}). Max number of types allowed per service is ${maxNumberOfTypesPerService}.`
-      )
-    )
-  }
-  if (endpoint.serviceEndpoint.length > maxNumberOfUrlsPerService) {
-    errors.push(
-      new SDKErrors.DidError(
-        `The service with ID "${endpoint.id}" has too many URIs (${endpoint.serviceEndpoint.length}). Max number of URIs allowed per service is ${maxNumberOfUrlsPerService}.`
-      )
-    )
-  }
-  endpoint.type.forEach((type) => {
-    const typeEncodedLength = stringToU8a(type).length
-    if (typeEncodedLength > maxServiceTypeLength) {
-      errors.push(
-        new SDKErrors.DidError(
-          `The service with ID "${endpoint.id}" has the type "${type}" that is too long (${typeEncodedLength} bytes). Max number of bytes allowed for a service type is ${maxServiceTypeLength}.`
-        )
-      )
-    }
-  })
-  endpoint.serviceEndpoint.forEach((uri) => {
-    const uriEncodedLength = stringToU8a(uri).length
-    if (uriEncodedLength > maxServiceUrlLength) {
-      errors.push(
-        new SDKErrors.DidError(
-          `The service with ID "${endpoint.id}" has the URI "${uri}" that is too long (${uriEncodedLength} bytes). Max number of bytes allowed for a service URI is ${maxServiceUrlLength}.`
-        )
-      )
-    }
-  })
-  return errors.length > 0 ? [false, errors] : [true, undefined]
 }
 
 export function getAddressByKey({

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -26,8 +26,8 @@ import { ConfigService } from '@kiltprotocol/config'
 import type { EncodedDid } from '../Did.chain'
 import {
   generateDidAuthenticatedTx,
-  queryServiceEndpoints,
   didFromChain,
+  servicesFromChain,
 } from '../Did.chain'
 
 import * as Did from './index.js'
@@ -107,7 +107,7 @@ const existingServiceEndpoints: DidServiceEndpoint[] = [
 
 jest.mock('../Did.chain')
 jest.mocked(didFromChain).mockReturnValue(existingDidRecord)
-jest.mocked(queryServiceEndpoints).mockResolvedValue(existingServiceEndpoints)
+jest.mocked(servicesFromChain).mockReturnValue(existingServiceEndpoints)
 jest
   .mocked(generateDidAuthenticatedTx)
   .mockResolvedValue({} as SubmittableExtrinsic)

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -26,7 +26,7 @@ import {
   didFromChain,
   didToChain,
   generateDidAuthenticatedTx,
-  queryServiceEndpoints,
+  servicesFromChain,
 } from '../Did.chain.js'
 import { parseDidUri, signatureAlgForKeyType } from '../Did.utils.js'
 
@@ -67,7 +67,9 @@ export async function query(didUri: DidUri): Promise<DidDocument | null> {
     keyAgreement: didRec.keyAgreement,
   }
 
-  const service = await queryServiceEndpoints(didUri)
+  const service = servicesFromChain(
+    await api.query.did.serviceEndpoints.entries(didToChain(didUri))
+  )
   if (service.length > 0) {
     did.service = service
   }

--- a/packages/did/src/DidDetails/LightDidDetails.utils.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.utils.ts
@@ -96,10 +96,7 @@ export function validateCreateDocumentInput(input: CreateDocumentInput): void {
         `Cannot specify a service ID with the name "${service.id}" as it is a reserved keyword`
       )
     }
-    const [, errors] = checkServiceEndpointSyntax(service)
-    if (errors && errors.length > 0) {
-      throw errors[0]
-    }
+    checkServiceEndpointSyntax(service)
   })
 }
 

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -12,7 +12,7 @@ import {
   signatureVerify,
 } from '@polkadot/util-crypto'
 import type { Enum, Option, StorageKey, U8aFixed } from '@polkadot/types'
-import type { AccountId32, Extrinsic } from '@polkadot/types/interfaces'
+import type { AccountId32 } from '@polkadot/types/interfaces'
 import type { AnyNumber, Codec, TypeDef } from '@polkadot/types/types'
 import type { HexString } from '@polkadot/util/types'
 import type { KeyringPair } from '@polkadot/keyring/types'
@@ -187,37 +187,6 @@ export async function queryWeb3Name(
 
 type AssociateAccountToChainResult = [string, AnyNumber, EncodedSignature]
 
-function associateAccountToChainArgs(
-  account: Address,
-  signatureValidUntilBlock: AnyNumber,
-  signature: Uint8Array | HexString,
-  sigType: KeypairType
-): AssociateAccountToChainResult {
-  const proof = { [sigType]: signature } as EncodedSignature
-
-  const api = ConfigService.get('api')
-  if (isEthereumEnabled(api)) {
-    if (sigType === 'ethereum') {
-      const result = [
-        { Ethereum: [account, signature] },
-        signatureValidUntilBlock,
-      ]
-      // Force type cast to enable the old blockchain types to accept the future format
-      return result as unknown as AssociateAccountToChainResult
-    }
-    const result = [{ Dotsama: [account, proof] }, signatureValidUntilBlock]
-    // Force type cast to enable the old blockchain types to accept the future format
-    return result as unknown as AssociateAccountToChainResult
-  }
-
-  if (sigType === 'ethereum')
-    throw new SDKErrors.CodecMismatchError(
-      'Ethereum linking is not yet supported by this chain'
-    )
-
-  return [account, signatureValidUntilBlock, proof]
-}
-
 /* ### HELPERS ### */
 
 /**
@@ -265,7 +234,7 @@ function getUnprefixedSignature(
 }
 
 /**
- * Builds an extrinsic to link `account` to a `did` where the fees and deposit are covered by some third account.
+ * Builds the parameters for an extrinsic to link the `account` to the `did` where the fees and deposit are covered by some third account.
  * This extrinsic must be authorized using the same full DID.
  * Note that in addition to the signing account and DID used here, the submitting account will also be able to dissolve the link via reclaiming its deposit!
  *
@@ -273,14 +242,14 @@ function getUnprefixedSignature(
  * @param did Full DID to be linked.
  * @param sign The sign callback that generates the account signature over the encoded (DidAddress, BlockNumber) tuple.
  * @param nBlocksValid The link request will be rejected if submitted later than (current block number + nBlocksValid)?
- * @returns An Extrinsic that must be DID-authorized by the full DID used.
+ * @returns An array of parameters for `api.tx.didLookup.associateAccount` that must be DID-authorized by the full DID used.
  */
-export async function getAuthorizeLinkWithAccountExtrinsic(
+export async function associateAccountToChainArgs(
   accountAddress: Address,
   did: DidUri,
   sign: LinkingSignCallback,
   nBlocksValid = 10
-): Promise<Extrinsic> {
+): Promise<AssociateAccountToChainResult> {
   const api = ConfigService.get('api')
 
   const blockNo = await api.query.system.number()
@@ -316,7 +285,23 @@ export async function getAuthorizeLinkWithAccountExtrinsic(
     accountAddress
   )
 
-  return api.tx.didLookup.associateAccount(
-    ...associateAccountToChainArgs(accountAddress, validTill, signature, type)
-  )
+  const proof = { [type]: signature } as EncodedSignature
+
+  if (isEthereumEnabled(api)) {
+    if (type === 'ethereum') {
+      const result = [{ Ethereum: [accountAddress, signature] }, validTill]
+      // Force type cast to enable the old blockchain types to accept the future format
+      return result as unknown as AssociateAccountToChainResult
+    }
+    const result = [{ Dotsama: [accountAddress, proof] }, validTill]
+    // Force type cast to enable the old blockchain types to accept the future format
+    return result as unknown as AssociateAccountToChainResult
+  }
+
+  if (type === 'ethereum')
+    throw new SDKErrors.CodecMismatchError(
+      'Ethereum linking is not yet supported by this chain'
+    )
+
+  return [accountAddress, validTill, proof]
 }

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -29,7 +29,7 @@ import { getFullDidUriFromKey, stripFragment } from '../Did.utils'
 import {
   didFromChain,
   serviceEndpointFromChain,
-  queryServiceEndpoints,
+  servicesFromChain,
 } from '../Did.chain.js'
 
 import {
@@ -147,8 +147,8 @@ jest
   .mocked(serviceEndpointFromChain)
   .mockReturnValue(generateServiceEndpoint('#service-1'))
 jest
-  .mocked(queryServiceEndpoints)
-  .mockResolvedValue([generateServiceEndpoint('#service-1')])
+  .mocked(servicesFromChain)
+  .mockReturnValue([generateServiceEndpoint('#service-1')])
 
 describe('When resolving a key', () => {
   it('correctly resolves it for a full DID if both the DID and the key exist', async () => {
@@ -300,8 +300,8 @@ describe('When resolving a full DID', () => {
 
   it('correctly resolves the document with service endpoints', async () => {
     jest
-      .mocked(queryServiceEndpoints)
-      .mockResolvedValue([
+      .mocked(servicesFromChain)
+      .mockReturnValue([
         generateServiceEndpoint('#id-1'),
         generateServiceEndpoint('#id-2'),
       ])

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -28,7 +28,7 @@ import { ConfigService } from '@kiltprotocol/config'
 import { getFullDidUriFromKey, stripFragment } from '../Did.utils'
 import {
   didFromChain,
-  serviceEndpointFromChain,
+  serviceFromChain,
   servicesFromChain,
 } from '../Did.chain.js'
 
@@ -144,7 +144,7 @@ jest.mocked(didFromChain).mockReturnValue({
   },
 })
 jest
-  .mocked(serviceEndpointFromChain)
+  .mocked(serviceFromChain)
   .mockReturnValue(generateServiceEndpoint('#service-1'))
 jest
   .mocked(servicesFromChain)

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -193,7 +193,7 @@ export async function resolveServiceEndpoint(
     if (encoded.isNone) {
       return null
     }
-    const serviceEndpoint = serviceEndpointFromChain(encoded.unwrap())
+    const serviceEndpoint = serviceEndpointFromChain(encoded)
     return {
       ...serviceEndpoint,
       id: serviceUri,

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -20,7 +20,7 @@ import * as Did from '../index.js'
 import {
   didToChain,
   resourceIdToChain,
-  serviceEndpointFromChain,
+  serviceFromChain,
 } from '../Did.chain.js'
 import { getFullDidUri, parseDidUri } from '../Did.utils.js'
 
@@ -193,7 +193,7 @@ export async function resolveServiceEndpoint(
     if (encoded.isNone) {
       return null
     }
-    const serviceEndpoint = serviceEndpointFromChain(encoded)
+    const serviceEndpoint = serviceFromChain(encoded)
     return {
       ...serviceEndpoint,
       id: serviceUri,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

This is a follow-up for #613 to remove some more chain wrappers: 

Did.Chain.queryServiceEndpoints
Did.Chain.getAddEndpointExtrinsic
Did.AccountLinks.getAuthorizeLinkWithAccountExtrinsic

We also remove the validations of lengths and amounts for properties of a DID service, as they should be done by application developers on higher level, and are already done by the blockchain itself.

serviceEndpointFromChain renamed to serviceFromChain

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
