### PR TITLE
feat!: export ConfigService from the SDK

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,5 +19,5 @@ export * as CType from './ctype/index.js'
 export { DelegationNode, DelegationNodeUtils } from './delegation/index.js'
 export * as Quote from './quote/index.js'
 
-export { connect, disconnect, config, init } from './kilt/index.js'
+export { connect, disconnect, init } from './kilt/index.js'
 export { SDKErrors } from '@kiltprotocol/utils'

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -19,7 +19,7 @@ import { ConfigService } from '@kiltprotocol/config'
 import { latest, rpc, runtime } from '@kiltprotocol/type-definitions'
 
 /**
- * Prepares crypto modules (required e.g. For identity creation) and calls ConfigService.set().
+ * Prepares crypto modules (required e.g. for identity creation) and calls ConfigService.set().
  *
  * @param configs Arguments to pass on to ConfigService.set().
  * @returns Promise that must be awaited to assure crypto is ready.

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -19,26 +19,15 @@ import { ConfigService } from '@kiltprotocol/config'
 import { latest, rpc, runtime } from '@kiltprotocol/type-definitions'
 
 /**
- * Allows setting global configuration such as the log level and the polkadot ApiPromise instance used throughout the sdk.
+ * Prepares crypto modules (required e.g. For identity creation) and calls ConfigService.set().
  *
- * @param configs Config options object.
- */
-export function config<K extends Partial<ConfigService.configOpts>>(
-  configs: K
-): void {
-  ConfigService.set(configs)
-}
-
-/**
- * Prepares crypto modules (required e.g. For identity creation) and calls Kilt.config().
- *
- * @param configs Arguments to pass on to Kilt.config().
+ * @param configs Arguments to pass on to ConfigService.set().
  * @returns Promise that must be awaited to assure crypto is ready.
  */
 export async function init<K extends Partial<ConfigService.configOpts>>(
   configs?: K
 ): Promise<void> {
-  config(configs || {})
+  ConfigService.set(configs || {})
   await cryptoWaitReady()
 }
 

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@kiltprotocol/augment-api": "workspace:*",
     "@kiltprotocol/chain-helpers": "workspace:*",
+    "@kiltprotocol/config": "workspace:*",
     "@kiltprotocol/core": "workspace:*",
     "@kiltprotocol/did": "workspace:*",
     "@kiltprotocol/messaging": "workspace:*",

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -12,6 +12,7 @@
 import '@kiltprotocol/augment-api'
 
 export * from '@kiltprotocol/core'
+export { ConfigService } from '@kiltprotocol/config'
 export * as Message from '@kiltprotocol/messaging'
 export { Blockchain } from '@kiltprotocol/chain-helpers'
 export * as ChainHelpers from '@kiltprotocol/chain-helpers'

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -35,7 +35,7 @@ const {
   BalanceUtils,
 } = kilt
 
-kilt.config({ submitTxResolveOn: Blockchain.IS_IN_BLOCK })
+kilt.ConfigService.set({ submitTxResolveOn: Blockchain.IS_IN_BLOCK })
 
 function makeSignCallback(
   keypair: KeyringPair

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,7 @@ __metadata:
   dependencies:
     "@kiltprotocol/augment-api": "workspace:*"
     "@kiltprotocol/chain-helpers": "workspace:*"
+    "@kiltprotocol/config": "workspace:*"
     "@kiltprotocol/core": "workspace:*"
     "@kiltprotocol/did": "workspace:*"
     "@kiltprotocol/messaging": "workspace:*"


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2040

Make the ConfigService directly available when importing from the sdk-js.
Removes the redundant `Kilt.config()` function.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
