### PR TITLE
fix: missing JSDoc annotations and other lints

### DIFF
--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -19,7 +19,7 @@ import { ConfigService } from '@kiltprotocol/config'
 import { latest, rpc, runtime } from '@kiltprotocol/type-definitions'
 
 /**
- * Prepares crypto modules (required e.g. for identity creation) and calls ConfigService.set().
+ * Prepares crypto modules (required for identity creation and others) and calls ConfigService.set().
  *
  * @param configs Arguments to pass on to ConfigService.set().
  * @returns Promise that must be awaited to assure crypto is ready.

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -62,7 +62,6 @@ export function validateQuoteSchema(
  * Signs a [[Quote]] object as an Attester.
  *
  * @param quoteInput A [[Quote]] object.
- * @param attesterIdentity The DID used to sign the object.
  * @param sign The callback to sign with the private key.
  * @returns A signed [[Quote]] object.
  */

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -60,14 +60,32 @@ export type ChainDidPublicKeyDetails = DidDidDetailsDidPublicKeyDetails
 
 // ### RAW QUERYING (lowest layer)
 
+/**
+ * Format a DID to be used as a parameter for the blockchain API functions.
+
+ * @param did The DID to format.
+ * @returns The blockchain-formatted DID.
+ */
 export function toChain(did: DidUri): KiltAddress {
   return parse(did).address
 }
 
