### PR TITLE
fix: metadata update command in weekly tests

### DIFF
--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -52,9 +52,6 @@ jobs:
             locked_dependencies.txt
             yarn.lock
 
-      - name: Update metadata to latest spiritnet metadata
-        run: yarn workspace @kiltprotocol/augment-api run update-metadata
-
       - name: yarn build
         run: yarn build
       - name: zip build

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -53,7 +53,7 @@ jobs:
             yarn.lock
 
       - name: Update metadata to latest spiritnet metadata
-        run: yarn workspace @kiltprotocol/testing node ./scripts/fetchMetadata.js -o ./src/mocks/metadata/spiritnet.json -e wss://spiritnet.kilt.io/
+        run: yarn workspace @kiltprotocol/augment-api run update-metadata
 
       - name: yarn build
         run: yarn build


### PR DESCRIPTION
## fixes KILTprotocol/sdk-js#653

Weekly tests have been failing because the script they use to update the chain metadata for tests has been moved.
This PR fixes this.

__We could also think about removing that step altogether though, as checking for incompatibilities with new polkadot package versions should be considered separate from checking for incompatibilities introduced by runtime upgrades.__