### PR TITLE
refactor!: simplify CType

### DIFF
--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -241,10 +241,8 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   }, 60_000)
 
   it('should not be possible to attest a claim on a Ctype that is not on chain', async () => {
-    const badCtype = CType.fromSchema({
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'badDriversLicense',
-      properties: {
+    const badCtype = CType.fromProperties(
+      {
         name: {
           type: 'string',
         },
@@ -252,8 +250,8 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
           type: 'integer',
         },
       },
-      type: 'object',
-    })
+      'badDriversLicense'
+    )
 
     const content = { name: 'Ralph', weight: 120 }
     const claim = Claim.fromCTypeAndClaimContents(
@@ -419,10 +417,8 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   })
 
   describe('when there is another Ctype that works as a legitimation', () => {
-    const officialLicenseAuthorityCType = CType.fromSchema({
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'License Authority',
-      properties: {
+    const officialLicenseAuthorityCType = CType.fromProperties(
+      {
         LicenseType: {
           type: 'string',
         },
@@ -430,8 +426,8 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
           type: 'string',
         },
       },
-      type: 'object',
-    })
+      'License Authority'
+    )
 
     beforeAll(async () => {
       if (await isCtypeOnChain(officialLicenseAuthorityCType)) return

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -241,8 +241,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   }, 60_000)
 
   it('should not be possible to attest a claim on a Ctype that is not on chain', async () => {
-    const badCtype = CType.fromProperties(
-      {
+    const badCtype = CType.fromSchema({
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'badDriversLicense',
+      properties: {
         name: {
           type: 'string',
         },
@@ -250,8 +252,8 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
           type: 'integer',
         },
       },
-      'badDriversLicense'
-    )
+      type: 'object',
+    })
 
     const content = { name: 'Ralph', weight: 120 }
     const claim = Claim.fromCTypeAndClaimContents(
@@ -417,8 +419,10 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   })
 
   describe('when there is another Ctype that works as a legitimation', () => {
-    const officialLicenseAuthorityCType = CType.fromProperties(
-      {
+    const officialLicenseAuthorityCType = CType.fromSchema({
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'License Authority',
+      properties: {
         LicenseType: {
           type: 'string',
         },
@@ -426,8 +430,8 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
           type: 'string',
         },
       },
-      'License Authority'
-    )
+      type: 'object',
+    })
 
     beforeAll(async () => {
       if (await isCtypeOnChain(officialLicenseAuthorityCType)) return

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -246,7 +246,6 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
   it('should not be possible to attest a claim on a Ctype that is not on chain', async () => {
     const badCtype = CType.fromSchema({
-      $id: 'kilt:ctype:0x1',
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'badDriversLicense',
       properties: {

--- a/packages/core/src/__integrationtests__/Attestation.spec.ts
+++ b/packages/core/src/__integrationtests__/Attestation.spec.ts
@@ -241,17 +241,14 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
   }, 60_000)
 
   it('should not be possible to attest a claim on a Ctype that is not on chain', async () => {
-    const badCtype = CType.fromProperties(
-      {
-        name: {
-          type: 'string',
-        },
-        weight: {
-          type: 'integer',
-        },
+    const badCtype = CType.fromProperties('badDriversLicense', {
+      name: {
+        type: 'string',
       },
-      'badDriversLicense'
-    )
+      weight: {
+        type: 'integer',
+      },
+    })
 
     const content = { name: 'Ralph', weight: 120 }
     const claim = Claim.fromCTypeAndClaimContents(
@@ -418,6 +415,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
 
   describe('when there is another Ctype that works as a legitimation', () => {
     const officialLicenseAuthorityCType = CType.fromProperties(
+      'License Authority',
       {
         LicenseType: {
           type: 'string',
@@ -425,8 +423,7 @@ describe('When there is an attester, claimer and ctype drivers license', () => {
         LicenseSubtypes: {
           type: 'string',
         },
-      },
-      'License Authority'
+      }
     )
 
     beforeAll(async () => {

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -72,9 +72,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     await submitTx(authorizedStoreTx, paymentAccount)
 
     expect(
-      CType.fromChain(
-        await api.query.ctype.ctypes(CType.getCTypeHashFromId(ctype.$id))
-      )
+      CType.fromChain(await api.query.ctype.ctypes(CType.idToHash(ctype.$id)))
     ).toBe(ctypeCreator.uri)
     await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
   }, 40_000)
@@ -102,9 +100,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     ).rejects.toMatchObject({ section: 'ctype', name: 'CTypeAlreadyExists' })
 
     expect(
-      CType.fromChain(
-        await api.query.ctype.ctypes(CType.getCTypeHashFromId(ctype.$id))
-      )
+      CType.fromChain(await api.query.ctype.ctypes(CType.idToHash(ctype.$id)))
     ).toBe(ctypeCreator.uri)
   }, 45_000)
 
@@ -115,8 +111,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
     await expect(CType.verifyStored(iAmNotThere)).rejects.toThrow()
     expect(
-      (await api.query.ctype.ctypes(CType.getCTypeHashFromId(iAmNotThere.$id)))
-        .isNone
+      (await api.query.ctype.ctypes(CType.idToHash(iAmNotThere.$id))).isNone
     ).toBe(true)
 
     const fakeHash = Crypto.hashStr('abcdefg')

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -35,15 +35,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
   function makeCType(): ICType {
     ctypeCounter += 1
-    return {
-      $id: `kilt:ctype:0x${ctypeCounter}`,
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: `ctype${ctypeCounter}`,
-      properties: {
-        name: { type: 'string' },
-      },
-      type: 'object',
-    }
+    return CType.fromProperties(`ctype${ctypeCounter}`, {
+      name: { type: 'string' },
+    })
   }
 
   beforeAll(async () => {
@@ -115,25 +109,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
   }, 45_000)
 
   it('should tell when a ctype is not on chain', async () => {
-    const iAmNotThere: ICType = {
-      $id: 'kilt:ctype:0x2',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'ctype2',
-      properties: {
-        game: { type: 'string' },
-      },
-      type: 'object',
-    }
-
-    const iAmNotThereWithOwner: ICType = {
-      $id: 'kilt:ctype:0x3',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'ctype2',
-      properties: {
-        game: { type: 'string' },
-      },
-      type: 'object',
-    }
+    const iAmNotThere: ICType = CType.fromProperties('ctype2', {
+      game: { type: 'string' },
+    })
 
     await expect(CType.verifyStored(iAmNotThere)).rejects.toThrow()
     expect(
@@ -143,8 +121,6 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
     const fakeHash = Crypto.hashStr('abcdefg')
     expect((await api.query.ctype.ctypes(fakeHash)).isNone).toBe(true)
-
-    await expect(CType.verifyStored(iAmNotThereWithOwner)).rejects.toThrow()
   })
 })
 

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -72,7 +72,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     await submitTx(authorizedStoreTx, paymentAccount)
 
     expect(
-      CType.fromChain(await api.query.ctype.ctypes(CType.idToHash(ctype.$id)))
+      CType.fromChain(await api.query.ctype.ctypes(CType.idToChain(ctype.$id)))
     ).toBe(ctypeCreator.uri)
     await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
   }, 40_000)
@@ -100,7 +100,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
     ).rejects.toMatchObject({ section: 'ctype', name: 'CTypeAlreadyExists' })
 
     expect(
-      CType.fromChain(await api.query.ctype.ctypes(CType.idToHash(ctype.$id)))
+      CType.fromChain(await api.query.ctype.ctypes(CType.idToChain(ctype.$id)))
     ).toBe(ctypeCreator.uri)
   }, 45_000)
 
@@ -111,7 +111,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
 
     await expect(CType.verifyStored(iAmNotThere)).rejects.toThrow()
     expect(
-      (await api.query.ctype.ctypes(CType.idToHash(iAmNotThere.$id))).isNone
+      (await api.query.ctype.ctypes(CType.idToChain(iAmNotThere.$id))).isNone
     ).toBe(true)
 
     const fakeHash = Crypto.hashStr('abcdefg')

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -109,7 +109,7 @@ describe('When there is an CtypeCreator and a verifier', () => {
   }, 45_000)
 
   it('should tell when a ctype is not on chain', async () => {
-    const iAmNotThere: ICType = CType.fromProperties('ctype2', {
+    const iAmNotThere = CType.fromProperties('ctype2', {
       game: { type: 'string' },
     })
 

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -61,7 +61,7 @@ async function writeHierarchy(
   const rootNode = DelegationNode.newRoot({
     account: delegator.uri,
     permissions: [Permission.DELEGATE],
-    cTypeHash: CType.getCTypeHashFromId(cTypeId),
+    cTypeHash: CType.idToHash(cTypeId),
   })
 
   const storeTx = await rootNode.getStoreTx()
@@ -457,9 +457,7 @@ describe('hierarchyDetails', () => {
 
     const details = await delegatedNode.getHierarchyDetails()
 
-    expect(CType.getIdForCTypeHash(details.cTypeHash)).toBe(
-      driversLicenseCType.$id
-    )
+    expect(CType.hashToId(details.cTypeHash)).toBe(driversLicenseCType.$id)
     expect(details.id).toBe(rootNode.id)
   }, 60_000)
 })

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -55,13 +55,13 @@ let attesterKey: KeyTool
 
 async function writeHierarchy(
   delegator: DidDocument,
-  ctypeId: ICType['$id'],
+  cTypeId: ICType['$id'],
   sign: SignCallback
 ): Promise<DelegationNode> {
   const rootNode = DelegationNode.newRoot({
     account: delegator.uri,
     permissions: [Permission.DELEGATE],
-    cTypeHash: CType.getCTypeHashFromId(ctypeId),
+    cTypeHash: CType.getCTypeHashFromId(cTypeId),
   })
 
   const storeTx = await rootNode.getStoreTx()

--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -55,13 +55,13 @@ let attesterKey: KeyTool
 
 async function writeHierarchy(
   delegator: DidDocument,
-  ctypeHash: ICType['hash'],
+  ctypeId: ICType['$id'],
   sign: SignCallback
 ): Promise<DelegationNode> {
   const rootNode = DelegationNode.newRoot({
     account: delegator.uri,
     permissions: [Permission.DELEGATE],
-    cTypeHash: ctypeHash,
+    cTypeHash: CType.getCTypeHashFromId(ctypeId),
   })
 
   const storeTx = await rootNode.getStoreTx()
@@ -136,7 +136,7 @@ it('fetches the correct deposit amount', async () => {
 it('should be possible to delegate attestation rights', async () => {
   const rootNode = await writeHierarchy(
     root,
-    driversLicenseCType.hash,
+    driversLicenseCType.$id,
     rootKey.getSignCallback(root)
   )
   const delegatedNode = await addDelegation(
@@ -158,7 +158,7 @@ describe('and attestation rights have been delegated', () => {
   beforeAll(async () => {
     rootNode = await writeHierarchy(
       root,
-      driversLicenseCType.hash,
+      driversLicenseCType.$id,
       rootKey.getSignCallback(root)
     )
     delegatedNode = await addDelegation(
@@ -262,7 +262,7 @@ describe('revocation', () => {
   it('delegator can revoke but not remove delegation', async () => {
     const rootNode = await writeHierarchy(
       delegator,
-      driversLicenseCType.hash,
+      driversLicenseCType.$id,
       delegatorSign
     )
     const delegationA = await addDelegation(
@@ -310,7 +310,7 @@ describe('revocation', () => {
   it('delegate cannot revoke root but can revoke own delegation', async () => {
     const delegationRoot = await writeHierarchy(
       delegator,
-      driversLicenseCType.hash,
+      driversLicenseCType.$id,
       delegatorSign
     )
     const delegationA = await addDelegation(
@@ -350,7 +350,7 @@ describe('revocation', () => {
   it('delegator can revoke root, revoking all delegations in tree', async () => {
     let delegationRoot = await writeHierarchy(
       delegator,
-      driversLicenseCType.hash,
+      driversLicenseCType.$id,
       delegatorSign
     )
     const delegationA = await addDelegation(
@@ -390,7 +390,7 @@ describe('Deposit claiming', () => {
     // Delegation nodes are written on the chain using `paymentAccount`.
     const rootNode = await writeHierarchy(
       root,
-      driversLicenseCType.hash,
+      driversLicenseCType.$id,
       rootKey.getSignCallback(root)
     )
     const delegatedNode = await addDelegation(
@@ -445,7 +445,7 @@ describe('hierarchyDetails', () => {
   it('can fetch hierarchyDetails', async () => {
     const rootNode = await writeHierarchy(
       root,
-      driversLicenseCType.hash,
+      driversLicenseCType.$id,
       rootKey.getSignCallback(root)
     )
     const delegatedNode = await addDelegation(
@@ -459,7 +459,9 @@ describe('hierarchyDetails', () => {
 
     const details = await delegatedNode.getHierarchyDetails()
 
-    expect(details.cTypeHash).toBe(driversLicenseCType.hash)
+    expect(CType.getIdForCTypeHash(details.cTypeHash)).toBe(
+      driversLicenseCType.$id
+    )
     expect(details.id).toBe(rootNode.id)
   }, 60_000)
 })

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -499,7 +499,12 @@ describe('DID authorization', () => {
   }, 60_000)
 
   it('authorizes ctype creation with DID signature', async () => {
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromSchema({
+      title: UUID.generate(),
+      properties: {},
+      type: 'object',
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    })
     const call = api.tx.ctype.add(CType.toChain(ctype))
     const tx = await Did.authorizeTx(
       did.uri,
@@ -525,7 +530,12 @@ describe('DID authorization', () => {
     )
     await submitTx(tx, paymentAccount)
 
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromSchema({
+      title: UUID.generate(),
+      properties: {},
+      type: 'object',
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    })
     const call = api.tx.ctype.add(CType.toChain(ctype))
     const tx2 = await Did.authorizeTx(
       did.uri,
@@ -965,7 +975,12 @@ describe('DID extrinsics batching', () => {
   }, 50_000)
 
   it('simple batch succeeds despite failures of some extrinsics', async () => {
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromSchema({
+      title: UUID.generate(),
+      properties: {},
+      type: 'object',
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    })
     const ctypeStoreTx = api.tx.ctype.add(CType.toChain(ctype))
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
@@ -995,7 +1010,12 @@ describe('DID extrinsics batching', () => {
   })
 
   it('batchAll fails if any extrinsics fail', async () => {
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromSchema({
+      title: UUID.generate(),
+      properties: {},
+      type: 'object',
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    })
     const ctypeStoreTx = api.tx.ctype.add(CType.toChain(ctype))
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
@@ -1062,7 +1082,12 @@ describe('DID extrinsics batching', () => {
     // Authentication key
     const web3NameReleaseExt = api.tx.web3Names.releaseByOwner()
     // Attestation key
-    const ctype1 = CType.fromProperties({}, UUID.generate())
+    const ctype1 = CType.fromSchema({
+      title: UUID.generate(),
+      properties: {},
+      type: 'object',
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    })
     const ctype1Creation = api.tx.ctype.add(CType.toChain(ctype1))
     // Delegation key
     const rootNode = DelegationNode.newRoot({
@@ -1075,7 +1100,12 @@ describe('DID extrinsics batching', () => {
     // Authentication key
     const web3NameNewClaimExt = api.tx.web3Names.claim('test-2')
     // Attestation key
-    const ctype2 = CType.fromProperties({}, UUID.generate())
+    const ctype2 = CType.fromSchema({
+      title: UUID.generate(),
+      properties: {},
+      type: 'object',
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    })
     const ctype2Creation = api.tx.ctype.add(CType.toChain(ctype2))
     // Delegation key
     const delegationHierarchyRemoval = await rootNode.getRevokeTx(fullDid.uri)

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -988,7 +988,7 @@ describe('DID extrinsics batching', () => {
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
       permissions: [Permission.DELEGATE],
-      cTypeHash: ctype.hash,
+      cTypeHash: CType.getCTypeHashFromId(ctype.$id),
     })
     const delegationStoreTx = await rootNode.getStoreTx()
     const delegationRevocationTx = await rootNode.getRevokeTx(fullDid.uri)
@@ -1023,7 +1023,7 @@ describe('DID extrinsics batching', () => {
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
       permissions: [Permission.DELEGATE],
-      cTypeHash: ctype.hash,
+      cTypeHash: CType.getCTypeHashFromId(ctype.$id),
     })
     const delegationStoreTx = await rootNode.getStoreTx()
     const delegationRevocationTx = await rootNode.getRevokeTx(fullDid.uri)
@@ -1096,7 +1096,7 @@ describe('DID extrinsics batching', () => {
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
       permissions: [Permission.DELEGATE],
-      cTypeHash: ctype1.hash,
+      cTypeHash: CType.getCTypeHashFromId(ctype1.$id),
     })
     const delegationHierarchyCreation = await rootNode.getStoreTx()
 

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -499,12 +499,7 @@ describe('DID authorization', () => {
   }, 60_000)
 
   it('authorizes ctype creation with DID signature', async () => {
-    const ctype = CType.fromSchema({
-      title: UUID.generate(),
-      properties: {},
-      type: 'object',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    })
+    const ctype = CType.fromProperties({}, UUID.generate())
     const call = api.tx.ctype.add(CType.toChain(ctype))
     const tx = await Did.authorizeTx(
       did.uri,
@@ -530,12 +525,7 @@ describe('DID authorization', () => {
     )
     await submitTx(tx, paymentAccount)
 
-    const ctype = CType.fromSchema({
-      title: UUID.generate(),
-      properties: {},
-      type: 'object',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    })
+    const ctype = CType.fromProperties({}, UUID.generate())
     const call = api.tx.ctype.add(CType.toChain(ctype))
     const tx2 = await Did.authorizeTx(
       did.uri,
@@ -975,12 +965,7 @@ describe('DID extrinsics batching', () => {
   }, 50_000)
 
   it('simple batch succeeds despite failures of some extrinsics', async () => {
-    const ctype = CType.fromSchema({
-      title: UUID.generate(),
-      properties: {},
-      type: 'object',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    })
+    const ctype = CType.fromProperties({}, UUID.generate())
     const ctypeStoreTx = api.tx.ctype.add(CType.toChain(ctype))
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
@@ -1010,12 +995,7 @@ describe('DID extrinsics batching', () => {
   })
 
   it('batchAll fails if any extrinsics fail', async () => {
-    const ctype = CType.fromSchema({
-      title: UUID.generate(),
-      properties: {},
-      type: 'object',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    })
+    const ctype = CType.fromProperties({}, UUID.generate())
     const ctypeStoreTx = api.tx.ctype.add(CType.toChain(ctype))
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
@@ -1082,12 +1062,7 @@ describe('DID extrinsics batching', () => {
     // Authentication key
     const web3NameReleaseExt = api.tx.web3Names.releaseByOwner()
     // Attestation key
-    const ctype1 = CType.fromSchema({
-      title: UUID.generate(),
-      properties: {},
-      type: 'object',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    })
+    const ctype1 = CType.fromProperties({}, UUID.generate())
     const ctype1Creation = api.tx.ctype.add(CType.toChain(ctype1))
     // Delegation key
     const rootNode = DelegationNode.newRoot({
@@ -1100,12 +1075,7 @@ describe('DID extrinsics batching', () => {
     // Authentication key
     const web3NameNewClaimExt = api.tx.web3Names.claim('test-2')
     // Attestation key
-    const ctype2 = CType.fromSchema({
-      title: UUID.generate(),
-      properties: {},
-      type: 'object',
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    })
+    const ctype2 = CType.fromProperties({}, UUID.generate())
     const ctype2Creation = api.tx.ctype.add(CType.toChain(ctype2))
     // Delegation key
     const delegationHierarchyRemoval = await rootNode.getRevokeTx(fullDid.uri)

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -970,7 +970,7 @@ describe('DID extrinsics batching', () => {
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
       permissions: [Permission.DELEGATE],
-      cTypeHash: CType.getCTypeHashFromId(ctype.$id),
+      cTypeHash: CType.idToHash(ctype.$id),
     })
     const delegationStoreTx = await rootNode.getStoreTx()
     const delegationRevocationTx = await rootNode.getRevokeTx(fullDid.uri)
@@ -1000,7 +1000,7 @@ describe('DID extrinsics batching', () => {
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
       permissions: [Permission.DELEGATE],
-      cTypeHash: CType.getCTypeHashFromId(ctype.$id),
+      cTypeHash: CType.idToHash(ctype.$id),
     })
     const delegationStoreTx = await rootNode.getStoreTx()
     const delegationRevocationTx = await rootNode.getRevokeTx(fullDid.uri)
@@ -1068,7 +1068,7 @@ describe('DID extrinsics batching', () => {
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
       permissions: [Permission.DELEGATE],
-      cTypeHash: CType.getCTypeHashFromId(ctype1.$id),
+      cTypeHash: CType.idToHash(ctype1.$id),
     })
     const delegationHierarchyCreation = await rootNode.getStoreTx()
 

--- a/packages/core/src/__integrationtests__/Did.spec.ts
+++ b/packages/core/src/__integrationtests__/Did.spec.ts
@@ -499,7 +499,7 @@ describe('DID authorization', () => {
   }, 60_000)
 
   it('authorizes ctype creation with DID signature', async () => {
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromProperties(UUID.generate(), {})
     const call = api.tx.ctype.add(CType.toChain(ctype))
     const tx = await Did.authorizeTx(
       did.uri,
@@ -525,7 +525,7 @@ describe('DID authorization', () => {
     )
     await submitTx(tx, paymentAccount)
 
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromProperties(UUID.generate(), {})
     const call = api.tx.ctype.add(CType.toChain(ctype))
     const tx2 = await Did.authorizeTx(
       did.uri,
@@ -965,7 +965,7 @@ describe('DID extrinsics batching', () => {
   }, 50_000)
 
   it('simple batch succeeds despite failures of some extrinsics', async () => {
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromProperties(UUID.generate(), {})
     const ctypeStoreTx = api.tx.ctype.add(CType.toChain(ctype))
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
@@ -995,7 +995,7 @@ describe('DID extrinsics batching', () => {
   })
 
   it('batchAll fails if any extrinsics fail', async () => {
-    const ctype = CType.fromProperties({}, UUID.generate())
+    const ctype = CType.fromProperties(UUID.generate(), {})
     const ctypeStoreTx = api.tx.ctype.add(CType.toChain(ctype))
     const rootNode = DelegationNode.newRoot({
       account: fullDid.uri,
@@ -1062,7 +1062,7 @@ describe('DID extrinsics batching', () => {
     // Authentication key
     const web3NameReleaseExt = api.tx.web3Names.releaseByOwner()
     // Attestation key
-    const ctype1 = CType.fromProperties({}, UUID.generate())
+    const ctype1 = CType.fromProperties(UUID.generate(), {})
     const ctype1Creation = api.tx.ctype.add(CType.toChain(ctype1))
     // Delegation key
     const rootNode = DelegationNode.newRoot({
@@ -1075,7 +1075,7 @@ describe('DID extrinsics batching', () => {
     // Authentication key
     const web3NameNewClaimExt = api.tx.web3Names.claim('test-2')
     // Attestation key
-    const ctype2 = CType.fromProperties({}, UUID.generate())
+    const ctype2 = CType.fromProperties(UUID.generate(), {})
     const ctype2Creation = api.tx.ctype.add(CType.toChain(ctype2))
     // Delegation key
     const delegationHierarchyRemoval = await rootNode.getRevokeTx(fullDid.uri)

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -103,10 +103,8 @@ export async function isCtypeOnChain(ctype: ICType): Promise<boolean> {
   }
 }
 
-export const driversLicenseCType = CType.fromSchema({
-  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-  title: 'Drivers License',
-  properties: {
+export const driversLicenseCType = CType.fromProperties(
+  {
     name: {
       type: 'string',
     },
@@ -114,13 +112,11 @@ export const driversLicenseCType = CType.fromSchema({
       type: 'integer',
     },
   },
-  type: 'object',
-})
+  'Drivers License'
+)
 
-export const driversLicenseCTypeForDeposit = CType.fromSchema({
-  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-  title: 'Drivers License for deposit test',
-  properties: {
+export const driversLicenseCTypeForDeposit = CType.fromProperties(
+  {
     name: {
       type: 'string',
     },
@@ -131,8 +127,8 @@ export const driversLicenseCTypeForDeposit = CType.fromSchema({
       type: 'string',
     },
   },
-  type: 'object',
-})
+  'Drivers License for deposit test'
+)
 
 // Submits resolving when IS_IN_BLOCK
 export async function submitTx(

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -103,8 +103,10 @@ export async function isCtypeOnChain(ctype: ICType): Promise<boolean> {
   }
 }
 
-export const driversLicenseCType = CType.fromProperties(
-  {
+export const driversLicenseCType = CType.fromSchema({
+  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+  title: 'Drivers License',
+  properties: {
     name: {
       type: 'string',
     },
@@ -112,11 +114,13 @@ export const driversLicenseCType = CType.fromProperties(
       type: 'integer',
     },
   },
-  'Drivers License'
-)
+  type: 'object',
+})
 
-export const driversLicenseCTypeForDeposit = CType.fromProperties(
-  {
+export const driversLicenseCTypeForDeposit = CType.fromSchema({
+  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+  title: 'Drivers License for deposit test',
+  properties: {
     name: {
       type: 'string',
     },
@@ -127,8 +131,8 @@ export const driversLicenseCTypeForDeposit = CType.fromProperties(
       type: 'string',
     },
   },
-  'Drivers License for deposit test'
-)
+  type: 'object',
+})
 
 // Submits resolving when IS_IN_BLOCK
 export async function submitTx(

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -124,7 +124,7 @@ export const driversLicenseCTypeForDeposit = CType.fromProperties(
     location: {
       type: 'string',
     },
-  },
+  }
 )
 
 // Submits resolving when IS_IN_BLOCK

--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -103,19 +103,17 @@ export async function isCtypeOnChain(ctype: ICType): Promise<boolean> {
   }
 }
 
-export const driversLicenseCType = CType.fromProperties(
-  {
-    name: {
-      type: 'string',
-    },
-    age: {
-      type: 'integer',
-    },
+export const driversLicenseCType = CType.fromProperties('Drivers License', {
+  name: {
+    type: 'string',
   },
-  'Drivers License'
-)
+  age: {
+    type: 'integer',
+  },
+})
 
 export const driversLicenseCTypeForDeposit = CType.fromProperties(
+  'Drivers License for deposit test',
   {
     name: {
       type: 'string',
@@ -127,7 +125,6 @@ export const driversLicenseCTypeForDeposit = CType.fromProperties(
       type: 'string',
     },
   },
-  'Drivers License for deposit test'
 )
 
 // Submits resolving when IS_IN_BLOCK

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -17,7 +17,6 @@ import type {
   ICType,
   IClaim,
   ICredential,
-  ICTypeSchema,
   CTypeHash,
 } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
@@ -41,23 +40,18 @@ describe('Attestation', () => {
     'did:kilt:4nwPAmtsK5toZfBM9WvmAe4Fa3LyZ3X3JHt7EUFfrcPPAZAm'
   const identityBob: DidUri =
     'did:kilt:4nxhWrDR27YzC5z4soRcz31MaeFn287JRqiE5y4u7jBEdgP2'
-  let rawCTypeSchema: ICTypeSchema
   let testCType: ICType
   let testContents: any
   let testClaim: IClaim
   let credential: ICredential
 
   beforeAll(async () => {
-    rawCTypeSchema = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'Attestation',
-      properties: {
+    testCType = CType.fromProperties(
+      {
         name: { type: 'string' },
       },
-      type: 'object',
-    }
-
-    testCType = CType.fromSchema(rawCTypeSchema)
+      'Attestation'
+    )
 
     testContents = {}
     testClaim = Claim.fromCTypeAndClaimContents(

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -19,6 +19,7 @@ import type {
   ICType,
   IClaim,
   ICredential,
+  ICTypeSchema,
 } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import { ApiMocks } from '@kiltprotocol/testing'
@@ -41,7 +42,7 @@ describe('Attestation', () => {
     'did:kilt:4nwPAmtsK5toZfBM9WvmAe4Fa3LyZ3X3JHt7EUFfrcPPAZAm'
   const identityBob: DidUri =
     'did:kilt:4nxhWrDR27YzC5z4soRcz31MaeFn287JRqiE5y4u7jBEdgP2'
-  let rawCTypeSchema: ICType['schema']
+  let rawCTypeSchema: ICTypeSchema
   let testCType: ICType
   let testContents: any
   let testClaim: IClaim
@@ -49,7 +50,6 @@ describe('Attestation', () => {
 
   beforeAll(async () => {
     rawCTypeSchema = {
-      $id: 'kilt:ctype:0x1',
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'Attestation',
       properties: {
@@ -58,7 +58,7 @@ describe('Attestation', () => {
       type: 'object',
     }
 
-    testCType = CType.fromSchema(rawCTypeSchema, identityAlice)
+    testCType = CType.fromSchema(rawCTypeSchema)
 
     testContents = {}
     testClaim = Claim.fromCTypeAndClaimContents(

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -57,10 +57,7 @@ describe('Attestation', () => {
       type: 'object',
     }
 
-    testCType = CType.fromProperties(
-      rawCTypeSchema.properties,
-      rawCTypeSchema.title
-    )
+    testCType = CType.fromSchema(rawCTypeSchema)
 
     testContents = {}
     testClaim = Claim.fromCTypeAndClaimContents(

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -11,8 +11,6 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import type { HexString } from '@polkadot/util/types'
-
 import type {
   IAttestation,
   DidUri,
@@ -20,6 +18,7 @@ import type {
   IClaim,
   ICredential,
   ICTypeSchema,
+  CTypeHash,
 } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import { ApiMocks } from '@kiltprotocol/testing'
@@ -70,9 +69,9 @@ describe('Attestation', () => {
   })
 
   it('error check should throw errors on faulty Attestations', () => {
-    const cTypeHash: HexString =
+    const cTypeHash: CTypeHash =
       '0xa8c5bdb22aaea3fceb5467d37169cbe49c71f226233037537e70a32a032304ff'
-    const claimHash: HexString =
+    const claimHash: CTypeHash =
       '0x21a3448ccf10f6568d8cd9a08af689c220d842b893a40344d010e398ab74e557'
 
     const everything = {

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -57,7 +57,10 @@ describe('Attestation', () => {
       type: 'object',
     }
 
-    testCType = CType.fromSchema(rawCTypeSchema)
+    testCType = CType.fromProperties(
+      rawCTypeSchema.properties,
+      rawCTypeSchema.title
+    )
 
     testContents = {}
     testClaim = Claim.fromCTypeAndClaimContents(

--- a/packages/core/src/attestation/Attestation.spec.ts
+++ b/packages/core/src/attestation/Attestation.spec.ts
@@ -46,12 +46,9 @@ describe('Attestation', () => {
   let credential: ICredential
 
   beforeAll(async () => {
-    testCType = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'Attestation'
-    )
+    testCType = CType.fromProperties('Attestation', {
+      name: { type: 'string' },
+    })
 
     testContents = {}
     testClaim = Claim.fromCTypeAndClaimContents(

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -186,7 +186,7 @@ describe('Claim', () => {
   })
 
   it('should throw an error on faulty constructor input', () => {
-    const cTypeHash = CType.getCTypeHashFromId(testCType.$id)
+    const cTypeHash = CType.idToHash(testCType.$id)
     const ownerAddress = did
 
     const everything = {

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -10,7 +10,7 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { IClaim, ICType, DidUri } from '@kiltprotocol/types'
+import type { IClaim, ICType, DidUri, ICTypeSchema } from '@kiltprotocol/types'
 import * as CType from '../ctype'
 import * as Claim from './Claim'
 
@@ -153,7 +153,7 @@ describe('compute hashes & validate by reproducing them', () => {
 describe('Claim', () => {
   let did: DidUri
   let claimContents: any
-  let rawCType: ICType['schema']
+  let rawCType: ICTypeSchema
   let testCType: ICType
   let claim: IClaim
 
@@ -165,7 +165,6 @@ describe('Claim', () => {
     }
 
     rawCType = {
-      $id: 'kilt:ctype:0x1',
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'ClaimCtype',
       properties: {
@@ -181,7 +180,7 @@ describe('Claim', () => {
 
   it('can be made from object', () => {
     const claimObj = JSON.parse(JSON.stringify(claim))
-    expect(() => Claim.verify(claimObj, testCType.schema)).not.toThrow()
+    expect(() => Claim.verify(claimObj, testCType)).not.toThrow()
   })
 
   it('allows falsy claim values', () => {
@@ -195,7 +194,7 @@ describe('Claim', () => {
   })
 
   it('should throw an error on faulty constructor input', () => {
-    const cTypeHash = testCType.hash
+    const cTypeHash = CType.getCTypeHashFromId(testCType.$id)
     const ownerAddress = did
 
     const everything = {

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -163,12 +163,9 @@ describe('Claim', () => {
       name: 'Bob',
     }
 
-    testCType = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'ClaimCtype'
-    )
+    testCType = CType.fromProperties('ClaimCtype', {
+      name: { type: 'string' },
+    })
 
     claim = Claim.fromCTypeAndClaimContents(testCType, claimContents, did)
   })

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -173,7 +173,7 @@ describe('Claim', () => {
       type: 'object',
     }
 
-    testCType = CType.fromSchema(rawCType)
+    testCType = CType.fromProperties(rawCType.properties, rawCType.title)
 
     claim = Claim.fromCTypeAndClaimContents(testCType, claimContents, did)
   })

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -173,7 +173,7 @@ describe('Claim', () => {
       type: 'object',
     }
 
-    testCType = CType.fromProperties(rawCType.properties, rawCType.title)
+    testCType = CType.fromSchema(rawCType)
 
     claim = Claim.fromCTypeAndClaimContents(testCType, claimContents, did)
   })

--- a/packages/core/src/claim/Claim.spec.ts
+++ b/packages/core/src/claim/Claim.spec.ts
@@ -10,7 +10,7 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { IClaim, ICType, DidUri, ICTypeSchema } from '@kiltprotocol/types'
+import type { IClaim, ICType, DidUri } from '@kiltprotocol/types'
 import * as CType from '../ctype'
 import * as Claim from './Claim'
 
@@ -153,7 +153,6 @@ describe('compute hashes & validate by reproducing them', () => {
 describe('Claim', () => {
   let did: DidUri
   let claimContents: any
-  let rawCType: ICTypeSchema
   let testCType: ICType
   let claim: IClaim
 
@@ -164,16 +163,12 @@ describe('Claim', () => {
       name: 'Bob',
     }
 
-    rawCType = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'ClaimCtype',
-      properties: {
+    testCType = CType.fromProperties(
+      {
         name: { type: 'string' },
       },
-      type: 'object',
-    }
-
-    testCType = CType.fromSchema(rawCType)
+      'ClaimCtype'
+    )
 
     claim = Claim.fromCTypeAndClaimContents(testCType, claimContents, did)
   })

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -19,7 +19,13 @@
 
 import { hexToBn } from '@polkadot/util'
 import type { HexString } from '@polkadot/util/types'
-import type { DidUri, IClaim, ICType, PartialClaim } from '@kiltprotocol/types'
+import type {
+  DidUri,
+  IClaim,
+  ICType,
+  ICTypeSchema,
+  PartialClaim,
+} from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
 import * as CType from '../ctype/index.js'
@@ -217,7 +223,7 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
 
 function verifyAgainstCType(
   claimContents: IClaim['contents'],
-  cTypeSchema: ICType['schema']
+  cTypeSchema: ICTypeSchema
 ): void {
   CType.verifyClaimAgainstSchema(claimContents, cTypeSchema)
 }
@@ -226,12 +232,9 @@ function verifyAgainstCType(
  * Verifies the data structure and schema of a Claim.
  *
  * @param claimInput IClaim to verify.
- * @param cTypeSchema ICType['schema'] to verify claimInput's contents.
+ * @param cTypeSchema ICTypeSchema to verify claimInput's contents.
  */
-export function verify(
-  claimInput: IClaim,
-  cTypeSchema: ICType['schema']
-): void {
+export function verify(claimInput: IClaim, cTypeSchema: ICTypeSchema): void {
   verifyAgainstCType(claimInput.contents, cTypeSchema)
   verifyDataStructure(claimInput)
 }
@@ -248,18 +251,14 @@ export function verify(
  */
 export function fromNestedCTypeClaim(
   cTypeInput: ICType,
-  nestedCType: Array<ICType['schema']>,
+  nestedCType: ICTypeSchema[],
   claimContents: IClaim['contents'],
   claimOwner: DidUri
 ): IClaim {
-  CType.verifyClaimAgainstNestedSchemas(
-    cTypeInput.schema,
-    nestedCType,
-    claimContents
-  )
+  CType.verifyClaimAgainstNestedSchemas(cTypeInput, nestedCType, claimContents)
 
   const claim = {
-    cTypeHash: cTypeInput.hash,
+    cTypeHash: CType.getCTypeHashFromId(cTypeInput.$id),
     contents: claimContents,
     owner: claimOwner,
   }
@@ -281,9 +280,9 @@ export function fromCTypeAndClaimContents(
   claimOwner: DidUri
 ): IClaim {
   CType.verifyDataStructure(ctypeInput)
-  verifyAgainstCType(claimContents, ctypeInput.schema)
+  verifyAgainstCType(claimContents, ctypeInput)
   const claim = {
-    cTypeHash: ctypeInput.hash,
+    cTypeHash: CType.getCTypeHashFromId(ctypeInput.$id),
     contents: claimContents,
     owner: claimOwner,
   }

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -40,7 +40,7 @@ function jsonLDcontents(
 ): Record<string, unknown> {
   const { cTypeHash, contents, owner } = claim
   if (!cTypeHash) throw new SDKErrors.CTypeHashMissingError()
-  const vocabulary = `${CType.getIdForCTypeHash(cTypeHash)}#`
+  const vocabulary = `${CType.hashToId(cTypeHash)}#`
   const result: Record<string, unknown> = {}
   if (owner) result['@id'] = owner
   if (!expanded) {
@@ -74,7 +74,7 @@ export function toJsonLD(
     [`${prefix}credentialSubject`]: credentialSubject,
   }
   result[`${prefix}credentialSchema`] = {
-    '@id': CType.getIdForCTypeHash(claim.cTypeHash),
+    '@id': CType.hashToId(claim.cTypeHash),
   }
   if (!expanded) result['@context'] = { '@vocab': VC_VOCAB }
   return result
@@ -245,7 +245,7 @@ export function fromNestedCTypeClaim(
   CType.verifyClaimAgainstNestedSchemas(cTypeInput, nestedCType, claimContents)
 
   const claim = {
-    cTypeHash: CType.getCTypeHashFromId(cTypeInput.$id),
+    cTypeHash: CType.idToHash(cTypeInput.$id),
     contents: claimContents,
     owner: claimOwner,
   }
@@ -269,7 +269,7 @@ export function fromCTypeAndClaimContents(
   CType.verifyDataStructure(cType)
   CType.verifyClaimAgainstSchema(claimContents, cType)
   const claim = {
-    cTypeHash: CType.getCTypeHashFromId(cType.$id),
+    cTypeHash: CType.idToHash(cType.$id),
     contents: claimContents,
     owner: claimOwner,
   }

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -215,21 +215,14 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
   DataUtils.verifyIsHex(input.cTypeHash, 256)
 }
 
-function verifyAgainstCType(
-  claimContents: IClaim['contents'],
-  cTypeSchema: ICType
-): void {
-  CType.verifyClaimAgainstSchema(claimContents, cTypeSchema)
-}
-
 /**
  * Verifies the data structure and schema of a Claim.
  *
  * @param claimInput IClaim to verify.
- * @param cTypeSchema ICType to verify claimInput's contents.
+ * @param cType ICType to verify claimInput's contents.
  */
-export function verify(claimInput: IClaim, cTypeSchema: ICType): void {
-  verifyAgainstCType(claimInput.contents, cTypeSchema)
+export function verify(claimInput: IClaim, cType: ICType): void {
+  CType.verifyClaimAgainstSchema(claimInput.contents, cType)
   verifyDataStructure(claimInput)
 }
 
@@ -263,20 +256,20 @@ export function fromNestedCTypeClaim(
 /**
  * Constructs a new Claim from the given [[ICType]], IClaim['contents'] and [[DidUri]].
  *
- * @param ctypeInput [[ICType]] for which the Claim will be built.
+ * @param cType [[ICType]] for which the Claim will be built.
  * @param claimContents IClaim['contents'] to be used as the pure contents of the instantiated Claim.
  * @param claimOwner The DID to be used as the Claim owner.
  * @returns A Claim object.
  */
 export function fromCTypeAndClaimContents(
-  ctypeInput: ICType,
+  cType: ICType,
   claimContents: IClaim['contents'],
   claimOwner: DidUri
 ): IClaim {
-  CType.verifyDataStructure(ctypeInput)
-  verifyAgainstCType(claimContents, ctypeInput)
+  CType.verifyDataStructure(cType)
+  CType.verifyClaimAgainstSchema(claimContents, cType)
   const claim = {
-    cTypeHash: CType.getCTypeHashFromId(ctypeInput.$id),
+    cTypeHash: CType.getCTypeHashFromId(cType.$id),
     contents: claimContents,
     owner: claimOwner,
   }

--- a/packages/core/src/claim/Claim.ts
+++ b/packages/core/src/claim/Claim.ts
@@ -19,13 +19,7 @@
 
 import { hexToBn } from '@polkadot/util'
 import type { HexString } from '@polkadot/util/types'
-import type {
-  DidUri,
-  IClaim,
-  ICType,
-  ICTypeSchema,
-  PartialClaim,
-} from '@kiltprotocol/types'
+import type { DidUri, IClaim, ICType, PartialClaim } from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
 import * as CType from '../ctype/index.js'
@@ -223,7 +217,7 @@ export function verifyDataStructure(input: IClaim | PartialClaim): void {
 
 function verifyAgainstCType(
   claimContents: IClaim['contents'],
-  cTypeSchema: ICTypeSchema
+  cTypeSchema: ICType
 ): void {
   CType.verifyClaimAgainstSchema(claimContents, cTypeSchema)
 }
@@ -232,9 +226,9 @@ function verifyAgainstCType(
  * Verifies the data structure and schema of a Claim.
  *
  * @param claimInput IClaim to verify.
- * @param cTypeSchema ICTypeSchema to verify claimInput's contents.
+ * @param cTypeSchema ICType to verify claimInput's contents.
  */
-export function verify(claimInput: IClaim, cTypeSchema: ICTypeSchema): void {
+export function verify(claimInput: IClaim, cTypeSchema: ICType): void {
   verifyAgainstCType(claimInput.contents, cTypeSchema)
   verifyDataStructure(claimInput)
 }
@@ -251,7 +245,7 @@ export function verify(claimInput: IClaim, cTypeSchema: ICTypeSchema): void {
  */
 export function fromNestedCTypeClaim(
   cTypeInput: ICType,
-  nestedCType: ICTypeSchema[],
+  nestedCType: ICType[],
   claimContents: IClaim['contents'],
   claimOwner: DidUri
 ): IClaim {

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -38,12 +38,9 @@ import * as CType from '../ctype'
 import * as Credential from './Credential'
 import { getCTypeHashFromId } from '../ctype'
 
-const testCType = CType.fromProperties(
-  {
-    name: { type: 'string' },
-  },
-  'raw ctype'
-)
+const testCType = CType.fromProperties('raw ctype', {
+  name: { type: 'string' },
+})
 
 function buildCredential(
   claimerDid: DidUri,
@@ -334,10 +331,7 @@ describe('Credential', () => {
   ): Promise<[ICredentialPresentation, IAttestation]> {
     // create claim
 
-    const ctype = CType.fromProperties(
-      { name: { type: 'string' } },
-      'Credential'
-    )
+    const ctype = CType.fromProperties('Credential', { name: { type: 'string' } })
 
     const claim = Claim.fromCTypeAndClaimContents(ctype, contents, claimer.uri)
     // build credential with legitimations
@@ -512,7 +506,7 @@ describe('Credential', () => {
   })
 })
 
-describe('create presentation', () => {
+describe('create presentation', ;() => {
   let migratedClaimerLightDid: DidDocument
   let migratedClaimerFullDid: DidDocument
   let newKeyForMigratedClaimerDid: KeyTool
@@ -523,7 +517,7 @@ describe('create presentation', () => {
   let attester: DidDocument
   let credential: ICredential
 
-  const ctype = CType.fromProperties(testCType.properties, testCType.title)
+  const ctype = CType.fromProperties(testCType.title, testCType.properties)
 
   // Returns a full DID that has the same subject of the first light DID, but the same key authentication key as the second one, if provided, or as the first one otherwise.
   function createMinimalFullDidFromLightDid(

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -23,6 +23,7 @@ import type {
   ICredential,
   ICredentialPresentation,
   ICType,
+  ICTypeSchema,
   SignCallback,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors, UUID } from '@kiltprotocol/utils'
@@ -36,9 +37,9 @@ import * as Attestation from '../attestation'
 import * as Claim from '../claim'
 import * as CType from '../ctype'
 import * as Credential from './Credential'
+import { getCTypeHashFromId } from '../ctype'
 
-const rawCType: ICType['schema'] = {
-  $id: 'kilt:ctype:0x2',
+const rawCType: ICTypeSchema = {
   $schema: 'http://kilt-protocol.org/draft-01/ctype#',
   title: 'raw ctype',
   properties: {
@@ -57,7 +58,7 @@ function buildCredential(
   const testCType = CType.fromSchema(rawCType)
 
   const claim: IClaim = {
-    cTypeHash: testCType.hash,
+    cTypeHash: getCTypeHashFromId(testCType.$id),
     contents,
     owner: claimerDid,
   }
@@ -358,8 +359,7 @@ describe('Credential', () => {
   ): Promise<[ICredentialPresentation, IAttestation]> {
     // create claim
 
-    const rawCType2: ICType['schema'] = {
-      $id: 'kilt:ctype:0x1',
+    const rawCType2: ICTypeSchema = {
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'Credential',
       properties: {
@@ -652,7 +652,7 @@ describe('create presentation', () => {
       migratedThenDeletedClaimerLightDid
     )
 
-    ctype = CType.fromSchema(rawCType, migratedClaimerFullDid.uri)
+    ctype = CType.fromSchema(rawCType)
 
     // cannot be used since the variable needs to be established in the outer scope
     credential = Credential.fromClaim(
@@ -683,7 +683,7 @@ describe('create presentation', () => {
     expect(presentation.claimerSignature?.challenge).toEqual(challenge)
   })
   it('should create presentation and exclude specific attributes using a light DID', async () => {
-    ctype = CType.fromSchema(rawCType, attester.uri)
+    ctype = CType.fromSchema(rawCType)
 
     // cannot be used since the variable needs to be established in the outer scope
     credential = Credential.fromClaim(
@@ -712,7 +712,7 @@ describe('create presentation', () => {
     expect(presentation.claimerSignature?.challenge).toEqual(challenge)
   })
   it('should create presentation and exclude specific attributes using a migrated DID', async () => {
-    ctype = CType.fromSchema(rawCType, attester.uri)
+    ctype = CType.fromSchema(rawCType)
 
     // cannot be used since the variable needs to be established in the outer scope
     credential = Credential.fromClaim(
@@ -744,7 +744,7 @@ describe('create presentation', () => {
   })
 
   it('should fail to create a valid presentation and exclude specific attributes using a light DID after it has been migrated', async () => {
-    ctype = CType.fromSchema(rawCType, attester.uri)
+    ctype = CType.fromSchema(rawCType)
 
     // cannot be used since the variable needs to be established in the outer scope
     credential = Credential.fromClaim(
@@ -777,7 +777,7 @@ describe('create presentation', () => {
   })
 
   it('should fail to create a valid presentation using a light DID after it has been migrated and deleted', async () => {
-    ctype = CType.fromSchema(rawCType, attester.uri)
+    ctype = CType.fromSchema(rawCType)
 
     // cannot be used since the variable needs to be established in the outer scope
     credential = Credential.fromClaim(

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -49,7 +49,7 @@ function buildCredential(
   // create claim
 
   const claim: IClaim = {
-    cTypeHash: CType.getCTypeHashFromId(testCType.$id),
+    cTypeHash: CType.idToHash(testCType.$id),
     contents,
     owner: claimerDid,
   }

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -36,7 +36,6 @@ import * as Attestation from '../attestation'
 import * as Claim from '../claim'
 import * as CType from '../ctype'
 import * as Credential from './Credential'
-import { getCTypeHashFromId } from '../ctype'
 
 const testCType = CType.fromProperties('raw ctype', {
   name: { type: 'string' },
@@ -50,7 +49,7 @@ function buildCredential(
   // create claim
 
   const claim: IClaim = {
-    cTypeHash: getCTypeHashFromId(testCType.$id),
+    cTypeHash: CType.getCTypeHashFromId(testCType.$id),
     contents,
     owner: claimerDid,
   }

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -331,7 +331,9 @@ describe('Credential', () => {
   ): Promise<[ICredentialPresentation, IAttestation]> {
     // create claim
 
-    const ctype = CType.fromProperties('Credential', { name: { type: 'string' } })
+    const ctype = CType.fromProperties('Credential', {
+      name: { type: 'string' },
+    })
 
     const claim = Claim.fromCTypeAndClaimContents(ctype, contents, claimer.uri)
     // build credential with legitimations
@@ -506,7 +508,7 @@ describe('Credential', () => {
   })
 })
 
-describe('create presentation', ;() => {
+describe('create presentation', () => {
   let migratedClaimerLightDid: DidDocument
   let migratedClaimerFullDid: DidDocument
   let newKeyForMigratedClaimerDid: KeyTool

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -202,7 +202,7 @@ export function verifyAgainstCType(
   ctype: ICType
 ): void {
   verifyDataStructure(credential)
-  verifyClaimAgainstSchema(credential.claim.contents, ctype.schema)
+  verifyClaimAgainstSchema(credential.claim.contents, ctype)
 }
 
 /**

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -8,10 +8,10 @@
 import type { Option } from '@polkadot/types'
 import type { AccountId } from '@polkadot/types/interfaces'
 
-import type { DidUri, ICType } from '@kiltprotocol/types'
+import type { CTypeHash, DidUri, ICType } from '@kiltprotocol/types'
 import * as Did from '@kiltprotocol/did'
 
-import { serializeForHash } from './CType.js'
+import { idToHash, serializeForHash } from './CType.js'
 
 /**
  * Encodes the provided CType for use in `api.tx.ctype.add()`.
@@ -21,6 +21,16 @@ import { serializeForHash } from './CType.js'
  */
 export function toChain(ctype: ICType): string {
   return serializeForHash(ctype)
+}
+
+/**
+ * Encodes the provided CType['$id'] for use in `api.query.ctype.ctypes()`.
+ *
+ * @param cTypeId The CType id to translate for the blockchain.
+ * @returns Encoded CType id.
+ */
+export function idToChain(cTypeId: ICType['$id']): CTypeHash {
+  return idToHash(cTypeId)
 }
 
 /**

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -21,7 +21,7 @@ import { getSchemaPropertiesForHash } from './CType.js'
  * @returns Encoded CType.
  */
 export function toChain(ctype: ICType): string {
-  return Crypto.encodeObjectAsStr(getSchemaPropertiesForHash(ctype.schema))
+  return Crypto.encodeObjectAsStr(getSchemaPropertiesForHash(ctype))
 }
 
 /**

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -8,11 +8,10 @@
 import type { Option } from '@polkadot/types'
 import type { AccountId } from '@polkadot/types/interfaces'
 
-import { Crypto } from '@kiltprotocol/utils'
 import type { DidUri, ICType } from '@kiltprotocol/types'
 import * as Did from '@kiltprotocol/did'
 
-import { getSchemaPropertiesForHash } from './CType.js'
+import { serializeForHash } from './CType.js'
 
 /**
  * Encodes the provided CType for use in `api.tx.ctype.add()`.
@@ -21,7 +20,7 @@ import { getSchemaPropertiesForHash } from './CType.js'
  * @returns Encoded CType.
  */
 export function toChain(ctype: ICType): string {
-  return Crypto.encodeObjectAsStr(getSchemaPropertiesForHash(ctype))
+  return serializeForHash(ctype)
 }
 
 /**

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -10,23 +10,27 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { ICType, ICTypeMetadata } from '@kiltprotocol/types'
+import type { ICType, ICTypeMetadata, ICTypeSchema } from '@kiltprotocol/types'
 import * as CType from './CType'
 import { MetadataModel } from './CType.schemas'
 
 describe('CType', () => {
+  let rawCType: ICTypeSchema
   let ctype: ICType
   let ctypeMetadata: ICTypeMetadata['metadata']
   let metadata: ICTypeMetadata
 
   beforeAll(async () => {
-    ctype = CType.fromProperties(
-      {
+    rawCType = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'CtypeMetaData',
+      properties: {
         'first-property': { type: 'integer' },
         'second-property': { type: 'string' },
       },
-      'CtypeMetaData'
-    )
+      type: 'object',
+    }
+    ctype = CType.fromSchema(rawCType)
 
     ctypeMetadata = {
       title: { default: 'Title' },

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -10,20 +10,18 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { ICType, ICTypeMetadata } from '@kiltprotocol/types'
+import type { ICType, ICTypeMetadata, ICTypeSchema } from '@kiltprotocol/types'
 import * as CType from './CType'
 import { MetadataModel } from './CType.schemas'
 
 describe('CType', () => {
-  const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
-  let rawCType: ICType['schema']
+  let rawCType: ICTypeSchema
   let ctype: ICType
   let ctypeMetadata: ICTypeMetadata['metadata']
   let metadata: ICTypeMetadata
 
   beforeAll(async () => {
     rawCType = {
-      $id: 'kilt:ctype:0x1',
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'CtypeMetaData',
       properties: {
@@ -32,7 +30,7 @@ describe('CType', () => {
       },
       type: 'object',
     }
-    ctype = CType.fromSchema(rawCType, didAlice)
+    ctype = CType.fromSchema(rawCType)
 
     ctypeMetadata = {
       title: { default: 'Title' },
@@ -45,13 +43,13 @@ describe('CType', () => {
 
     metadata = {
       metadata: ctypeMetadata,
-      ctypeHash: ctype.hash,
+      ctypeId: ctype.$id,
     }
   })
 
   it('verifies the metadata of a ctype', async () => {
     expect(() => CType.verifyCTypeMetadata(metadata)).not.toThrow()
-    expect(metadata.ctypeHash).not.toHaveLength(0)
+    expect(metadata.ctypeId).not.toHaveLength(0)
     expect(() =>
       CType.verifyObjectAgainstSchema(metadata, MetadataModel)
     ).not.toThrow()
@@ -60,12 +58,12 @@ describe('CType', () => {
     ).toThrow()
   })
   it('checks if the metadata matches corresponding ctype hash', async () => {
-    expect(metadata.ctypeHash).toEqual(ctype.hash)
+    expect(metadata.ctypeId).toEqual(ctype.$id)
   })
   it('throws error when supplied malformed constructor input', () => {
     const faultyMetadata: ICTypeMetadata = {
       metadata: ctypeMetadata,
-      ctypeHash: ctype.hash,
+      ctypeId: ctype.$id,
     }
     // @ts-expect-error
     delete faultyMetadata.metadata.properties

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -10,27 +10,23 @@
  */
 
 import { SDKErrors } from '@kiltprotocol/utils'
-import type { ICType, ICTypeMetadata, ICTypeSchema } from '@kiltprotocol/types'
+import type { ICType, ICTypeMetadata } from '@kiltprotocol/types'
 import * as CType from './CType'
 import { MetadataModel } from './CType.schemas'
 
 describe('CType', () => {
-  let rawCType: ICTypeSchema
   let ctype: ICType
   let ctypeMetadata: ICTypeMetadata['metadata']
   let metadata: ICTypeMetadata
 
   beforeAll(async () => {
-    rawCType = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'CtypeMetaData',
-      properties: {
+    ctype = CType.fromProperties(
+      {
         'first-property': { type: 'integer' },
         'second-property': { type: 'string' },
       },
-      type: 'object',
-    }
-    ctype = CType.fromSchema(rawCType)
+      'CtypeMetaData'
+    )
 
     ctypeMetadata = {
       title: { default: 'Title' },

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -39,13 +39,13 @@ describe('CType', () => {
 
     metadata = {
       metadata: ctypeMetadata,
-      ctypeId: ctype.$id,
+      cTypeId: ctype.$id,
     }
   })
 
   it('verifies the metadata of a ctype', async () => {
     expect(() => CType.verifyCTypeMetadata(metadata)).not.toThrow()
-    expect(metadata.ctypeId).not.toHaveLength(0)
+    expect(metadata.cTypeId).not.toHaveLength(0)
     expect(() =>
       CType.verifyObjectAgainstSchema(metadata, MetadataModel)
     ).not.toThrow()
@@ -54,12 +54,12 @@ describe('CType', () => {
     ).toThrow()
   })
   it('checks if the metadata matches corresponding ctype hash', async () => {
-    expect(metadata.ctypeId).toEqual(ctype.$id)
+    expect(metadata.cTypeId).toEqual(ctype.$id)
   })
   it('throws error when supplied malformed constructor input', () => {
     const faultyMetadata: ICTypeMetadata = {
       metadata: ctypeMetadata,
-      ctypeId: ctype.$id,
+      cTypeId: ctype.$id,
     }
     // @ts-expect-error
     delete faultyMetadata.metadata.properties

--- a/packages/core/src/ctype/CType.metadata.spec.ts
+++ b/packages/core/src/ctype/CType.metadata.spec.ts
@@ -20,13 +20,10 @@ describe('CType', () => {
   let metadata: ICTypeMetadata
 
   beforeAll(async () => {
-    ctype = CType.fromProperties(
-      {
-        'first-property': { type: 'integer' },
-        'second-property': { type: 'string' },
-      },
-      'CtypeMetaData'
-    )
+    ctype = CType.fromProperties('CtypeMetaData', {
+      'first-property': { type: 'integer' },
+      'second-property': { type: 'string' },
+    })
 
     ctypeMetadata = {
       title: { default: 'Title' },

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -146,8 +146,8 @@ export const MetadataModel = {
       required: ['title', 'properties'],
       additionalProperties: false,
     },
-    ctypeId: { type: 'string', minLength: 1 },
+    cTypeId: { type: 'string', minLength: 1 },
   },
-  required: ['metadata', 'ctypeId'],
+  required: ['metadata', 'cTypeId'],
   additionalProperties: false,
 }

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -65,25 +65,6 @@ export const CTypeModel: JsonSchema.Schema = {
   required: ['$id', 'title', '$schema', 'properties', 'type'],
 }
 
-export const CTypeWrapperModel = {
-  $id: 'http://kilt-protocol.org/draft-01/ctype-wrapper#',
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  type: 'object',
-  properties: {
-    schema: {
-      type: 'object',
-      properties: CTypeModel.properties,
-      required: CTypeModel.required,
-    },
-    owner: { type: ['string', 'null'] },
-    hash: {
-      type: 'string',
-    },
-  },
-  additionalProperties: false,
-  required: ['schema', 'hash'],
-}
-
 export const MetadataModel = {
   $id: 'http://kilt-protocol.org/draft-01/ctype-metadata',
   $schema: 'http://json-schema.org/draft-07/schema#',

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -146,8 +146,8 @@ export const MetadataModel = {
       required: ['title', 'properties'],
       additionalProperties: false,
     },
-    ctypeHash: { type: 'string', minLength: 1 },
+    ctypeId: { type: 'string', minLength: 1 },
   },
-  required: ['metadata', 'ctypeHash'],
+  required: ['metadata', 'ctypeId'],
   additionalProperties: false,
 }

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -33,12 +33,9 @@ describe('CType', () => {
   let claimContents: any
   let claim: IClaim
   beforeAll(async () => {
-    claimCtype = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'CtypeModel 2'
-    )
+    claimCtype = CType.fromProperties('CtypeModel 2', {
+      name: { type: 'string' },
+    })
 
     claimContents = {
       name: 'Bob',
@@ -48,13 +45,10 @@ describe('CType', () => {
   })
 
   it('makes ctype object from schema without id', () => {
-    const ctype = CType.fromProperties(
-      {
-        'first-property': { type: 'integer' },
-        'second-property': { type: 'string' },
-      },
-      'CtypeModel 1'
-    )
+    const ctype = CType.fromProperties('CtypeModel 1', {
+      'first-property': { type: 'integer' },
+      'second-property': { type: 'string' },
+    })
 
     expect(ctype.$id).toBe(
       'kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84'
@@ -111,8 +105,8 @@ describe('blank ctypes', () => {
   let ctype2: ICType
 
   beforeAll(async () => {
-    ctype1 = CType.fromProperties({}, 'hasDriversLicense')
-    ctype2 = CType.fromProperties({}, 'claimedSomething')
+    ctype1 = CType.fromProperties('hasDriversLicense', {})
+    ctype2 = CType.fromProperties('claimedSomething', {})
   })
 
   it('two ctypes with no properties have different hashes if id is different', () => {
@@ -157,13 +151,10 @@ describe('CType verification', () => {
     required: ['first-property', 'second-property'],
   } as unknown as ICType
 
-  const ctypeWrapperModel: ICType = CType.fromProperties(
-    {
-      'first-property': { type: 'integer' },
-      'second-property': { type: 'string' },
-    },
-    'name'
-  )
+  const ctypeWrapperModel: ICType = CType.fromProperties('name', {
+    'first-property': { type: 'integer' },
+    'second-property': { type: 'string' },
+  })
 
   const goodClaim = {
     'first-property': 10,
@@ -197,12 +188,9 @@ describe('CType verification', () => {
 })
 
 describe('CType registration verification', () => {
-  const ctype = CType.fromProperties(
-    {
-      name: { type: 'string' },
-    },
-    'CtypeModel 2'
-  )
+  const ctype = CType.fromProperties('CtypeModel 2', {
+    name: { type: 'string' },
+  })
 
   describe('when CType is not registered', () => {
     it('does not verify registration when not registered', async () => {

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -132,7 +132,7 @@ describe('blank ctypes', () => {
 
 describe('CType verification', () => {
   const ctypeInput = {
-    $id: 'kilt:ctype:0xdeadbeef',
+    $id: 'kilt:ctype:0x1',
     $schema: 'http://kilt-protocol.org/draft-01/ctype-input#',
     title: 'Ctype Title',
     properties: [

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -29,32 +29,16 @@ const encodedAliceDid = ApiMocks.mockChainQueryReturn(
 const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
 
 describe('CType', () => {
-  let schema1: ICTypeSchema
-  let schema2: ICTypeSchema
   let claimCtype: ICType
   let claimContents: any
   let claim: IClaim
   beforeAll(async () => {
-    schema1 = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'CtypeModel 2',
-      properties: {
+    claimCtype = CType.fromProperties(
+      {
         name: { type: 'string' },
       },
-      type: 'object',
-    }
-
-    schema2 = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'CtypeModel 1',
-      properties: {
-        'first-property': { type: 'integer' },
-        'second-property': { type: 'string' },
-      },
-      type: 'object',
-    }
-
-    claimCtype = CType.fromSchema(schema1)
+      'CtypeModel 2'
+    )
 
     claimContents = {
       name: 'Bob',
@@ -64,7 +48,13 @@ describe('CType', () => {
   })
 
   it('makes ctype object from schema without id', () => {
-    const ctype = CType.fromSchema(schema2)
+    const ctype = CType.fromProperties(
+      {
+        'first-property': { type: 'integer' },
+        'second-property': { type: 'string' },
+      },
+      'CtypeModel 1'
+    )
 
     expect(ctype.$id).toBe(
       'kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84'
@@ -117,28 +107,12 @@ describe('CType', () => {
 })
 
 describe('blank ctypes', () => {
-  let ctypeSchema1: ICTypeSchema
-  let ctypeSchema2: ICTypeSchema
   let ctype1: ICType
   let ctype2: ICType
 
   beforeAll(async () => {
-    ctypeSchema1 = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'hasDriversLicense',
-      properties: {},
-      type: 'object',
-    }
-
-    ctypeSchema2 = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'claimedSomething',
-      properties: {},
-      type: 'object',
-    }
-
-    ctype1 = CType.fromSchema(ctypeSchema1)
-    ctype2 = CType.fromSchema(ctypeSchema2)
+    ctype1 = CType.fromProperties({}, 'hasDriversLicense')
+    ctype2 = CType.fromProperties({}, 'claimedSomething')
   })
 
   it('two ctypes with no properties have different hashes if id is different', () => {
@@ -182,15 +156,13 @@ describe('CType verification', () => {
     required: ['first-property', 'second-property'],
   } as unknown as ICTypeSchema
 
-  const ctypeWrapperModel: ICType = CType.fromSchema({
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    title: 'name',
-    properties: {
+  const ctypeWrapperModel: ICType = CType.fromProperties(
+    {
       'first-property': { type: 'integer' },
       'second-property': { type: 'string' },
     },
-    type: 'object',
-  })
+    'name'
+  )
 
   const goodClaim = {
     'first-property': 10,
@@ -224,18 +196,15 @@ describe('CType verification', () => {
 })
 
 describe('CType registration verification', () => {
-  const rawCType: ICTypeSchema = {
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    title: 'CtypeModel 2',
-    properties: {
+  const ctype = CType.fromProperties(
+    {
       name: { type: 'string' },
     },
-    type: 'object',
-  }
+    'CtypeModel 2'
+  )
 
   describe('when CType is not registered', () => {
     it('does not verify registration when not registered', async () => {
-      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).rejects.toThrow()
     })
   })
@@ -246,17 +215,14 @@ describe('CType registration verification', () => {
     })
 
     it('verifies registration when owner not set', async () => {
-      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
     })
 
     it('verifies registration when owner matches', async () => {
-      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
     })
 
     it('verifies registration when owner does not match', async () => {
-      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
     })
   })

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -29,16 +29,32 @@ const encodedAliceDid = ApiMocks.mockChainQueryReturn(
 const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
 
 describe('CType', () => {
+  let schema1: ICTypeSchema
+  let schema2: ICTypeSchema
   let claimCtype: ICType
   let claimContents: any
   let claim: IClaim
   beforeAll(async () => {
-    claimCtype = CType.fromProperties(
-      {
+    schema1 = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'CtypeModel 2',
+      properties: {
         name: { type: 'string' },
       },
-      'CtypeModel 2'
-    )
+      type: 'object',
+    }
+
+    schema2 = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'CtypeModel 1',
+      properties: {
+        'first-property': { type: 'integer' },
+        'second-property': { type: 'string' },
+      },
+      type: 'object',
+    }
+
+    claimCtype = CType.fromSchema(schema1)
 
     claimContents = {
       name: 'Bob',
@@ -48,13 +64,7 @@ describe('CType', () => {
   })
 
   it('makes ctype object from schema without id', () => {
-    const ctype = CType.fromProperties(
-      {
-        'first-property': { type: 'integer' },
-        'second-property': { type: 'string' },
-      },
-      'CtypeModel 1'
-    )
+    const ctype = CType.fromSchema(schema2)
 
     expect(ctype.$id).toBe(
       'kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84'
@@ -107,12 +117,28 @@ describe('CType', () => {
 })
 
 describe('blank ctypes', () => {
+  let ctypeSchema1: ICTypeSchema
+  let ctypeSchema2: ICTypeSchema
   let ctype1: ICType
   let ctype2: ICType
 
   beforeAll(async () => {
-    ctype1 = CType.fromProperties({}, 'hasDriversLicense')
-    ctype2 = CType.fromProperties({}, 'claimedSomething')
+    ctypeSchema1 = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'hasDriversLicense',
+      properties: {},
+      type: 'object',
+    }
+
+    ctypeSchema2 = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'claimedSomething',
+      properties: {},
+      type: 'object',
+    }
+
+    ctype1 = CType.fromSchema(ctypeSchema1)
+    ctype2 = CType.fromSchema(ctypeSchema2)
   })
 
   it('two ctypes with no properties have different hashes if id is different', () => {
@@ -156,13 +182,15 @@ describe('CType verification', () => {
     required: ['first-property', 'second-property'],
   } as unknown as ICTypeSchema
 
-  const ctypeWrapperModel: ICType = CType.fromProperties(
-    {
+  const ctypeWrapperModel: ICType = CType.fromSchema({
+    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    title: 'name',
+    properties: {
       'first-property': { type: 'integer' },
       'second-property': { type: 'string' },
     },
-    'name'
-  )
+    type: 'object',
+  })
 
   const goodClaim = {
     'first-property': 10,
@@ -196,15 +224,18 @@ describe('CType verification', () => {
 })
 
 describe('CType registration verification', () => {
-  const ctype = CType.fromProperties(
-    {
+  const rawCType: ICTypeSchema = {
+    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    title: 'CtypeModel 2',
+    properties: {
       name: { type: 'string' },
     },
-    'CtypeModel 2'
-  )
+    type: 'object',
+  }
 
   describe('when CType is not registered', () => {
     it('does not verify registration when not registered', async () => {
+      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).rejects.toThrow()
     })
   })
@@ -215,14 +246,17 @@ describe('CType registration verification', () => {
     })
 
     it('verifies registration when owner not set', async () => {
+      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
     })
 
     it('verifies registration when owner matches', async () => {
+      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
     })
 
     it('verifies registration when owner does not match', async () => {
+      const ctype = CType.fromSchema(rawCType)
       await expect(CType.verifyStored(ctype)).resolves.not.toThrow()
     })
   })

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -210,13 +210,13 @@ export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
  * Creates a new [[ICType]] object from a set of atomic claims and a title.
  * The CType id will be automatically generated.
  *
- * @param properties Key-value pairs describing the admissible atomic claims for a credential with this CType. The value of each property is a json-schema (e.g. `{ "type": "number" }`) used to validate that property.
  * @param title The new CType's title as a string.
+ * @param properties Key-value pairs describing the admissible atomic claims for a credential with this CType. The value of each property is a json-schema (for example `{ "type": "number" }`) used to validate that property.
  * @returns A ctype object, including cTypeId, $schema, and type.
  */
 export function fromProperties(
-  properties: ICType['properties'],
-  title: ICType['title']
+  title: ICType['title'],
+  properties: ICType['properties']
 ): ICType {
   const schema: Omit<ICType, '$id'> = {
     properties,

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -38,6 +38,7 @@ export function getSchemaPropertiesForHash(
   // We need to remove the CType ID from the CType before storing it on the blockchain
   // otherwise the resulting hash will be different, as the hash on chain would contain the CType ID,
   // which is itself a hash of the CType schema.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { $id: _, ...schemaWithoutId } = ctypeSchema as ICType
   return schemaWithoutId
 }

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -26,32 +26,27 @@ import { ConfigService } from '@kiltprotocol/config'
 import { CTypeModel, MetadataModel } from './CType.schemas.js'
 
 /**
- * Utility for (re)creating ctype hashes. For this, the $id property needs to be stripped from the CType schema.
+ * Utility for (re)creating CType hashes. Sorts the schema and strips the $id property (which contains the CType hash) before stringifying.
  *
- * @param ctypeSchema The CType schema (with or without $id).
- * @returns CtypeSchema without the $id property.
+ * @param cType The CType (with or without $id).
+ * @returns A deterministic JSON serialization of a CType, omitting the $id property.
  */
-export function serializeForHash(
-  ctypeSchema: ICType | Omit<ICType, '$id'>
-): string {
-  // We need to remove the CType ID from the CType before storing it on the blockchain
-  // otherwise the resulting hash will be different, as the hash on chain would contain the CType ID,
-  // which is itself a hash of the CType schema.
+export function serializeForHash(cType: ICType | Omit<ICType, '$id'>): string {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { $id: _, ...schemaWithoutId } = ctypeSchema as ICType
+  const { $id, ...schemaWithoutId } = cType as ICType
   return Crypto.encodeObjectAsStr(schemaWithoutId)
 }
 
 /**
  * Calculates the CType hash from a schema.
  *
- * @param schema The CType schema (with or without $id).
+ * @param cType The ICType (with or without $id).
  * @returns Hash as hex string.
  */
 export function getHashForSchema(
-  schema: ICType | Omit<ICType, '$id'>
+  cType: ICType | Omit<ICType, '$id'>
 ): CTypeHash {
-  const serializedSchema = serializeForHash(schema)
+  const serializedSchema = serializeForHash(cType)
   return Crypto.hashStr(serializedSchema)
 }
 

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -56,7 +56,7 @@ export function getHashForSchema(
  * @param hash CType hash as hex string.
  * @returns Schema id uri.
  */
-export function getIdForCTypeHash(hash: CTypeHash): ICType['$id'] {
+export function hashToId(hash: CTypeHash): ICType['$id'] {
   return `kilt:ctype:${hash}`
 }
 
@@ -66,7 +66,7 @@ export function getIdForCTypeHash(hash: CTypeHash): ICType['$id'] {
  * @param id A CType id of the form 'kilt:ctype:0x[0-9a-f]'.
  * @returns The CType hash as a zero-prefixed string of hex digits.
  */
-export function getCTypeHashFromId(id: ICType['$id']): CTypeHash {
+export function idToHash(id: ICType['$id']): CTypeHash {
   const result = id.match(/kilt:ctype:(0x[0-9a-f]+)/i)
   if (!result)
     throw new SDKErrors.CTypeHashMissingError(
@@ -84,7 +84,7 @@ export function getCTypeHashFromId(id: ICType['$id']): CTypeHash {
 export function getIdForSchema(
   schema: ICType | Omit<ICType, '$id'>
 ): ICType['$id'] {
-  return getIdForCTypeHash(getHashForSchema(schema))
+  return hashToId(getHashForSchema(schema))
 }
 
 /**
@@ -139,7 +139,7 @@ export function verifyClaimAgainstSchema(
  */
 export async function verifyStored(ctype: ICType): Promise<void> {
   const api = ConfigService.get('api')
-  const hash = getCTypeHashFromId(ctype.$id)
+  const hash = idToHash(ctype.$id)
   const encoded = await api.query.ctype.ctypes(hash)
   if (encoded.isNone)
     throw new SDKErrors.CTypeHashMissingError(

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -22,7 +22,7 @@ import type {
   ICTypeSchema,
   CTypeHash,
 } from '@kiltprotocol/types'
-import { Crypto, SDKErrors, JsonSchema, jsonabc } from '@kiltprotocol/utils'
+import { Crypto, SDKErrors, JsonSchema } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
 import { CTypeModel, MetadataModel } from './CType.schemas.js'
 
@@ -153,7 +153,7 @@ export async function verifyStored(ctype: ICType): Promise<void> {
  * Checks whether the input meets all the required criteria of an ICType object.
  * Throws on invalid input.
  *
- * @param input The ICType object.
+ * @param input The potentially only partial ICType.
  */
 export function verifyDataStructure(input: ICType): void {
   verifyObjectAgainstSchema(input, CTypeModel)
@@ -204,24 +204,19 @@ export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
 }
 
 /**
- * Creates a new [[ICType]] object from a set of atomic claims and a title.
- * The CType id will be automatically generated.
+ * Creates a new [[CType]] from an [[ICTypeSchema]].
+ * _Note_ that you can either supply the schema as [[ICTypeSchema]] with the id
+ * or without the id as [[CTypeSchemaWithoutId]] which will automatically generate it.
  *
- * @param properties Key-value pairs describing the admissible atomic claims for a credential with this CType. The value of each property is a json-schema (e.g. `{ "type": "number" }`) used to validate that property.
- * @param title The new CType's title as a string.
- * @returns A ctype object, including cTypeId, $schema, and type.
+ * @param schema The JSON schema from which the [[CType]] should be generated.
+ *
+ * @returns A ctype object with cTypeHash, owner and the schema.
  */
-export function fromProperties(
-  properties: ICType['properties'],
-  title: ICType['title']
-): ICType {
-  const schema: ICTypeSchema = {
-    properties,
-    title,
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    type: 'object',
+export function fromSchema(schema: ICTypeSchema): ICType {
+  const ctype: ICType = {
+    ...schema,
+    $id: getIdForSchema(schema),
   }
-  const ctype = jsonabc.sortObj({ ...schema, $id: getIdForSchema(schema) })
   verifyDataStructure(ctype)
   return ctype
 }

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -20,10 +20,10 @@ import type {
   IClaim,
   ICTypeMetadata,
   ICTypeSchema,
+  CTypeHash,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors, JsonSchema } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
-import type { HexString } from '@polkadot/util/types'
 import { CTypeModel, MetadataModel } from './CType.schemas.js'
 
 /**
@@ -48,7 +48,7 @@ export function getSchemaPropertiesForHash(
  * @param schema The CType schema (with or without $id).
  * @returns Hash as hex string.
  */
-export function getHashForSchema(schema: ICTypeSchema): HexString {
+export function getHashForSchema(schema: ICTypeSchema): CTypeHash {
   const preparedSchema = getSchemaPropertiesForHash(schema)
   return Crypto.hashObjectAsStr(preparedSchema)
 }
@@ -59,7 +59,7 @@ export function getHashForSchema(schema: ICTypeSchema): HexString {
  * @param hash CType hash as hex string.
  * @returns Schema id uri.
  */
-export function getIdForCTypeHash(hash: HexString): ICType['$id'] {
+export function getIdForCTypeHash(hash: CTypeHash): ICType['$id'] {
   return `kilt:ctype:${hash}`
 }
 
@@ -69,13 +69,13 @@ export function getIdForCTypeHash(hash: HexString): ICType['$id'] {
  * @param id A CType id of the form 'kilt:ctype:0x[0-9a-f]'.
  * @returns The CType hash as a zero-prefixed string of hex digits.
  */
-export function getCTypeHashFromId(id: ICType['$id']): HexString {
+export function getCTypeHashFromId(id: ICType['$id']): CTypeHash {
   const result = id.match(/kilt:ctype:(0x[0-9a-f]+)/i)
   if (!result)
     throw new SDKErrors.CTypeHashMissingError(
       `The string ${id} is not a valid CType id`
     )
-  return result[1] as HexString
+  return result[1] as CTypeHash
 }
 
 /**

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -64,6 +64,21 @@ export function getIdForCTypeHash(hash: HexString): ICType['$id'] {
 }
 
 /**
+ * Extracts the CType hash from a CType $id.
+ *
+ * @param id A CType id of the form 'kilt:ctype:0x[0-9a-f]'.
+ * @returns The CType hash as a zero-prefixed string of hex digits.
+ */
+export function getCTypeHashFromId(id: ICType['$id']): HexString {
+  const result = id.match(/kilt:ctype:(0x[0-9a-f]+)/i)
+  if (!result)
+    throw new SDKErrors.CTypeHashMissingError(
+      `The string ${id} is not a valid CType id`
+    )
+  return result[1] as HexString
+}
+
+/**
  * Calculates the schema $id for a CType schema by hashing it.
  *
  * @param schema CType schema for which to create schema id.
@@ -125,7 +140,7 @@ export function verifyClaimAgainstSchema(
  */
 export async function verifyStored(ctype: ICType): Promise<void> {
   const api = ConfigService.get('api')
-  const hash = getHashForSchema(ctype)
+  const hash = getCTypeHashFromId(ctype.$id)
   const encoded = await api.query.ctype.ctypes(hash)
   if (encoded.isNone)
     throw new SDKErrors.CTypeHashMissingError(

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -9,42 +9,59 @@
  * @group unit/ctype
  */
 
-import type { ICType, IClaim, IClaimContents } from '@kiltprotocol/types'
+import type {
+  ICType,
+  IClaim,
+  IClaimContents,
+  ICTypeSchema,
+} from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import * as CType from './CType'
 import * as Claim from '../claim'
 
 describe('Nested CTypes', () => {
   const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
+  let passportCType: ICTypeSchema
+  let kycCType: ICTypeSchema
   let passport: ICType
   let kyc: ICType
   let claimContents: IClaimContents
   let claimDeepContents: IClaim['contents']
+  let nested: ICTypeSchema
+  let nestedDeeply: ICTypeSchema
   let nestedCType: ICType
   let deeplyNestedCType: ICType
   let nestedData: IClaim
   let nestedDeepData: IClaim
 
   beforeAll(async () => {
-    passport = CType.fromProperties(
-      {
+    passportCType = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'Passport',
+      properties: {
         fullName: { type: 'string' },
         passportIdentifier: { type: 'string' },
         streetAddress: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
       },
-      'Passport'
-    )
+      type: 'object',
+    }
 
-    kyc = CType.fromProperties(
-      {
+    kycCType = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'KYC',
+      properties: {
         ID: { type: 'string' },
         number: { type: 'string' },
         name: { type: 'string' },
       },
-      'KYC'
-    )
+      type: 'object',
+    }
+
+    passport = CType.fromSchema(passportCType)
+
+    kyc = CType.fromSchema(kycCType)
 
     claimContents = {
       fullName: 'Archer Macdonald',
@@ -72,8 +89,11 @@ describe('Nested CTypes', () => {
       },
     }
 
-    nestedCType = CType.fromProperties(
-      {
+    nested = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'KYC and Passport',
+      type: 'object',
+      properties: {
         fullName: {
           $ref: `${passport.$id}#/properties/fullName`,
         },
@@ -99,11 +119,12 @@ describe('Nested CTypes', () => {
           $ref: `${kyc.$id}#/properties/name`,
         },
       },
-      'KYC and Passport'
-    )
-
-    deeplyNestedCType = CType.fromProperties(
-      {
+    }
+    nestedDeeply = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'test',
+      type: 'object',
+      properties: {
         passport: {
           $ref: `${passport.$id}`,
         },
@@ -111,8 +132,11 @@ describe('Nested CTypes', () => {
           $ref: `${kyc.$id}`,
         },
       },
-      'test'
-    )
+    }
+
+    nestedCType = CType.fromSchema(nested)
+
+    deeplyNestedCType = CType.fromSchema(nestedDeeply)
 
     nestedData = Claim.fromNestedCTypeClaim(
       nestedCType,

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -9,59 +9,42 @@
  * @group unit/ctype
  */
 
-import type {
-  ICType,
-  IClaim,
-  IClaimContents,
-  ICTypeSchema,
-} from '@kiltprotocol/types'
+import type { ICType, IClaim, IClaimContents } from '@kiltprotocol/types'
 import { SDKErrors } from '@kiltprotocol/utils'
 import * as CType from './CType'
 import * as Claim from '../claim'
 
 describe('Nested CTypes', () => {
   const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
-  let passportCType: ICTypeSchema
-  let kycCType: ICTypeSchema
   let passport: ICType
   let kyc: ICType
   let claimContents: IClaimContents
   let claimDeepContents: IClaim['contents']
-  let nested: ICTypeSchema
-  let nestedDeeply: ICTypeSchema
   let nestedCType: ICType
   let deeplyNestedCType: ICType
   let nestedData: IClaim
   let nestedDeepData: IClaim
 
   beforeAll(async () => {
-    passportCType = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'Passport',
-      properties: {
+    passport = CType.fromProperties(
+      {
         fullName: { type: 'string' },
         passportIdentifier: { type: 'string' },
         streetAddress: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
       },
-      type: 'object',
-    }
+      'Passport'
+    )
 
-    kycCType = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'KYC',
-      properties: {
+    kyc = CType.fromProperties(
+      {
         ID: { type: 'string' },
         number: { type: 'string' },
         name: { type: 'string' },
       },
-      type: 'object',
-    }
-
-    passport = CType.fromSchema(passportCType)
-
-    kyc = CType.fromSchema(kycCType)
+      'KYC'
+    )
 
     claimContents = {
       fullName: 'Archer Macdonald',
@@ -89,11 +72,8 @@ describe('Nested CTypes', () => {
       },
     }
 
-    nested = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'KYC and Passport',
-      type: 'object',
-      properties: {
+    nestedCType = CType.fromProperties(
+      {
         fullName: {
           $ref: `${passport.$id}#/properties/fullName`,
         },
@@ -119,12 +99,11 @@ describe('Nested CTypes', () => {
           $ref: `${kyc.$id}#/properties/name`,
         },
       },
-    }
-    nestedDeeply = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'test',
-      type: 'object',
-      properties: {
+      'KYC and Passport'
+    )
+
+    deeplyNestedCType = CType.fromProperties(
+      {
         passport: {
           $ref: `${passport.$id}`,
         },
@@ -132,11 +111,8 @@ describe('Nested CTypes', () => {
           $ref: `${kyc.$id}`,
         },
       },
-    }
-
-    nestedCType = CType.fromSchema(nested)
-
-    deeplyNestedCType = CType.fromSchema(nestedDeeply)
+      'test'
+    )
 
     nestedData = Claim.fromNestedCTypeClaim(
       nestedCType,

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -26,25 +26,19 @@ describe('Nested CTypes', () => {
   let nestedDeepData: IClaim
 
   beforeAll(async () => {
-    passport = CType.fromProperties(
-      {
-        fullName: { type: 'string' },
-        passportIdentifier: { type: 'string' },
-        streetAddress: { type: 'string' },
-        city: { type: 'string' },
-        state: { type: 'string' },
-      },
-      'Passport'
-    )
+    passport = CType.fromProperties('Passport', {
+      fullName: { type: 'string' },
+      passportIdentifier: { type: 'string' },
+      streetAddress: { type: 'string' },
+      city: { type: 'string' },
+      state: { type: 'string' },
+    })
 
-    kyc = CType.fromProperties(
-      {
-        ID: { type: 'string' },
-        number: { type: 'string' },
-        name: { type: 'string' },
-      },
-      'KYC'
-    )
+    kyc = CType.fromProperties('KYC', {
+      ID: { type: 'string' },
+      number: { type: 'string' },
+      name: { type: 'string' },
+    })
 
     claimContents = {
       fullName: 'Archer Macdonald',
@@ -72,47 +66,41 @@ describe('Nested CTypes', () => {
       },
     }
 
-    nestedCType = CType.fromProperties(
-      {
-        fullName: {
-          $ref: `${passport.$id}#/properties/fullName`,
-        },
-        passportIdentifier: {
-          $ref: `${passport.$id}#/properties/passportIdentifier`,
-        },
-        streetAddress: {
-          $ref: `${passport.$id}#/properties/streetAddress`,
-        },
-        city: {
-          $ref: `${passport.$id}#/properties/city`,
-        },
-        state: {
-          $ref: `${passport.$id}#/properties/state`,
-        },
-        ID: {
-          $ref: `${kyc.$id}#/properties/ID`,
-        },
-        number: {
-          $ref: `${kyc.$id}#/properties/number`,
-        },
-        name: {
-          $ref: `${kyc.$id}#/properties/name`,
-        },
+    nestedCType = CType.fromProperties('KYC and Passport', {
+      fullName: {
+        $ref: `${passport.$id}#/properties/fullName`,
       },
-      'KYC and Passport'
-    )
+      passportIdentifier: {
+        $ref: `${passport.$id}#/properties/passportIdentifier`,
+      },
+      streetAddress: {
+        $ref: `${passport.$id}#/properties/streetAddress`,
+      },
+      city: {
+        $ref: `${passport.$id}#/properties/city`,
+      },
+      state: {
+        $ref: `${passport.$id}#/properties/state`,
+      },
+      ID: {
+        $ref: `${kyc.$id}#/properties/ID`,
+      },
+      number: {
+        $ref: `${kyc.$id}#/properties/number`,
+      },
+      name: {
+        $ref: `${kyc.$id}#/properties/name`,
+      },
+    })
 
-    deeplyNestedCType = CType.fromProperties(
-      {
-        passport: {
-          $ref: `${passport.$id}`,
-        },
-        KYC: {
-          $ref: `${kyc.$id}`,
-        },
+    deeplyNestedCType = CType.fromProperties('test', {
+      passport: {
+        $ref: `${passport.$id}`,
       },
-      'test'
-    )
+      KYC: {
+        $ref: `${kyc.$id}`,
+      },
+    })
 
     nestedData = Claim.fromNestedCTypeClaim(
       nestedCType,

--- a/packages/core/src/delegation/DelegationDecoder.ts
+++ b/packages/core/src/delegation/DelegationDecoder.ts
@@ -38,8 +38,6 @@ export type DelegationHierarchyDetailsRecord = Pick<
   'cTypeHash'
 >
 
-export type CtypeHash = Hash
-
 export function delegationHierarchyDetailsFromChain(
   encoded: Option<DelegationDelegationHierarchyDelegationHierarchyDetails>
 ): DelegationHierarchyDetailsRecord {

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -9,12 +9,12 @@
  * @group unit/delegation
  */
 
-import type { HexString } from '@polkadot/util/types'
 import {
   IDelegationNode,
   IDelegationHierarchyDetails,
   Permission,
   DidUri,
+  CTypeHash,
 } from '@kiltprotocol/types'
 import { encodeAddress } from '@polkadot/keyring'
 import { ApiMocks } from '@kiltprotocol/testing'
@@ -70,7 +70,7 @@ describe('DelegationNode', () => {
       })
     jest
       .mocked(mockedApi.tx.delegation.createHierarchy)
-      .mockImplementation(async (nodeId: string, cTypeHash: HexString) => {
+      .mockImplementation(async (nodeId: string, cTypeHash: CTypeHash) => {
         hierarchiesDetails[nodeId] = {
           id: nodeId,
           cTypeHash,
@@ -538,7 +538,7 @@ describe('DelegationNode', () => {
 })
 
 describe('DelegationHierarchy', () => {
-  let ctypeHash: HexString
+  let ctypeHash: CTypeHash
   let ROOT_IDENTIFIER: string
   let ROOT_SUCCESS: string
 

--- a/packages/core/src/delegation/DelegationNode.spec.ts
+++ b/packages/core/src/delegation/DelegationNode.spec.ts
@@ -15,7 +15,6 @@ import {
   IDelegationHierarchyDetails,
   Permission,
   DidUri,
-  ICType,
 } from '@kiltprotocol/types'
 import { encodeAddress } from '@polkadot/keyring'
 import { ApiMocks } from '@kiltprotocol/testing'
@@ -539,7 +538,7 @@ describe('DelegationNode', () => {
 })
 
 describe('DelegationHierarchy', () => {
-  let ctypeHash: ICType['hash']
+  let ctypeHash: HexString
   let ROOT_IDENTIFIER: string
   let ROOT_SUCCESS: string
 

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -10,7 +10,6 @@ import type {
   DidUri,
   DidVerificationKey,
   IAttestation,
-  ICType,
   IDelegationHierarchyDetails,
   IDelegationNode,
   SignCallback,
@@ -155,7 +154,7 @@ export class DelegationNode implements IDelegationNode {
    *
    * @returns The CType hash associated with the delegation hierarchy.
    */
-  public async getCTypeHash(): Promise<ICType['hash']> {
+  public async getCTypeHash(): Promise<HexString> {
     const { cTypeHash } = await this.getHierarchyDetails()
     return cTypeHash
   }

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -5,7 +5,10 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import type { HexString } from '@polkadot/util/types'
+
 import type {
+  CTypeHash,
   DidDocument,
   DidUri,
   DidVerificationKey,
@@ -18,7 +21,7 @@ import type {
 import { Crypto, SDKErrors, UUID } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
 import * as Did from '@kiltprotocol/did'
-import type { HexString } from '@polkadot/util/types'
+
 import type { DelegationHierarchyDetailsRecord } from './DelegationDecoder'
 import { fromChain as attestationFromChain } from '../attestation/Attestation.chain.js'
 import {
@@ -154,7 +157,7 @@ export class DelegationNode implements IDelegationNode {
    *
    * @returns The CType hash associated with the delegation hierarchy.
    */
-  public async getCTypeHash(): Promise<HexString> {
+  public async getCTypeHash(): Promise<CTypeHash> {
     const { cTypeHash } = await this.getHierarchyDetails()
     return cTypeHash
   }

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -82,7 +82,7 @@ describe('Quote', () => {
     })
 
     claim = {
-      cTypeHash: CType.getCTypeHashFromId(testCType.$id),
+      cTypeHash: CType.idToHash(testCType.$id),
       contents: {},
       owner: claimerIdentity.uri,
     }

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -21,6 +21,7 @@ import type {
   IQuoteAgreement,
   IQuoteAttesterSigned,
   ICredential,
+  ICTypeSchema,
 } from '@kiltprotocol/types'
 import { Crypto } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
@@ -42,7 +43,7 @@ describe('Quote', () => {
 
   let invalidCost: ICostBreakdown
   let date: string
-  let cTypeSchema: ICType['schema']
+  let cTypeSchema: ICTypeSchema
   let testCType: ICType
   let claim: IClaim
   let credential: ICredential
@@ -81,7 +82,6 @@ describe('Quote', () => {
     date = new Date(2019, 11, 10).toISOString()
 
     cTypeSchema = {
-      $id: 'kilt:ctype:0x1',
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'Quote Information',
       properties: {
@@ -93,7 +93,7 @@ describe('Quote', () => {
     testCType = CType.fromSchema(cTypeSchema)
 
     claim = {
-      cTypeHash: testCType.hash,
+      cTypeHash: CType.getCTypeHashFromId(testCType.$id),
       contents: {},
       owner: claimerIdentity.uri,
     }

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -77,12 +77,9 @@ describe('Quote', () => {
     } as unknown as ICostBreakdown
     date = new Date(2019, 11, 10).toISOString()
 
-    testCType = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'Quote Information'
-    )
+    testCType = CType.fromProperties('Quote Information', {
+      name: { type: 'string' },
+    })
 
     claim = {
       cTypeHash: CType.getCTypeHashFromId(testCType.$id),

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -21,6 +21,7 @@ import type {
   IQuoteAgreement,
   IQuoteAttesterSigned,
   ICredential,
+  ICTypeSchema,
 } from '@kiltprotocol/types'
 import { Crypto } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
@@ -43,6 +44,7 @@ describe('Quote', () => {
 
   let invalidCost: ICostBreakdown
   let date: string
+  let cTypeSchema: ICTypeSchema
   let testCType: ICType
   let claim: IClaim
   let credential: ICredential
@@ -80,12 +82,16 @@ describe('Quote', () => {
     } as unknown as ICostBreakdown
     date = new Date(2019, 11, 10).toISOString()
 
-    testCType = CType.fromProperties(
-      {
+    cTypeSchema = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'Quote Information',
+      properties: {
         name: { type: 'string' },
       },
-      'Quote Information'
-    )
+      type: 'object',
+    }
+
+    testCType = CType.fromSchema(cTypeSchema)
 
     claim = {
       cTypeHash: CType.getCTypeHashFromId(testCType.$id),

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -21,7 +21,6 @@ import type {
   IQuoteAgreement,
   IQuoteAttesterSigned,
   ICredential,
-  ICTypeSchema,
 } from '@kiltprotocol/types'
 import { Crypto } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
@@ -44,7 +43,6 @@ describe('Quote', () => {
 
   let invalidCost: ICostBreakdown
   let date: string
-  let cTypeSchema: ICTypeSchema
   let testCType: ICType
   let claim: IClaim
   let credential: ICredential
@@ -82,16 +80,12 @@ describe('Quote', () => {
     } as unknown as ICostBreakdown
     date = new Date(2019, 11, 10).toISOString()
 
-    cTypeSchema = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'Quote Information',
-      properties: {
+    testCType = CType.fromProperties(
+      {
         name: { type: 'string' },
       },
-      type: 'object',
-    }
-
-    testCType = CType.fromSchema(cTypeSchema)
+      'Quote Information'
+    )
 
     claim = {
       cTypeHash: CType.getCTypeHashFromId(testCType.$id),

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -50,6 +50,7 @@ import type {
   MessageBody,
   PartialClaim,
   ICredentialPresentation,
+  ICTypeSchema,
 } from '@kiltprotocol/types'
 import {
   Quote,
@@ -703,12 +704,16 @@ describe('Error checking / Verification', () => {
   ): Promise<[ICredential, IAttestation]> {
     // create claim
 
-    const testCType = CType.fromProperties(
-      {
+    const rawCType: ICTypeSchema = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'Credential',
+      properties: {
         name: { type: 'string' },
       },
-      'Credential'
-    )
+      type: 'object',
+    }
+
+    const testCType = CType.fromSchema(rawCType)
 
     const claim = Claim.fromCTypeAndClaimContents(
       testCType,
@@ -734,6 +739,8 @@ describe('Error checking / Verification', () => {
   let keyBob: KeyTool
 
   let date: string
+  let rawCType: ICTypeSchema
+  let rawCTypeWithMultipleProperties: ICTypeSchema
   let testCType: ICType
   let testCTypeWithMultipleProperties: ICType
   let claim: IClaim
@@ -819,20 +826,29 @@ describe('Error checking / Verification', () => {
       return null
     }
 
-    // CType
-    testCType = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'ClaimCtype'
-    )
-    testCTypeWithMultipleProperties = CType.fromProperties(
-      {
+    rawCTypeWithMultipleProperties = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'Drivers license Claim',
+      properties: {
         name: { type: 'string' },
         id: { type: 'string' },
         age: { type: 'string' },
       },
-      'Drivers license Claim'
+      type: 'object',
+    }
+    // CType Schema
+    rawCType = {
+      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+      title: 'ClaimCtype',
+      properties: {
+        name: { type: 'string' },
+      },
+      type: 'object',
+    }
+    // CType
+    testCType = CType.fromSchema(rawCType)
+    testCTypeWithMultipleProperties = CType.fromSchema(
+      rawCTypeWithMultipleProperties
     )
 
     // Claim

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -745,7 +745,7 @@ describe('Error checking / Verification', () => {
   let messageRejectAcceptDelegation: IMessage
   let messageInformCreateDelegation: IMessage
 
-  beforeAll(;async () => {
+  beforeAll(async () => {
     keyAlice = makeSigningKeyTool()
     identityAlice = await createLocalDemoFullDidFromKeypair(keyAlice.keypair)
     keyBob = makeSigningKeyTool()

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -666,12 +666,9 @@ describe('Error checking / Verification', () => {
   ): Promise<[ICredential, IAttestation]> {
     // create claim
 
-    const testCType = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'Credential'
-    )
+    const testCType = CType.fromProperties('Credential', {
+      name: { type: 'string' },
+    })
 
     const claim = Claim.fromCTypeAndClaimContents(
       testCType,
@@ -748,7 +745,7 @@ describe('Error checking / Verification', () => {
   let messageRejectAcceptDelegation: IMessage
   let messageInformCreateDelegation: IMessage
 
-  beforeAll(async () => {
+  beforeAll(;async () => {
     keyAlice = makeSigningKeyTool()
     identityAlice = await createLocalDemoFullDidFromKeypair(keyAlice.keypair)
     keyBob = makeSigningKeyTool()
@@ -771,19 +768,16 @@ describe('Error checking / Verification', () => {
     }
 
     // CType
-    testCType = CType.fromProperties(
-      {
-        name: { type: 'string' },
-      },
-      'ClaimCtype'
-    )
+    testCType = CType.fromProperties('ClaimCtype', {
+      name: { type: 'string' },
+    })
     testCTypeWithMultipleProperties = CType.fromProperties(
+      'Drivers license Claim',
       {
         name: { type: 'string' },
         id: { type: 'string' },
         age: { type: 'string' },
-      },
-      'Drivers license Claim'
+      }
     )
 
     // Claim

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -50,7 +50,6 @@ import type {
   MessageBody,
   PartialClaim,
   ICredentialPresentation,
-  ICTypeSchema,
 } from '@kiltprotocol/types'
 import {
   Quote,
@@ -704,16 +703,12 @@ describe('Error checking / Verification', () => {
   ): Promise<[ICredential, IAttestation]> {
     // create claim
 
-    const rawCType: ICTypeSchema = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'Credential',
-      properties: {
+    const testCType = CType.fromProperties(
+      {
         name: { type: 'string' },
       },
-      type: 'object',
-    }
-
-    const testCType = CType.fromSchema(rawCType)
+      'Credential'
+    )
 
     const claim = Claim.fromCTypeAndClaimContents(
       testCType,
@@ -739,8 +734,6 @@ describe('Error checking / Verification', () => {
   let keyBob: KeyTool
 
   let date: string
-  let rawCType: ICTypeSchema
-  let rawCTypeWithMultipleProperties: ICTypeSchema
   let testCType: ICType
   let testCTypeWithMultipleProperties: ICType
   let claim: IClaim
@@ -826,29 +819,20 @@ describe('Error checking / Verification', () => {
       return null
     }
 
-    rawCTypeWithMultipleProperties = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'Drivers license Claim',
-      properties: {
+    // CType
+    testCType = CType.fromProperties(
+      {
+        name: { type: 'string' },
+      },
+      'ClaimCtype'
+    )
+    testCTypeWithMultipleProperties = CType.fromProperties(
+      {
         name: { type: 'string' },
         id: { type: 'string' },
         age: { type: 'string' },
       },
-      type: 'object',
-    }
-    // CType Schema
-    rawCType = {
-      $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-      title: 'ClaimCtype',
-      properties: {
-        name: { type: 'string' },
-      },
-      type: 'object',
-    }
-    // CType
-    testCType = CType.fromSchema(rawCType)
-    testCTypeWithMultipleProperties = CType.fromSchema(
-      rawCTypeWithMultipleProperties
+      'Drivers license Claim'
     )
 
     // Claim

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -50,6 +50,7 @@ import type {
   MessageBody,
   PartialClaim,
   ICredentialPresentation,
+  ICTypeSchema,
 } from '@kiltprotocol/types'
 import {
   Quote,
@@ -702,8 +703,7 @@ describe('Error checking / Verification', () => {
   ): Promise<[ICredential, IAttestation]> {
     // create claim
 
-    const rawCType: ICType['schema'] = {
-      $id: Crypto.hashStr('kilt:ctype:0x1'),
+    const rawCType: ICTypeSchema = {
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'Credential',
       properties: {
@@ -738,8 +738,8 @@ describe('Error checking / Verification', () => {
   let keyBob: KeyTool
 
   let date: string
-  let rawCType: ICType['schema']
-  let rawCTypeWithMultipleProperties: ICType['schema']
+  let rawCType: ICTypeSchema
+  let rawCTypeWithMultipleProperties: ICTypeSchema
   let testCType: ICType
   let testCTypeWithMultipleProperties: ICType
   let claim: IClaim
@@ -826,7 +826,6 @@ describe('Error checking / Verification', () => {
     }
 
     rawCTypeWithMultipleProperties = {
-      $id: Crypto.hashStr('kilt:ctype:0x2'),
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'Drivers license Claim',
       properties: {
@@ -838,7 +837,6 @@ describe('Error checking / Verification', () => {
     }
     // CType Schema
     rawCType = {
-      $id: Crypto.hashStr('kilt:ctype:0x1'),
       $schema: 'http://kilt-protocol.org/draft-01/ctype#',
       title: 'ClaimCtype',
       properties: {
@@ -847,10 +845,9 @@ describe('Error checking / Verification', () => {
       type: 'object',
     }
     // CType
-    testCType = CType.fromSchema(rawCType, identityAlice.uri)
+    testCType = CType.fromSchema(rawCType)
     testCTypeWithMultipleProperties = CType.fromSchema(
-      rawCTypeWithMultipleProperties,
-      identityAlice.uri
+      rawCTypeWithMultipleProperties
     )
 
     // Claim

--- a/packages/messaging/src/Message.ts
+++ b/packages/messaging/src/Message.ts
@@ -229,7 +229,7 @@ export function verifyRequiredCTypeProperties(
   CType.verifyDataStructure(cType as ICType)
 
   const unknownProperties = requiredProperties.find(
-    (property) => !(property in cType.schema.properties)
+    (property) => !(property in cType.properties)
   )
   if (unknownProperties) {
     throw new SDKErrors.CTypeUnknownPropertiesError()

--- a/packages/types/src/Attestation.ts
+++ b/packages/types/src/Attestation.ts
@@ -5,14 +5,14 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import type { HexString } from '@polkadot/util/types'
 import type { DidUri } from './DidDocument'
-import type { ICType } from './CType'
 import type { IDelegationNode } from './Delegation'
 import type { ICredential } from './Credential'
 
 export interface IAttestation {
   claimHash: ICredential['rootHash']
-  cTypeHash: ICType['hash']
+  cTypeHash: HexString
   owner: DidUri
   delegationId: IDelegationNode['id'] | null
   revoked: boolean

--- a/packages/types/src/Attestation.ts
+++ b/packages/types/src/Attestation.ts
@@ -5,14 +5,14 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { HexString } from '@polkadot/util/types'
 import type { DidUri } from './DidDocument'
 import type { IDelegationNode } from './Delegation'
 import type { ICredential } from './Credential'
+import type { CTypeHash } from './CType'
 
 export interface IAttestation {
   claimHash: ICredential['rootHash']
-  cTypeHash: HexString
+  cTypeHash: CTypeHash
   owner: DidUri
   delegationId: IDelegationNode['id'] | null
   revoked: boolean

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -6,7 +6,6 @@
  */
 
 import type { HexString } from '@polkadot/util/types'
-import type { DidUri } from './DidDocument'
 
 export type InstanceType =
   | 'array'
@@ -18,7 +17,6 @@ export type InstanceType =
   | 'string'
 
 export interface ICTypeSchema {
-  $id: string
   $schema: string
   title: string
   properties: {
@@ -27,10 +25,6 @@ export interface ICTypeSchema {
   type: 'object'
 }
 
-export type CTypeSchemaWithoutId = Omit<ICTypeSchema, '$id'>
-
-export interface ICType {
-  hash: HexString
-  owner: DidUri | null
-  schema: ICTypeSchema
+export interface ICType extends ICTypeSchema {
+  $id: `kilt:ctype:${HexString}`
 }

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -18,15 +18,12 @@ export type InstanceType =
 
 export type CTypeHash = HexString
 
-export interface ICTypeSchema {
+export interface ICType {
+  $id: `kilt:ctype:${CTypeHash}`
   $schema: string
   title: string
   properties: {
     [key: string]: { $ref?: string; type?: InstanceType; format?: string }
   }
   type: 'object'
-}
-
-export interface ICType extends ICTypeSchema {
-  $id: `kilt:ctype:${CTypeHash}`
 }

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -16,6 +16,8 @@ export type InstanceType =
   | 'object'
   | 'string'
 
+export type CTypeHash = HexString
+
 export interface ICTypeSchema {
   $schema: string
   title: string
@@ -26,5 +28,5 @@ export interface ICTypeSchema {
 }
 
 export interface ICType extends ICTypeSchema {
-  $id: `kilt:ctype:${HexString}`
+  $id: `kilt:ctype:${CTypeHash}`
 }

--- a/packages/types/src/CTypeMetadata.ts
+++ b/packages/types/src/CTypeMetadata.ts
@@ -31,5 +31,5 @@ export interface IMetadata {
 
 export interface ICTypeMetadata {
   metadata: IMetadata
-  ctypeHash: ICType['hash'] | null
+  ctypeId: ICType['$id'] | null
 }

--- a/packages/types/src/CTypeMetadata.ts
+++ b/packages/types/src/CTypeMetadata.ts
@@ -31,5 +31,5 @@ export interface IMetadata {
 
 export interface ICTypeMetadata {
   metadata: IMetadata
-  ctypeId: ICType['$id'] | null
+  cTypeId: ICType['$id'] | null
 }

--- a/packages/types/src/Claim.ts
+++ b/packages/types/src/Claim.ts
@@ -5,15 +5,15 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import type { HexString } from '@polkadot/util/types'
 import type { DidUri } from './DidDocument'
-import type { ICType } from './CType'
 
 export type IClaimContents = Record<
   string,
   Record<string, unknown> | string | number | boolean
 >
 export interface IClaim {
-  cTypeHash: ICType['hash']
+  cTypeHash: HexString
   contents: IClaimContents
   owner: DidUri
 }

--- a/packages/types/src/Claim.ts
+++ b/packages/types/src/Claim.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { HexString } from '@polkadot/util/types'
+import type { CTypeHash } from './CType'
 import type { DidUri } from './DidDocument'
 
 export type IClaimContents = Record<
@@ -13,7 +13,7 @@ export type IClaimContents = Record<
   Record<string, unknown> | string | number | boolean
 >
 export interface IClaim {
-  cTypeHash: HexString
+  cTypeHash: CTypeHash
   contents: IClaimContents
   owner: DidUri
 }

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { HexString } from '@polkadot/util/types'
+import type { CTypeHash } from './CType'
 import type { DidUri } from './DidDocument'
 
 /* eslint-disable no-bitwise */
@@ -27,5 +27,5 @@ export interface IDelegationNode {
 
 export interface IDelegationHierarchyDetails {
   id: IDelegationNode['id']
-  cTypeHash: HexString
+  cTypeHash: CTypeHash
 }

--- a/packages/types/src/Delegation.ts
+++ b/packages/types/src/Delegation.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { ICType } from './CType'
+import type { HexString } from '@polkadot/util/types'
 import type { DidUri } from './DidDocument'
 
 /* eslint-disable no-bitwise */
@@ -27,5 +27,5 @@ export interface IDelegationNode {
 
 export interface IDelegationHierarchyDetails {
   id: IDelegationNode['id']
-  cTypeHash: ICType['hash']
+  cTypeHash: HexString
 }

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -6,10 +6,10 @@
  */
 
 import type { AnyJson } from '@polkadot/types/types/codec'
+import type { HexString } from '@polkadot/util/types'
 import type { DidSignature, DidUri } from './DidDocument.js'
 import type { IAttestation } from './Attestation.js'
 import type { PartialClaim } from './Claim.js'
-import type { ICType } from './CType.js'
 import type { IDelegationNode } from './Delegation.js'
 import type { IQuoteAgreement } from './Quote.js'
 import type { ICredential, ICredentialPresentation } from './Credential.js'
@@ -86,12 +86,12 @@ export interface ISubmitCredential extends IMessageBodyBase {
 }
 
 export interface IAcceptCredential extends IMessageBodyBase {
-  content: Array<ICType['hash']>
+  content: HexString[]
   type: 'accept-credential'
 }
 
 export interface IRejectCredential extends IMessageBodyBase {
-  content: Array<ICType['hash']>
+  content: HexString[]
   type: 'reject-credential'
 }
 
@@ -140,7 +140,7 @@ export interface IConfirmPayment extends IMessageBodyBase {
 
 export interface IRequestCredentialContent {
   cTypes: Array<{
-    cTypeHash: ICType['hash']
+    cTypeHash: HexString
     trustedAttesters?: DidUri[]
     requiredProperties?: string[]
   }>

--- a/packages/types/src/Message.ts
+++ b/packages/types/src/Message.ts
@@ -6,15 +6,15 @@
  */
 
 import type { AnyJson } from '@polkadot/types/types/codec'
-import type { HexString } from '@polkadot/util/types'
-import type { DidSignature, DidUri } from './DidDocument.js'
+
+import type { DidResourceUri, DidSignature, DidUri } from './DidDocument.js'
 import type { IAttestation } from './Attestation.js'
 import type { PartialClaim } from './Claim.js'
 import type { IDelegationNode } from './Delegation.js'
 import type { IQuoteAgreement } from './Quote.js'
 import type { ICredential, ICredentialPresentation } from './Credential.js'
 import type { ITerms } from './Terms.js'
-import type { DidResourceUri } from './index.js'
+import type { CTypeHash } from './CType.js'
 
 export type MessageBodyType =
   | 'error'
@@ -86,12 +86,12 @@ export interface ISubmitCredential extends IMessageBodyBase {
 }
 
 export interface IAcceptCredential extends IMessageBodyBase {
-  content: HexString[]
+  content: CTypeHash[]
   type: 'accept-credential'
 }
 
 export interface IRejectCredential extends IMessageBodyBase {
-  content: HexString[]
+  content: CTypeHash[]
   type: 'reject-credential'
 }
 
@@ -140,7 +140,7 @@ export interface IConfirmPayment extends IMessageBodyBase {
 
 export interface IRequestCredentialContent {
   cTypes: Array<{
-    cTypeHash: HexString
+    cTypeHash: CTypeHash
     trustedAttesters?: DidUri[]
     requiredProperties?: string[]
   }>

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -5,9 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { HexString } from '@polkadot/util/types'
 import type { DidSignature, DidUri } from './DidDocument'
 import type { ICredential } from './Credential'
+import type { CTypeHash } from './CType'
 
 export interface ICostBreakdown {
   tax: Record<string, unknown>
@@ -16,7 +16,7 @@ export interface ICostBreakdown {
 }
 export interface IQuote {
   attesterDid: DidUri
-  cTypeHash: HexString
+  cTypeHash: CTypeHash
   cost: ICostBreakdown
   currency: string
   timeframe: string

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { ICType } from './CType'
+import type { HexString } from '@polkadot/util/types'
 import type { DidSignature, DidUri } from './DidDocument'
 import type { ICredential } from './Credential'
 
@@ -16,7 +16,7 @@ export interface ICostBreakdown {
 }
 export interface IQuote {
   attesterDid: DidUri
-  cTypeHash: ICType['hash']
+  cTypeHash: HexString
   cost: ICostBreakdown
   currency: string
   timeframe: string

--- a/packages/vc-export/src/exportToVerifiableCredential.spec.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.spec.ts
@@ -36,26 +36,22 @@ import {
 const mockedApi: any = ApiMocks.getMockedApi()
 
 const ctype: ICType = {
-  schema: {
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    title: 'membership',
-    properties: {
-      birthday: {
-        type: 'string',
-        format: 'date',
-      },
-      name: {
-        type: 'string',
-      },
-      premium: {
-        type: 'boolean',
-      },
+  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+  title: 'membership',
+  properties: {
+    birthday: {
+      type: 'string',
+      format: 'date',
     },
-    type: 'object',
-    $id: 'kilt:ctype:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf',
+    name: {
+      type: 'string',
+    },
+    premium: {
+      type: 'boolean',
+    },
   },
-  owner: 'did:kilt:4sejigvu6STHdYmmYf2SuN92aNp8TbrsnBBDUj7tMrJ9Z3cG',
-  hash: '0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf',
+  type: 'object',
+  $id: 'kilt:ctype:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf',
 }
 
 const credential: ICredentialPresentation = {
@@ -146,11 +142,10 @@ it('exports includes ctype as schema', () => {
     toVC.fromCredentialAndAttestation(credential, attestation, ctype)
   ).toMatchObject({
     credentialSchema: {
-      '@id': ctype.schema.$id,
-      name: ctype.schema.title,
+      '@id': ctype.$id,
+      name: ctype.title,
       '@type': 'JsonSchemaValidator2018',
-      author: ctype.owner || null,
-      schema: ctype.schema,
+      schema: ctype,
     },
   })
 })
@@ -167,7 +162,6 @@ it('VC has correct format (full example)', () => {
     credentialSchema: {
       '@id': expect.any(String),
       '@type': 'JsonSchemaValidator2018',
-      author: expect.any(String),
       name: 'membership',
       schema: {
         $id: expect.any(String),

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -100,13 +100,11 @@ export function fromCredentialAndAttestation(
   // if ctype is given, add as credential schema
   let credentialSchema: CredentialSchema | undefined
   if (ctype) {
-    const { schema, owner } = ctype
     credentialSchema = {
-      '@id': schema.$id,
+      '@id': ctype.$id,
       '@type': JSON_SCHEMA_TYPE,
-      name: schema.title,
-      schema,
-      author: owner || undefined,
+      name: ctype.title,
+      schema: ctype,
     }
   }
 

--- a/packages/vc-export/src/types.ts
+++ b/packages/vc-export/src/types.ts
@@ -47,7 +47,7 @@ export interface CredentialDigestProof extends Proof {
 export interface CredentialSchema {
   '@id': string
   '@type': typeof JSON_SCHEMA_TYPE
-  schema: ICType['schema']
+  schema: ICType
   modelVersion?: string
   name?: string
   author?: string

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -309,7 +309,7 @@ export async function verifyCredentialDigestProof(
 /**
  * Validates the claims in the VC's `credentialSubject` against a CType definition on the `credentialSchema` property.
  *
- * @param credential A verifiable credential where `credentialSchema.schema` is an [[ICTypeSchema]].
+ * @param credential A verifiable credential where `credentialSchema.schema` is an [[ICType]].
  * @returns The [[VerificationResult]].
  */
 export function validateSchema(

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -248,17 +248,14 @@ async function runAll() {
 
   // CType workflow
   console.log('CType workflow started')
-  const DriversLicense = CType.fromProperties(
-    {
-      name: {
-        type: 'string',
-      },
-      age: {
-        type: 'integer',
-      },
+  const DriversLicense = CType.fromProperties('Drivers License', {
+    name: {
+      type: 'string',
     },
-    'Drivers License'
-  )
+    age: {
+      type: 'integer',
+    },
+  })
 
   const cTypeStoreTx = await Did.authorizeTx(
     alice.uri,

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -248,11 +248,8 @@ async function runAll() {
 
   // CType workflow
   console.log('CType workflow started')
-  const DriversLicense = CType.fromSchema({
-    $id: 'kilt:ctype:0x1',
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    title: 'Drivers License',
-    properties: {
+  const DriversLicense = CType.fromProperties(
+    {
       name: {
         type: 'string',
       },
@@ -260,8 +257,8 @@ async function runAll() {
         type: 'integer',
       },
     },
-    type: 'object',
-  })
+    'Drivers License'
+  )
 
   const cTypeStoreTx = await Did.authorizeTx(
     alice.uri,

--- a/tests/bundle-test.ts
+++ b/tests/bundle-test.ts
@@ -248,8 +248,11 @@ async function runAll() {
 
   // CType workflow
   console.log('CType workflow started')
-  const DriversLicense = CType.fromProperties(
-    {
+  const DriversLicense = CType.fromSchema({
+    $id: 'kilt:ctype:0x1',
+    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    title: 'Drivers License',
+    properties: {
       name: {
         type: 'string',
       },
@@ -257,8 +260,8 @@ async function runAll() {
         type: 'integer',
       },
     },
-    'Drivers License'
-  )
+    type: 'object',
+  })
 
   const cTypeStoreTx = await Did.authorizeTx(
     alice.uri,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2232

Redenomination of the `ICType` to what has formerly been the `ICTypeSchema`. This means that everything that used to require an `ICType` object - including an owner, hash and schema property - now requires just the value of the `schema` property instead. CTypes are therefore just a specific type of json schema, described by the `CTypeModel` metaschema.

Although this makes the value of the `$id` property the new canonical identifier of the CType, I have refrained from refactoring most other object to use it instead of the ctype hash, as this would significantly alter the api surface and reduce backwards compatibility.

## Implications for backwards compatibility

### Changes to Data structures

- __CType__: Existing CType data can be consumed after this change by simply extracting the value of the `schema` property.
- __CTypeMetadata__: Breaking change to the data structure: instead of a `ctypeHash` property, the CTypeMetadata is expected to have a `cTypeId` property. Its value can be derived from `ctypeHash` by prefixing it with `kilt:ctype:`.
- All other data structures that reference a CType still do so using the ctype hash, which is contained in its id. This has not been changed at this point so as not to harm backwards compatibility. 

### Changes to interfaces

- We currently do not have any message type for exchanging ctype data, which is why messaging is __not affected__. All message types that referenced ctypes still do so using the ctype hash.
- Only the CType schema has ever been submitted to the blockchain, so that __no changes__ are necessary here.

## How to test:
Unit & integration tests.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
