### PR TITLE
feat!: throw instead of return null

### DIFF
--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -426,14 +426,14 @@ describe('Deposit claiming', () => {
     // Test removal success with the right account.
     await submitExtrinsic(depositClaimTx, paymentAccount)
 
-    expect(await DelegationNode.query(delegatedNode.id)).toBeNull()
-    expect(await DelegationNode.query(subDelegatedNode.id)).toBeNull()
+    await expect(DelegationNode.query(delegatedNode.id)).rejects.toThrow()
+    await expect(DelegationNode.query(subDelegatedNode.id)).rejects.toThrow()
   }, 80_000)
 })
 
 describe('handling queries to data not on chain', () => {
   it('DelegationNode query on empty', async () => {
-    expect(await DelegationNode.query(randomAsHex(32))).toBeNull()
+    await expect(DelegationNode.query(randomAsHex(32))).rejects.toThrow()
   })
 
   it('getAttestationHashes on empty', async () => {

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -1145,7 +1145,7 @@ describe('DID extrinsics batching', () => {
 
     // Test correct use of delegation keys
     const node = await DelegationNode.query(rootNode.id)
-    expect(node?.revoked).toBe(true)
+    expect(node.revoked).toBe(true)
   })
 })
 

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -339,7 +339,6 @@ describe('DID migration', () => {
     await submitExtrinsic(storeTx, paymentAccount)
     const migratedFullDidUri = Did.getFullDidUri(lightDid.uri)
     const migratedFullDid = await Did.query(migratedFullDidUri)
-    if (!migratedFullDid) throw new Error('Cannot query created DID')
 
     expect(migratedFullDid).toMatchObject(<DidDocument>{
       uri: migratedFullDidUri,
@@ -382,7 +381,6 @@ describe('DID migration', () => {
     await submitExtrinsic(storeTx, paymentAccount)
     const migratedFullDidUri = Did.getFullDidUri(lightDid.uri)
     const migratedFullDid = await Did.query(migratedFullDidUri)
-    if (!migratedFullDid) throw new Error('Cannot query created DID')
 
     expect(migratedFullDid).toMatchObject(<DidDocument>{
       uri: migratedFullDidUri,
@@ -431,7 +429,6 @@ describe('DID migration', () => {
     await submitExtrinsic(storeTx, paymentAccount)
     const migratedFullDidUri = Did.getFullDidUri(lightDid.uri)
     const migratedFullDid = await Did.query(migratedFullDidUri)
-    if (!migratedFullDid) throw new Error('Cannot query created DID')
 
     expect(migratedFullDid).toMatchObject(<DidDocument>{
       uri: migratedFullDidUri,
@@ -499,11 +496,7 @@ describe('DID authorization', () => {
       storeDidCallback
     )
     await submitExtrinsic(createTx, paymentAccount)
-    const optional = await Did.query(
-      Did.getFullDidUriFromKey(authentication[0])
-    )
-    if (!optional) throw new Error('Cannot query created DID')
-    did = optional
+    did = await Did.query(Did.getFullDidUriFromKey(authentication[0]))
   }, 60_000)
 
   it('authorizes ctype creation with DID signature', async () => {
@@ -621,8 +614,6 @@ describe('DID management batching', () => {
       )
 
       expect(fullDid).not.toBeNull()
-      if (!fullDid) throw new Error('Cannot query created DID')
-
       expect(fullDid).toMatchObject({
         authentication: [
           expect.objectContaining({
@@ -753,7 +744,6 @@ describe('DID management batching', () => {
       const initialFullDid = await Did.query(
         Did.getFullDidUriFromKey(authentication[0])
       )
-      if (!initialFullDid) throw new Error('Cannot query created DID')
 
       const encryptionKeys = initialFullDid.keyAgreement
       if (!encryptionKeys) throw new Error('No key agreement keys')
@@ -812,7 +802,6 @@ describe('DID management batching', () => {
       const initialFullDid = await Did.query(
         Did.getFullDidUriFromKey(authentication[0])
       )
-      if (!initialFullDid) throw new Error('Cannot query created DID')
 
       const extrinsic = await Did.authorizeBatch({
         batchFunction: api.tx.utility.batchAll,
@@ -877,7 +866,6 @@ describe('DID management batching', () => {
       const fullDid = await Did.query(
         Did.getFullDidUriFromKey(authentication[0])
       )
-      if (!fullDid) throw new Error('Cannot query created DID')
 
       expect(fullDid.assertionMethod).toBeUndefined()
 
@@ -902,7 +890,6 @@ describe('DID management batching', () => {
       await submitExtrinsic(updateTx, paymentAccount)
 
       const updatedFullDid = await Did.query(fullDid.uri)
-      if (!updatedFullDid) throw new Error('Cannot query created DID')
 
       // .setAttestationKey() extrinsic went through in the batch
       expect(updatedFullDid.assertionMethod?.[0]).toBeDefined()
@@ -937,7 +924,6 @@ describe('DID management batching', () => {
       const fullDid = await Did.query(
         Did.getFullDidUriFromKey(authentication[0])
       )
-      if (!fullDid) throw new Error('Cannot query created DID')
 
       expect(fullDid.assertionMethod).toBeUndefined()
 
@@ -968,7 +954,6 @@ describe('DID management batching', () => {
       })
 
       const updatedFullDid = await Did.query(fullDid.uri)
-      if (!updatedFullDid) throw new Error('Cannot query created DID')
       // .setAttestationKey() extrinsic went through but it was then reverted
       expect(updatedFullDid.assertionMethod).toBeUndefined()
       // The service endpoint will match the one manually added, and not the one set in the builder.

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -87,9 +87,9 @@ export function fromCredentialAndDid(
  */
 export async function getDelegationDetails(
   input: IAttestation['delegationId'] | IAttestation
-): Promise<IDelegationHierarchyDetails | null> {
+): Promise<IDelegationHierarchyDetails> {
   if (input === null) {
-    return null
+    throw new SDKErrors.HierarchyQueryError('null')
   }
 
   let delegationId: IAttestation['delegationId']
@@ -101,13 +101,10 @@ export async function getDelegationDetails(
   }
 
   if (!delegationId) {
-    return null
+    throw new SDKErrors.HierarchyQueryError('null')
   }
 
   const delegationNode = await DelegationNode.query(delegationId)
-  if (!delegationNode) {
-    return null
-  }
   return delegationNode.getHierarchyDetails()
 }
 

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -81,10 +81,7 @@ export type DelegationNodeId = Hash
 
 export function delegationNodeFromChain(
   encoded: Option<DelegationDelegationHierarchyDelegationNode>
-): DelegationNodeRecord | null {
-  if (encoded.isNone) {
-    return null
-  }
+): DelegationNodeRecord {
   const delegationNode = encoded.unwrap()
 
   return {

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -42,13 +42,9 @@ export type CtypeHash = Hash
 
 export function delegationHierarchyDetailsFromChain(
   encoded: Option<DelegationDelegationHierarchyDelegationHierarchyDetails>
-): DelegationHierarchyDetailsRecord | null {
-  if (encoded.isNone) {
-    return null
-  }
-  const delegationHierarchyDetails = encoded.unwrap()
+): DelegationHierarchyDetailsRecord {
   return {
-    cTypeHash: delegationHierarchyDetails.ctypeHash.toHex(),
+    cTypeHash: encoded.unwrap().ctypeHash.toHex(),
   }
 }
 

--- a/packages/core/src/delegation/DelegationHierarchyDetails.chain.ts
+++ b/packages/core/src/delegation/DelegationHierarchyDetails.chain.ts
@@ -10,6 +10,7 @@ import type {
   IDelegationNode,
 } from '@kiltprotocol/types'
 import { ConfigService } from '@kiltprotocol/config'
+import { SDKErrors } from '@kiltprotocol/utils'
 
 import { delegationHierarchyDetailsFromChain } from './DelegationDecoder.js'
 
@@ -21,16 +22,14 @@ import { delegationHierarchyDetailsFromChain } from './DelegationDecoder.js'
  */
 export async function query(
   rootId: IDelegationNode['id']
-): Promise<IDelegationHierarchyDetails | null> {
+): Promise<IDelegationHierarchyDetails> {
   const api = ConfigService.get('api')
-  const decoded = delegationHierarchyDetailsFromChain(
-    await api.query.delegation.delegationHierarchies(rootId)
-  )
-  if (!decoded) {
-    return null
+  const chain = await api.query.delegation.delegationHierarchies(rootId)
+  if (chain.isNone) {
+    throw new SDKErrors.HierarchyQueryError(rootId)
   }
   return {
-    ...decoded,
+    ...delegationHierarchyDetailsFromChain(chain),
     id: rootId,
   }
 }

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -588,19 +588,14 @@ describe('DelegationHierarchy', () => {
     await rootDelegation.getStoreTx()
 
     const rootNode = await DelegationNode.query(ROOT_IDENTIFIER)
-    if (rootNode) {
-      expect(rootNode.id).toBe(ROOT_IDENTIFIER)
-    }
+    expect(rootNode.id).toBe(ROOT_IDENTIFIER)
   })
 
   it('query root delegation', async () => {
     const queriedDelegation = await DelegationNode.query(ROOT_IDENTIFIER)
-    expect(queriedDelegation).not.toBe(undefined)
-    if (queriedDelegation) {
-      expect(queriedDelegation.account).toBe(didAlice)
-      expect(await queriedDelegation.getCTypeHash()).toBe(ctypeHash)
-      expect(queriedDelegation.id).toBe(ROOT_IDENTIFIER)
-    }
+    expect(queriedDelegation.account).toBe(didAlice)
+    expect(await queriedDelegation.getCTypeHash()).toBe(ctypeHash)
+    expect(queriedDelegation.id).toBe(ROOT_IDENTIFIER)
   })
 
   it('root delegation verify', async () => {
@@ -614,7 +609,7 @@ describe('DelegationHierarchy', () => {
     })
     await aDelegationRootNode.getRevokeTx(didAlice)
     const node = await DelegationNode.query(ROOT_IDENTIFIER)
-    const fetchedNodeRevocationStatus = node?.revoked
+    const fetchedNodeRevocationStatus = node.revoked
     expect(fetchedNodeRevocationStatus).toEqual(true)
   })
 

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -173,15 +173,6 @@ export class DelegationNode implements IDelegationNode {
   }
 
   /**
-   * Fetches the parent node of this delegation node.
-   *
-   * @returns Promise containing the parent as [[DelegationNode]] or [null].
-   */
-  public async getParent(): Promise<DelegationNode | null> {
-    return this.parentId ? query(this.parentId) : null
-  }
-
-  /**
    * Fetches the children nodes of this delegation node.
    *
    * @returns Promise containing the children as an array of [[DelegationNode]], which is empty if there are no children.
@@ -348,15 +339,22 @@ export class DelegationNode implements IDelegationNode {
         node: this,
       }
     }
-    const parent = await this.getParent()
-    if (parent) {
+    if (!this.parentId) {
+      return {
+        steps: 0,
+        node: null,
+      }
+    }
+    try {
+      const parent = await query(this.parentId)
       const result = await parent.findAncestorOwnedBy(did)
       result.steps += 1
       return result
-    }
-    return {
-      steps: 0,
-      node: null,
+    } catch {
+      return {
+        steps: 0,
+        node: null,
+      }
     }
   }
 

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -167,12 +167,7 @@ export class DelegationNode implements IDelegationNode {
    */
   public async getHierarchyDetails(): Promise<IDelegationHierarchyDetails> {
     if (!this.hierarchyDetails) {
-      const hierarchyDetails = await queryDetails(this.hierarchyId)
-      if (!hierarchyDetails) {
-        throw new SDKErrors.HierarchyQueryError(this.hierarchyId)
-      }
-      this.hierarchyDetails = hierarchyDetails
-      return hierarchyDetails
+      this.hierarchyDetails = await queryDetails(this.hierarchyId)
     }
     return this.hierarchyDetails
   }

--- a/packages/core/src/delegation/DelegationNode.utils.ts
+++ b/packages/core/src/delegation/DelegationNode.utils.ts
@@ -47,9 +47,10 @@ export async function countNodeDepth(
   // if the attester is not the owner, we need to check the delegation tree
   if (attestation.owner !== attester && attestation.delegationId !== null) {
     delegationTreeTraversalSteps += 1
-    const delegationNode = await DelegationNode.query(attestation.delegationId)
-
-    if (typeof delegationNode !== 'undefined' && delegationNode !== null) {
+    try {
+      const delegationNode = await DelegationNode.query(
+        attestation.delegationId
+      )
       const { steps, node } = await delegationNode.findAncestorOwnedBy(attester)
       delegationTreeTraversalSteps += steps
       if (node === null) {
@@ -57,6 +58,8 @@ export async function countNodeDepth(
           'Attester is not authorized to revoke this attestation. (Attester not in delegation tree)'
         )
       }
+    } catch {
+      // ignore the error
     }
   } else if (attestation.owner !== attester) {
     throw new SDKErrors.UnauthorizedError(

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -135,8 +135,6 @@ describe('When creating an instance from the chain', () => {
     const fullDid = await Did.query(existingDid)
 
     expect(fullDid).not.toBeNull()
-    if (!fullDid) throw new Error('Cannot load created DID')
-
     expect(fullDid).toEqual(<DidDocument>{
       uri: 'did:kilt:4rp4rcDHP71YrBNvDhcH5iRoM3YzVoQVnCZvQPwPom9bjo2e',
       authentication: [
@@ -197,8 +195,7 @@ describe('When creating an instance from the chain', () => {
       ApiMocks.mockChainQueryReturn('did', 'did')
     )
 
-    const fullDid = await Did.query(nonExistingDid)
-    expect(fullDid).toBeNull()
+    await expect(Did.query(nonExistingDid)).rejects.toThrow()
   })
 
   describe('authorizeBatch', () => {

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -38,7 +38,7 @@ import { parse } from '../Did.utils.js'
  *
  * @returns The fetched [[DidDocument]], or null if DID does not exist.
  */
-export async function query(didUri: DidUri): Promise<DidDocument | null> {
+export async function query(didUri: DidUri): Promise<DidDocument> {
   const { fragment, type } = parse(didUri)
   if (fragment) {
     throw new SDKErrors.DidError(`DID URI cannot contain fragment: "${didUri}"`)
@@ -51,7 +51,7 @@ export async function query(didUri: DidUri): Promise<DidDocument | null> {
 
   const api = ConfigService.get('api')
   const encoded = await api.query.did.did(toChain(didUri))
-  if (encoded.isNone) return null
+  if (encoded.isNone) throw new SDKErrors.DidNotFoundError()
   const didRec = documentFromChain(encoded)
 
   const did: DidDocument = {

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -163,17 +163,12 @@ export function connectedAccountsFromChain(
  * @param linkedAccount The account to use for the lookup.
  * @returns The Web3 name linked to the given account, or `null` otherwise.
  */
-export async function queryWeb3Name(
-  linkedAccount: Address
-): Promise<Web3Name | null> {
+export async function queryWeb3Name(linkedAccount: Address): Promise<Web3Name> {
   const api = ConfigService.get('api')
   // TODO: Replace with custom RPC call when available.
   const encoded = await api.query.didLookup.connectedDids(
     accountToChain(linkedAccount)
   )
-  if (encoded.isNone) {
-    return null
-  }
   return web3NameFromChain(
     await api.query.web3Names.names(encoded.unwrap().did)
   )

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -164,12 +164,12 @@ describe('When resolving a key', () => {
   it('returns null if either the DID or the key do not exist', async () => {
     let keyIdUri: DidResourceUri = `${deletedDid}#enc`
 
-    expect(await resolveKey(keyIdUri)).toBeNull()
+    await expect(resolveKey(keyIdUri)).rejects.toThrow()
 
     const didWithNoEncryptionKey = didWithAuthenticationKey
     keyIdUri = `${didWithNoEncryptionKey}#enc`
 
-    expect(await resolveKey(keyIdUri)).toBeNull()
+    await expect(resolveKey(keyIdUri)).rejects.toThrow()
   })
 
   it('throws for invalid URIs', async () => {

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -207,12 +207,12 @@ describe('When resolving a service endpoint', () => {
 
     let serviceIdUri: DidResourceUri = `${deletedDid}#service-1`
 
-    expect(await resolveService(serviceIdUri)).toBeNull()
+    await expect(resolveService(serviceIdUri)).rejects.toThrow()
 
     const didWithNoServiceEndpoints = didWithAuthenticationKey
     serviceIdUri = `${didWithNoServiceEndpoints}#service-1`
 
-    expect(await resolveService(serviceIdUri)).toBeNull()
+    await expect(resolveService(serviceIdUri)).rejects.toThrow()
   })
 
   it('throws for invalid URIs', async () => {

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -178,7 +178,7 @@ export async function resolveKey(
  */
 export async function resolveService(
   serviceUri: DidResourceUri
-): Promise<ResolvedDidServiceEndpoint | null> {
+): Promise<ResolvedDidServiceEndpoint> {
   const { fragment: serviceId, did, type } = parse(serviceUri)
 
   // A fragment (serviceId) IS expected to resolve a service endpoint.
@@ -193,7 +193,7 @@ export async function resolveService(
       resourceIdToChain(serviceId)
     )
     if (encoded.isNone) {
-      return null
+      throw new SDKErrors.DidNotFoundError()
     }
     const serviceEndpoint = serviceFromChain(encoded)
     return {
@@ -204,7 +204,7 @@ export async function resolveService(
 
   const resolved = await resolve(did)
   if (!resolved) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
 
   const {
@@ -214,15 +214,15 @@ export async function resolveService(
 
   // If the light DID has been upgraded we consider the old key URI invalid, the full DID URI should be used instead.
   if (canonicalId) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
   if (!document) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
 
   const endpoint = Did.getService(document, serviceId)
   if (!endpoint) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
 
   return {

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -129,7 +129,7 @@ export async function strictResolve(
  */
 export async function resolveKey(
   keyUri: DidResourceUri
-): Promise<ResolvedDidKey | null> {
+): Promise<ResolvedDidKey> {
   const { did, fragment: keyId } = parse(keyUri)
 
   // A fragment (keyId) IS expected to resolve a key.
@@ -139,7 +139,7 @@ export async function resolveKey(
 
   const resolved = await resolve(did)
   if (!resolved) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
 
   const {
@@ -149,15 +149,15 @@ export async function resolveKey(
 
   // If the light DID has been upgraded we consider the old key URI invalid, the full DID URI should be used instead.
   if (canonicalId) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
   if (!document) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
 
   const key = Did.getKey(document, keyId)
   if (!key) {
-    return null
+    throw new SDKErrors.DidNotFoundError()
   }
 
   const { includedAt } = key

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -34,7 +34,13 @@ export async function resolve(
   const { type } = parse(did)
   const api = ConfigService.get('api')
 
-  const document = await Did.query(getFullDidUri(did))
+  let document: DidDocument | undefined
+  try {
+    document = await Did.query(getFullDidUri(did))
+  } catch {
+    // ignore errors
+  }
+
   if (type === 'full' && document) {
     return {
       document,

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -307,11 +307,7 @@ export async function decrypt(
     encrypted
 
   const senderKeyDetails = await resolveKey(senderKeyUri)
-  if (!senderKeyDetails) {
-    throw new SDKErrors.DidError(
-      `Could not resolve sender encryption key "${senderKeyUri}"`
-    )
-  }
+
   const { fragment } = Did.parse(receiverKeyUri)
   if (!fragment) {
     throw new SDKErrors.DidError(
@@ -421,9 +417,6 @@ export async function encrypt(
   } = {}
 ): Promise<IEncryptedMessage> {
   const receiverKey = await resolveKey(receiverKeyUri)
-  if (!receiverKey) {
-    throw new SDKErrors.DidError(`Cannot resolve key "${receiverKeyUri}"`)
-  }
   if (message.receiver !== receiverKey.controller) {
     throw new SDKErrors.IdentityMismatchError('receiver public key', 'receiver')
   }

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -315,9 +315,7 @@ export async function createFullDidFromLightDid(
     sign
   )
   await Blockchain.signAndSubmitTx(tx, payer)
-  const fullDid = await Did.query(Did.getFullDidUri(uri))
-  if (!fullDid) throw new Error('Could not fetch created DID document')
-  return fullDid
+  return Did.query(Did.getFullDidUri(uri))
 }
 
 export async function createFullDidFromSeed(

--- a/packages/types/src/DidResolver.ts
+++ b/packages/types/src/DidResolver.ts
@@ -67,6 +67,4 @@ export type DidResolve = (did: DidUri) => Promise<DidResolutionResult | null>
  * @returns A promise of a [[ResolvedDidKey]] object representing the DID public key or null if
  * the DID or key URI cannot be resolved.
  */
-export type DidResolveKey = (
-  didUri: DidResourceUri
-) => Promise<ResolvedDidKey | null>
+export type DidResolveKey = (didUri: DidResourceUri) => Promise<ResolvedDidKey>

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -50,6 +50,8 @@ export class DidExporterError extends SDKError {}
 // TODO: rename me
 export class DidBuilderError extends SDKError {}
 
+export class DidNotFoundError extends SDKError {}
+
 export class ClaimHashMissingError extends SDKError {}
 
 export class RevokedTypeError extends SDKError {}


### PR DESCRIPTION
This PR replaces `return null` with `throw new Error()` in the few remaining functions

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
