### PR TITLE
feat: remove Did.signPayload

### DIFF
--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -17,12 +17,7 @@
  * @packageDocumentation
  */
 
-import {
-  isDidSignature,
-  verifyDidSignature,
-  resolve,
-  signPayload,
-} from '@kiltprotocol/did'
+import { isDidSignature, verifyDidSignature, resolve } from '@kiltprotocol/did'
 import type {
   DidResolve,
   Hash,
@@ -35,6 +30,7 @@ import type {
   SignCallback,
 } from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
+import { u8aToHex } from '@polkadot/util'
 import * as Claim from '../claim/index.js'
 import { hashClaimContents } from '../claim/index.js'
 import { verifyClaimAgainstSchema } from '../ctype/index.js'
@@ -415,11 +411,14 @@ export async function createPresentation({
     excludedClaimProperties
   )
 
-  const { signature, keyUri } = await signPayload(
-    credential.claim.owner,
-    makeSigningData(presentation, challenge),
-    signCallback
-  )
+  const { signature, keyUri } = await signCallback({
+    data: makeSigningData(presentation, challenge),
+    did: credential.claim.owner,
+    keyRelationship: 'authentication',
+  })
 
-  return { ...credential, claimerSignature: { signature, keyUri, challenge } }
+  return {
+    ...credential,
+    claimerSignature: { signature: u8aToHex(signature), keyUri, challenge },
+  }
 }

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -153,13 +153,15 @@ describe('Quote', () => {
 
   it('tests created quote data against given data', async () => {
     expect(validQuoteData.attesterDid).toEqual(attesterIdentity.uri)
-    expect(
-      await Did.signPayload(
-        claimerIdentity.uri,
-        Crypto.hashObjectAsStr(validAttesterSignedQuote),
-        claimer.getSignCallback(claimerIdentity)
-      )
-    ).toEqual(quoteBothAgreed.claimerSignature)
+    const signature = await claimer.getSignCallback(claimerIdentity)({
+      data: Crypto.coToUInt8(Crypto.hashObjectAsStr(validAttesterSignedQuote)),
+      did: claimerIdentity.uri,
+      keyRelationship: 'authentication',
+    })
+    expect(signature.signature).toEqual(
+      quoteBothAgreed.claimerSignature.signature
+    )
+    expect(signature.keyUri).toEqual(quoteBothAgreed.claimerSignature.keyUri)
 
     const { fragment: attesterKeyId } = Did.Utils.parseDidUri(
       validAttesterSignedQuote.attesterSignature.keyUri

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -8,7 +8,7 @@
 import type { Option } from '@polkadot/types'
 import type { AccountId32, Extrinsic, Hash } from '@polkadot/types/interfaces'
 import type { AnyNumber } from '@polkadot/types/types'
-import { BN, hexToU8a } from '@polkadot/util'
+import { BN } from '@polkadot/util'
 
 import type {
   Deposit,
@@ -16,7 +16,6 @@ import type {
   DidEncryptionKey,
   DidKey,
   DidServiceEndpoint,
-  DidSignature,
   DidUri,
   DidVerificationKey,
   KiltAddress,
@@ -338,7 +337,7 @@ export async function getStoreTx(
     keyRelationship: 'authentication',
   })
   const encodedSignature = {
-    [signature.keyType]: signature.data,
+    [signature.keyType]: signature.signature,
   } as EncodedSignature
   return api.tx.did.create(encoded, encodedSignature)
 }
@@ -389,7 +388,7 @@ export async function generateDidAuthenticatedTx({
     did,
   })
   const encodedSignature = {
-    [signature.keyType]: signature.data,
+    [signature.keyType]: signature.signature,
   } as EncodedSignature
   return api.tx.did.submitDidCall(signableCall, encodedSignature)
 }
@@ -404,7 +403,7 @@ export async function generateDidAuthenticatedTx({
  */
 export function didSignatureToChain(
   key: DidVerificationKey,
-  signature: Pick<DidSignature, 'signature'>
+  signature: Uint8Array
 ): EncodedSignature {
   if (!verificationKeyTypes.includes(key.type)) {
     throw new SDKErrors.DidError(
@@ -412,5 +411,5 @@ export function didSignatureToChain(
     )
   }
 
-  return { [key.type]: hexToU8a(signature.signature) } as EncodedSignature
+  return { [key.type]: signature } as EncodedSignature
 }

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -5,18 +5,11 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import { u8aToHex } from '@polkadot/util'
-
 import type {
   DidDocument,
   DidKey,
   DidServiceEndpoint,
-  DidSignature,
-  DidUri,
-  SignCallback,
-  VerificationKeyRelationship,
 } from '@kiltprotocol/types'
-import { Crypto } from '@kiltprotocol/utils'
 
 /**
  * Gets all public keys associated with this DID.
@@ -61,32 +54,4 @@ export function getEndpoint(
   id: DidServiceEndpoint['id']
 ): DidServiceEndpoint | undefined {
   return did.service?.find((endpoint) => endpoint.id === id)
-}
-
-/**
- * Generate a signature over the provided input payload, either as a byte array or as a HEX-encoded string.
- *
- * @param did The DID to be used.
- * @param payload The byte array or HEX-encoded payload to sign.
- * @param sign The sign callback to use for the signing operation.
- * @param keyRelationship (optional) The key relationship, that should be used. Defaults to 'authentication'.
- *
- * @returns The resulting [[DidSignature]].
- */
-export async function signPayload(
-  did: DidUri,
-  payload: Uint8Array | string,
-  sign: SignCallback,
-  keyRelationship: VerificationKeyRelationship = 'authentication'
-): Promise<DidSignature> {
-  const { data: signature, keyUri } = await sign({
-    data: Crypto.coToUInt8(payload),
-    keyRelationship,
-    did,
-  })
-
-  return {
-    keyUri,
-    signature: u8aToHex(signature),
-  }
 }

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -66,6 +66,7 @@ import {
   createLocalDemoFullDidFromKeypair,
   KeyTool,
   KeyToolSignCallback,
+  makeDidSignature,
 } from '@kiltprotocol/testing'
 import { u8aToHex } from '@polkadot/util'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
@@ -972,9 +973,9 @@ describe('Error checking / Verification', () => {
       },
       metaData: {},
       signatures: {
-        inviter: await Did.signPayload(
-          identityAlice.uri,
+        inviter: await makeDidSignature(
           'signature',
+          identityAlice.uri,
           keyAlice.getSignCallback(identityAlice)
         ),
       },
@@ -989,14 +990,14 @@ describe('Error checking / Verification', () => {
         isPCR: false,
       },
       signatures: {
-        inviter: await Did.signPayload(
-          identityAlice.uri,
+        inviter: await makeDidSignature(
           'signature',
+          identityAlice.uri,
           keyAlice.getSignCallback(identityAlice)
         ),
-        invitee: await Did.signPayload(
-          identityBob.uri,
+        invitee: await makeDidSignature(
           'signature',
+          identityBob.uri,
           keyBob.getSignCallback(identityBob)
         ),
       },

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -19,6 +19,8 @@ import {
   DidDocument,
   DidKey,
   DidServiceEndpoint,
+  DidSignature,
+  DidUri,
   DidVerificationKey,
   EncryptCallback,
   EncryptionKeyType,
@@ -153,7 +155,7 @@ export function makeSignCallback(keypair: KeyringPair): KeyToolSignCallback {
       const signature = keypair.sign(data, { withType: false })
 
       return {
-        data: signature,
+        signature,
         keyUri: `${didDocument.uri}${keyId}`,
         keyType,
       }
@@ -174,7 +176,7 @@ export function makeStoreDidCallback(
   return async function sign({ data }) {
     const signature = keypair.sign(data, { withType: false })
     return {
-      data: signature,
+      signature,
       keyType: keypair.type,
     }
   }
@@ -364,4 +366,20 @@ export async function createFullDidFromSeed(
   const lightDid = await createMinimalLightDidFromKeypair(keypair)
   const sign = makeStoreDidCallback(keypair)
   return createFullDidFromLightDid(payer, lightDid, sign)
+}
+
+export async function makeDidSignature(
+  data: string,
+  didUri: DidUri,
+  signCallback: SignCallback
+): Promise<DidSignature> {
+  const { signature, keyUri } = await signCallback({
+    data: Crypto.coToUInt8(data),
+    did: didUri,
+    keyRelationship: 'authentication',
+  })
+  return {
+    signature: Crypto.u8aToHex(signature),
+    keyUri,
+  }
 }

--- a/packages/types/src/CryptoCallbacks.ts
+++ b/packages/types/src/CryptoCallbacks.ts
@@ -45,7 +45,7 @@ export interface SignResponseData {
   /**
    * Result of the signing.
    */
-  data: Uint8Array
+  signature: Uint8Array
   /**
    * The did key uri used for signing.
    */

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -50,7 +50,11 @@ function makeSignCallback(
         )
       }
       const signature = keypair.sign(data, { withType: false })
-      return { data: signature, keyUri: `${didDocument.uri}${keyId}`, keyType }
+      return {
+        signature: signature,
+        keyUri: `${didDocument.uri}${keyId}`,
+        keyType,
+      }
     }
   }
 }
@@ -60,7 +64,7 @@ function makeStoreDidCallback(keypair: KiltKeyringPair): StoreDidCallback {
   return async function sign({ data }) {
     const signature = keypair.sign(data, { withType: false })
     return {
-      data: signature,
+      signature,
       keyType: keypair.type,
     }
   }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2210
This PR removes the `signPayload` helper function, since it does not help with much anymore.

## How to test:
- Tests
- Look, if users of the SDK would still be able to go through their use cases (especially regarding Quote and the two messages)


## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
