### PR TITLE
fix: checkout v1 seems broken

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: make sure testcontainers image is in cache
         uses: ./.github/actions/cached-image-pull
         with:


### PR DESCRIPTION
Failing workflows indicate that there may be a problem with checkoutv1. This updates the only use of that GitHub action to v3.