+/**
+ * Format a DID resource ID to be used as a parameter for the blockchain API functions.
+
+ * @param id The DID resource ID to format.
+ * @returns The blockchain-formatted ID.
+ */
 export function resourceIdToChain(id: UriFragment): string {
   return id.replace(/^#/, '')
 }
 
+/**
+ * Convert the deposit data coming from the blockchain to JS object.
+ *
+ * @param deposit The blockchain-formatted deposit data.
+ * @returns The deposit data.
+ */
 export function depositFromChain(deposit: KiltSupportDeposit): Deposit {
   return {
     owner: Crypto.encodeAddress(deposit.owner, ss58Format),
@@ -101,10 +119,22 @@ function didPublicKeyDetailsFromChain(
   }
 }
 
+/**
+ * Convert the DID data from blockchain format to the DID URI.
+ *
+ * @param encoded The chain-formatted DID.
+ * @returns The DID URI.
+ */
 export function fromChain(encoded: AccountId32): DidUri {
   return getFullDidUri(Crypto.encodeAddress(encoded, ss58Format))
 }
 
+/**
+ * Convert the DID Document data from the blockchain format to a JS object.
+ *
+ * @param encoded The chain-formatted DID Document.
+ * @returns The DID Document.
+ */
 export function documentFromChain(
   encoded: Option<DidDidDetails>
 ): ChainDocument {
@@ -220,9 +250,15 @@ export function validateService(endpoint: DidServiceEndpoint): void {
   })
 }
 
-export function serviceToChain(endpoint: DidServiceEndpoint): ChainEndpoint {
-  validateService(endpoint)
-  const { id, type, serviceEndpoint } = endpoint
+/**
+ * Format the DID service to be used as a parameter for the blockchain API functions.
+ *
+ * @param service The DID service to format.
+ * @returns The blockchain-formatted DID service.
+ */
+export function serviceToChain(service: DidServiceEndpoint): ChainEndpoint {
+  validateService(service)
+  const { id, type, serviceEndpoint } = service
   return {
     id: resourceIdToChain(id),
     serviceTypes: type,
@@ -230,6 +266,12 @@ export function serviceToChain(endpoint: DidServiceEndpoint): ChainEndpoint {
   }
 }
 
+/**
+ * Convert the DID service data coming from the blockchain to JS object.
+ *
+ * @param encoded The blockchain-formatted DID service data.
+ * @returns The DID service.
+ */
 export function serviceFromChain(
   encoded: Option<DidServiceEndpointsDidEndpoint>
 ): DidServiceEndpoint {

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -135,29 +135,35 @@ export function validateUri(
     throw new TypeError(`DID string expected, got ${typeof input}`)
   }
   const { address, fragment } = parse(input as DidUri)
-  switch (expectType) {
-    // for backwards compatibility with previous implementations, `false` maps to `Did` while `true` maps to `undefined`.
-    // @ts-ignore
-    case false:
-    case 'Did':
-      if (fragment)
-        throw new SDKErrors.DidError(
-          'Expected a Kilt DidUri but got a DidResourceUri (containing a #fragment)'
-        )
-      break
-    case 'ResourceUri':
-      if (!fragment)
-        throw new SDKErrors.DidError(
-          'Expected a Kilt DidResourceUri (containing a #fragment) but got a DidUri'
-        )
-      break
-    default:
-      break
+
+  if (
+    fragment &&
+    (expectType === 'Did' ||
+      // for backwards compatibility with previous implementations, `false` maps to `Did` while `true` maps to `undefined`.
+      (typeof expectType === 'boolean' && expectType === false))
+  ) {
+    throw new SDKErrors.DidError(
+      'Expected a Kilt DidUri but got a DidResourceUri (containing a #fragment)'
+    )
+  }
+
+  if (!fragment && expectType === 'ResourceUri') {
+    throw new SDKErrors.DidError(
+      'Expected a Kilt DidResourceUri (containing a #fragment) but got a DidUri'
+    )
   }
 
   DataUtils.verifyKiltAddress(address)
 }
 
+/**
+ * Internal: derive the address part of the DID when it is created from authentication key.
+ *
+ * @param input The authentication key.
+ * @param input.publicKey The public key.
+ * @param input.type The type of the key.
+ * @returns The expected address of the DID.
+ */
 export function getAddressByKey({
   publicKey,
   type,

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -12,7 +12,6 @@ import { BN } from '@polkadot/util'
 import type {
   DidDocument,
   DidUri,
-  DidVerificationKey,
   KiltAddress,
   SignExtrinsicCallback,
   SubmittableExtrinsic,
@@ -112,6 +111,12 @@ function getKeyRelationshipForMethod(
   return methodMapping[section]
 }
 
+/**
+ * Detect the key relationship for a key which should be used to DID-authorize the provided extrinsic.
+ *
+ * @param extrinsic The unsigned extrinsic to inspect.
+ * @returns The key relationship.
+ */
 export function getKeyRelationshipForExtrinsic(
   extrinsic: Extrinsic
 ): VerificationKeyRelationship | undefined {
@@ -127,23 +132,6 @@ function increaseNonce(currentNonce: BN, increment = 1): BN {
   return currentNonce.eq(maxNonceValue)
     ? new BN(increment)
     : currentNonce.addn(increment)
-}
-
-/**
- * Returns all the DID keys that could be used to sign the provided extrinsic for submission.
- * This function should never be used directly by SDK users, who should rather call [[Did.authorizeExtrinsic]].
- *
- * @param did The DID data.
- * @param extrinsic The unsigned extrinsic to perform the lookup.
- *
- * @returns All the keys under the full DID that could be used to generate valid signatures to submit the provided extrinsic.
- */
-export function getKeysForExtrinsic(
-  did: DidDocument,
-  extrinsic: Extrinsic
-): DidVerificationKey[] {
-  const keyRelationship = getKeyRelationshipForExtrinsic(extrinsic)
-  return (keyRelationship && did[keyRelationship]) || []
 }
 
 /**

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -27,7 +27,9 @@ import * as Did from '../index.js'
 describe('When creating an instance from the details', () => {
   it('correctly assign the right sr25519 authentication key, x25519 encryption key, and service endpoints', () => {
     const authKey = Crypto.makeKeypairFromSeed(undefined, 'sr25519')
-    const encKey = Crypto.makeEncryptionKeyFromSeed(new Uint8Array(32).fill(1))
+    const encKey = Crypto.makeEncryptionKeypairFromSeed(
+      new Uint8Array(32).fill(1)
+    )
     const service: DidServiceEndpoint[] = [
       {
         id: '#service-1',
@@ -80,7 +82,9 @@ describe('When creating an instance from the details', () => {
 
   it('correctly assign the right ed25519 authentication key and encryption key', () => {
     const authKey = Crypto.makeKeypairFromSeed()
-    const encKey = Crypto.makeEncryptionKeyFromSeed(new Uint8Array(32).fill(1))
+    const encKey = Crypto.makeEncryptionKeypairFromSeed(
+      new Uint8Array(32).fill(1)
+    )
 
     const lightDid = Did.createLightDidDocument({
       authentication: [authKey],
@@ -123,7 +127,7 @@ describe('When creating an instance from the details', () => {
 
   it('throws for unsupported encryption key type', () => {
     const authKey = Crypto.makeKeypairFromSeed()
-    const encKey = Crypto.makeEncryptionKeyFromSeed()
+    const encKey = Crypto.makeEncryptionKeypairFromSeed()
     const invalidInput = {
       authentication: [authKey],
       // Not an encryption key type
@@ -140,7 +144,9 @@ describe('When creating an instance from the details', () => {
 describe('When creating an instance from a URI', () => {
   it('correctly assign the right authentication key, encryption key, and service endpoints', () => {
     const authKey = Crypto.makeKeypairFromSeed(undefined, 'sr25519')
-    const encKey = Crypto.makeEncryptionKeyFromSeed(new Uint8Array(32).fill(1))
+    const encKey = Crypto.makeEncryptionKeypairFromSeed(
+      new Uint8Array(32).fill(1)
+    )
     const endpoints: DidServiceEndpoint[] = [
       {
         id: '#service-1',
@@ -197,7 +203,7 @@ describe('When creating an instance from a URI', () => {
 
   it('fail if a fragment is present according to the options', () => {
     const authKey = Crypto.makeKeypairFromSeed()
-    const encKey = Crypto.makeEncryptionKeyFromSeed()
+    const encKey = Crypto.makeEncryptionKeypairFromSeed()
     const service: DidServiceEndpoint[] = [
       {
         id: '#service-1',

--- a/packages/did/src/DidLinks/AccountLinks.chain.ts
+++ b/packages/did/src/DidLinks/AccountLinks.chain.ts
@@ -96,6 +96,12 @@ function encodeMultiAddress(address: Address): EncodedMultiAddress {
 
 /* ### QUERY ### */
 
+/**
+ * Format a blockchain address to be used as a parameter for the blockchain API functions.
+ *
+ * @param account The account to format.
+ * @returns The blockchain-formatted account.
+ */
 export function accountToChain(account: Address): Address {
   const api = ConfigService.get('api')
   if (!isEthereumEnabled(api)) {

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -365,7 +365,7 @@ describe('When resolving a full DID', () => {
 
 describe('When resolving a light DID', () => {
   const authKey = Crypto.makeKeypairFromSeed()
-  const encryptionKey = Crypto.makeEncryptionKeyFromSeed()
+  const encryptionKey = Crypto.makeEncryptionKeypairFromSeed()
 
   beforeEach(() => {
     mockedApi.query.did.did.mockReturnValue(didNotFound)

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -66,7 +66,6 @@ export function makeEncryptCallback({
  *
  * @param secretKey The options parameter.
  * @param secretKey.secretKey The key to use for decryption.
- * @param secretKey.type The X25519 type, only this one is supported.
  * @returns The callback.
  */
 export function makeDecryptCallback({
@@ -96,7 +95,7 @@ export interface EncryptionKeyTool {
  * @returns Object with secret and public key and the key type.
  */
 export function makeEncryptionKeyTool(seed: string): EncryptionKeyTool {
-  const keypair = Crypto.makeEncryptionKeyFromSeed(blake2AsU8a(seed, 256))
+  const keypair = Crypto.makeEncryptionKeypairFromSeed(blake2AsU8a(seed, 256))
 
   const encrypt = makeEncryptCallback(keypair)
   const decrypt = makeDecryptCallback(keypair)

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -351,6 +351,13 @@ export function hashStatements(
   })
 }
 
+/**
+ * Generate typed KILT blockchain keypair from a seed or random data.
+ *
+ * @param seed The keypair seed, only optional in the tests.
+ * @param type Optional type of the keypair.
+ * @returns The keypair.
+ */
 export function makeKeypairFromSeed<
   KeyType extends KiltKeyringPair['type'] = 'ed25519'
 >(seed = randomAsU8a(32), type?: KeyType): KiltKeyringPair & { type: KeyType } {
@@ -358,6 +365,13 @@ export function makeKeypairFromSeed<
   return keyring.addFromSeed(seed) as KiltKeyringPair & { type: KeyType }
 }
 
+/**
+ * Generate typed KILT blockchain keypair from a polkadot keypair URI.
+ *
+ * @param uri The URI.
+ * @param type Optional type of the keypair.
+ * @returns The keypair.
+ */
 export function makeKeypairFromUri<
   KeyType extends KiltKeyringPair['type'] = 'ed25519'
 >(uri: string, type?: KeyType): KiltKeyringPair & { type: KeyType } {
@@ -365,7 +379,13 @@ export function makeKeypairFromUri<
   return keyring.addFromUri(uri) as KiltKeyringPair & { type: KeyType }
 }
 
-export function makeEncryptionKeyFromSeed(
+/**
+ * Generate from a seed a x25519 keypair to be used as DID encryption key.
+ *
+ * @param seed The keypair seed, only optional in the tests.
+ * @returns The keypair.
+ */
+export function makeEncryptionKeypairFromSeed(
   seed = randomAsU8a(32)
 ): KiltEncryptionKeypair {
   return {


### PR DESCRIPTION
This PR cleans up some leftovers reported by eslint.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
