### PR TITLE
feat: DID spec compliant implementation of resolve 

### DIFF
--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -6,10 +6,9 @@
  */
 
 import type {
-  ConformingDidDocument,
+  ConformingDidResolutionResult,
   DidDocument,
   DidKey,
-  DidResolutionDocumentMetadata,
   DidResolutionResult,
   DidResourceUri,
   DidUri,
@@ -101,13 +100,6 @@ export async function resolve(
   }
 }
 
-type DidResolutionMetadata = {
-  error?: 'notFound' | 'invalidDidUrl'
-  errorMessage?: string
-}
-
-type DidDocumentMetadata = Partial<DidResolutionDocumentMetadata>
-
 /**
  * Implementation of `resolve` compliant with W3C DID specifications (https://www.w3.org/TR/did-core/#did-resolution).
  * As opposed to `resolve`, which takes a more pragmatic approach, the `didDocument` property contains a fully compliant DID document abstract data model.
@@ -115,25 +107,19 @@ type DidDocumentMetadata = Partial<DidResolutionDocumentMetadata>
  * If a DID is invalid or has not been registered, this is indicated by the `error` property on the `didResolutionMetadata`.
  *
  * @param did The DID to resolve.
- * @returns `didResolutionMetadata`, `didDocument`, and `didDocumentMetadata` as an object.
+ * @returns An object with the properties `didDocument` (a spec-conforming DID document or `undefined`), `didDocumentMetadata` (equivalent to `metadata` returned by [[resolve]]), as well as `didResolutionMetadata` (indicating an `error` if any).
  */
-export async function resolveCompliant(did: DidUri): Promise<{
-  didDocumentMetadata: DidDocumentMetadata
-  didResolutionMetadata: DidResolutionMetadata
-  didDocument?: ConformingDidDocument | Pick<ConformingDidDocument, 'id'>
-}> {
-  const result: {
-    didDocumentMetadata: DidDocumentMetadata
-    didResolutionMetadata: DidResolutionMetadata
-    didDocument?: ConformingDidDocument | Pick<ConformingDidDocument, 'id'>
-  } = {
+export async function resolveCompliant(
+  did: DidUri
+): Promise<ConformingDidResolutionResult> {
+  const result: ConformingDidResolutionResult = {
     didDocumentMetadata: {},
     didResolutionMetadata: {},
   }
   try {
     Did.validateUri(did, 'Did')
   } catch (error) {
-    result.didResolutionMetadata.error = 'invalidDidUrl'
+    result.didResolutionMetadata.error = 'invalidDid'
     if (error instanceof Error) {
       result.didResolutionMetadata.errorMessage =
         error.name + error.message ? `: ${error.message}` : ''

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -83,6 +83,7 @@ export type ConformingDidDocument = {
   keyAgreement?: [DidEncryptionKey['id']]
   capabilityDelegation?: [DidVerificationKey['id']]
   service?: ConformingDidServiceEndpoint[]
+  alsoKnownAs?: string
 }
 
 /**

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -83,7 +83,7 @@ export type ConformingDidDocument = {
   keyAgreement?: [DidEncryptionKey['id']]
   capabilityDelegation?: [DidVerificationKey['id']]
   service?: ConformingDidServiceEndpoint[]
-  alsoKnownAs?: string
+  alsoKnownAs?: [`w3n:${string}`]
 }
 
 /**

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -92,9 +92,7 @@ export type ConformingDidDocument = {
 export type JsonLDDidDocument = ConformingDidDocument & { '@context': string[] }
 
 /**
- * DID Resolution Metadata returned by the DID `resolve` function as described by DID specifications.
- *
- * @link https://www.w3.org/TR/did-core/#did-resolution-metadata
+ * DID Resolution Metadata returned by the DID `resolve` function as described by DID specifications (https://www.w3.org/TR/did-core/#did-resolution-metadata).
  */
 export interface DidResolutionMetadata {
   error?: 'notFound' | 'invalidDid'
@@ -102,9 +100,7 @@ export interface DidResolutionMetadata {
 }
 
 /**
- * Object containing the return values of the DID `resolve` function as described by DID specifications.
- *
- * @link https://www.w3.org/TR/did-core/#did-resolution
+ * Object containing the return values of the DID `resolve` function as described by DID specifications (https://www.w3.org/TR/did-core/#did-resolution).
  */
 export interface ConformingDidResolutionResult {
   didDocumentMetadata: Partial<DidResolutionDocumentMetadata>

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -14,6 +14,7 @@ import {
   EncryptionKeyType,
   VerificationKeyType,
 } from './DidDocument.js'
+import { DidResolutionDocumentMetadata } from './DidResolver.js'
 
 export type ConformingDidDocumentKeyType =
   | 'Ed25519VerificationKey2018'
@@ -88,3 +89,25 @@ export type ConformingDidDocument = {
  * A JSON+LD DID Document that extends a traditional DID Document with additional semantic information.
  */
 export type JsonLDDidDocument = ConformingDidDocument & { '@context': string[] }
+
+/**
+ * DID Resolution Metadata returned by the DID `resolve` function as described by DID specifications.
+ *
+ * @link https://www.w3.org/TR/did-core/#did-resolution-metadata
+ */
+export interface DidResolutionMetadata {
+  error?: 'notFound' | 'invalidDid'
+  errorMessage?: string
+}
+
+/**
+ * Object containing the return values of the DID `resolve` function as described by DID specifications.
+ *
+ * @link https://www.w3.org/TR/did-core/#did-resolution
+ */
+export interface ConformingDidResolutionResult {
+  didDocumentMetadata: Partial<DidResolutionDocumentMetadata>
+  didResolutionMetadata: DidResolutionMetadata
+  didDocument?: Partial<ConformingDidDocument> &
+    Pick<ConformingDidDocument, 'id'>
+}

--- a/packages/types/src/DidResolver.ts
+++ b/packages/types/src/DidResolver.ts
@@ -48,7 +48,7 @@ export type DidResolutionResult = {
   /**
    * The DID's web3Name, if any.
    */
-  alsoKnownAs?: string
+  web3Name?: string
 }
 
 export type ResolvedDidKey = Pick<ConformingDidKey, 'id' | 'controller'> &

--- a/packages/types/src/DidResolver.ts
+++ b/packages/types/src/DidResolver.ts
@@ -45,6 +45,10 @@ export type DidResolutionResult = {
    * The DID resolution metadata.
    */
   metadata: DidResolutionDocumentMetadata
+  /**
+   * The DID's web3Name, if any.
+   */
+  alsoKnownAs?: string
 }
 
 export type ResolvedDidKey = Pick<ConformingDidKey, 'id' | 'controller'> &


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2283

Adds an implementation of the `resolve` function described by the resolution section of the DID specifications (https://www.w3.org/TR/did-core/#resolution) - rn I called it `compliantResolve`, because `DID.resolve` is taken in the sdk.

Main differences: 
- Returns an actual DID document, i.e. the result of `exportToDidDocument`.
- Returns a minimal DID document if a DID has been deleted or upgraded, instead of returning no document.
- Adds a `resolutionMetadata` structure, which can indicate resolution errors.
- Does not throw/return `null` for invalid/non-existent DIDs, but uses the `resolutionMetadata` error reporting.

To be able to add the `alsoKnownAs` field to the DidDocument, I also changed the signature of `resolve` to include the web3name in the returned data, if available.

## How to test:

Unit tests are included.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
