### PR TITLE
chore: rename DidBuilderError

### DIFF
--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -162,18 +162,14 @@ export function getAddressByKey({
   publicKey,
   type,
 }: Pick<DidVerificationKey, 'publicKey' | 'type'>): KiltAddress {
-  switch (type) {
-    case 'ed25519':
-    case 'sr25519':
-      return encodeAddress(publicKey, ss58Format)
-    case 'ecdsa': {
-      // Taken from https://github.com/polkadot-js/common/blob/master/packages/keyring/src/pair/index.ts#L44
-      const pk = publicKey.length > 32 ? blake2AsU8a(publicKey) : publicKey
-      return encodeAddress(pk, ss58Format)
-    }
-    default:
-      throw new SDKErrors.DidBuilderError(`Unsupported key type "${type}"`)
+  if (type === 'ed25519' || type === 'sr25519') {
+    return encodeAddress(publicKey, ss58Format)
   }
+
+  // Otherwise it’s ecdsa.
+  // Taken from https://github.com/polkadot-js/common/blob/master/packages/keyring/src/pair/index.ts#L44
+  const address = publicKey.length > 32 ? blake2AsU8a(publicKey) : publicKey
+  return encodeAddress(address, ss58Format)
 }
 
 /**

--- a/packages/did/src/DidDetails/FullDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.spec.ts
@@ -225,7 +225,7 @@ describe('When creating an instance from the chain', () => {
             submitter: keypair.address,
           })
         ).rejects.toMatchInlineSnapshot(
-          '[DidBuilderError: Can only batch extrinsics that require a DID signature]'
+          '[DidBatchError: Can only batch extrinsics that require a DID signature]'
         )
       })
 
@@ -308,7 +308,7 @@ describe('When creating an instance from the chain', () => {
             submitter: keypair.address,
           })
         ).rejects.toMatchInlineSnapshot(
-          '[DidBuilderError: Cannot build a batch with no transactions]'
+          '[DidBatchError: Cannot build a batch with no transactions]'
         )
       })
       it.todo('successfully create a batch with only 1 extrinsic')

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -216,7 +216,7 @@ function groupExtrinsicsByKeyRelationship(
   const [first, ...rest] = extrinsics.map((extrinsic) => {
     const keyRelationship = getKeyRelationshipForExtrinsic(extrinsic)
     if (!keyRelationship) {
-      throw new SDKErrors.DidBuilderError(
+      throw new SDKErrors.DidBatchError(
         'Can only batch extrinsics that require a DID signature'
       )
     }
@@ -274,7 +274,7 @@ export async function authorizeBatch({
   submitter: KiltAddress
 }): Promise<SubmittableExtrinsic> {
   if (extrinsics.length === 0) {
-    throw new SDKErrors.DidBuilderError(
+    throw new SDKErrors.DidBatchError(
       'Cannot build a batch with no transactions'
     )
   }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -47,8 +47,7 @@ export class DidError extends SDKError {}
 
 export class DidExporterError extends SDKError {}
 
-// TODO: rename me
-export class DidBuilderError extends SDKError {}
+export class DidBatchError extends SDKError {}
 
 export class ClaimHashMissingError extends SDKError {}
 


### PR DESCRIPTION
This PR addresses a TODO remnant from #581 and renames a legacy error.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
