### PR TITLE
chore: export constants from vc-export

### DIFF
--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -9,10 +9,6 @@
     ".": {
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
-    },
-    "./constants": {
-      "import": "./lib/esm/constants.js",
-      "require": "./lib/cjs/constants.js"
     }
   },
   "files": [

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
+    },
+    "./constants": {
+      "import": "./lib/esm/constants.js",
+      "require": "./lib/cjs/constants.js"
     }
   },
   "files": [

--- a/packages/vc-export/src/index.ts
+++ b/packages/vc-export/src/index.ts
@@ -17,5 +17,6 @@ export * as verification from './verificationUtils.js'
 export * as presentation from './presentationUtils.js'
 export { fromCredentialAndAttestation } from './exportToVerifiableCredential.js'
 export * as vcjsSuites from './vc-js/index.js'
+export * as constants from './constants.js'
 
 export type { types }


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1780

Exports constants from vc-export package, both via index.js and via path export.

## How to test:

Import them somewhere I guess.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
