### PR TITLE
refactor!: make verifyDidSignature accept Uint8Array

### DIFF
--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -24,6 +24,7 @@ import {
 } from '@kiltprotocol/did'
 import type {
   DidResolveKey,
+  DidResourceUri,
   Hash,
   IAttestation,
   IClaim,
@@ -233,7 +234,11 @@ export async function verifySignature(
     )
   const signingData = makeSigningData(input, claimerSignature.challenge)
   await verifyDidSignature({
-    signature: claimerSignature,
+    signature: Crypto.coToUInt8(claimerSignature.signature),
+    keyUri:
+      claimerSignature.keyUri ??
+      // accept the old did signature format where keyUri was keyId
+      (claimerSignature as unknown as { keyId: DidResourceUri }).keyId,
     message: signingData,
     expectedVerificationMethod: 'authentication',
     didResolveKey,

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -22,10 +22,10 @@ import {
   verifyDidSignature,
   resolveKey,
   signatureToJson,
+  signatureFromJson,
 } from '@kiltprotocol/did'
 import type {
   DidResolveKey,
-  DidResourceUri,
   Hash,
   IAttestation,
   IClaim,
@@ -234,11 +234,7 @@ export async function verifySignature(
     )
   const signingData = makeSigningData(input, claimerSignature.challenge)
   await verifyDidSignature({
-    signature: Crypto.coToUInt8(claimerSignature.signature),
-    keyUri:
-      claimerSignature.keyUri ??
-      // accept the old did signature format where keyUri was keyId
-      (claimerSignature as unknown as { keyId: DidResourceUri }).keyId,
+    ...signatureFromJson(claimerSignature),
     message: signingData,
     expectedVerificationMethod: 'authentication',
     didResolveKey,

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -21,6 +21,7 @@ import {
   isDidSignature,
   verifyDidSignature,
   resolveKey,
+  signatureToJson,
 } from '@kiltprotocol/did'
 import type {
   DidResolveKey,
@@ -35,7 +36,6 @@ import type {
   SignCallback,
 } from '@kiltprotocol/types'
 import { Crypto, DataUtils, SDKErrors } from '@kiltprotocol/utils'
-import { u8aToHex } from '@polkadot/util'
 import * as Claim from '../claim/index.js'
 import { hashClaimContents } from '../claim/index.js'
 import { verifyClaimAgainstSchema } from '../ctype/index.js'
@@ -420,7 +420,7 @@ export async function createPresentation({
     excludedClaimProperties
   )
 
-  const { signature, keyUri } = await signCallback({
+  const signature = await signCallback({
     data: makeSigningData(presentation, challenge),
     did: credential.claim.owner,
     keyRelationship: 'authentication',
@@ -428,6 +428,6 @@ export async function createPresentation({
 
   return {
     ...presentation,
-    claimerSignature: { signature: u8aToHex(signature), keyUri, challenge },
+    claimerSignature: { ...signatureToJson(signature), challenge },
   }
 }

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -142,9 +142,7 @@ describe('Quote', () => {
     const sign = claimer.getSignCallback(claimerIdentity)
     const signature = Did.signatureToJson(
       await sign({
-        data: Crypto.coToUInt8(
-          Crypto.hashStr(Crypto.encodeObjectAsStr(validAttesterSignedQuote))
-        ),
+        data: Crypto.hash(Crypto.encodeObjectAsStr(validAttesterSignedQuote)),
         did: claimerIdentity.uri,
         keyRelationship: 'authentication',
       })

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -9,8 +9,6 @@
  * @group unit/quote
  */
 
-import { u8aToHex } from '@polkadot/util'
-
 import type {
   DidDocument,
   IClaim,
@@ -170,10 +168,8 @@ describe('Quote', () => {
           })
         ),
         validAttesterSignedQuote.attesterSignature.signature,
-        u8aToHex(
-          Did.getKey(attesterIdentity, attesterKeyId!)?.publicKey ||
-            new Uint8Array()
-        )
+        Did.getKey(attesterIdentity, attesterKeyId!)?.publicKey ||
+          new Uint8Array()
       )
     ).not.toThrow()
     await Quote.verifyAttesterSignedQuote(validAttesterSignedQuote, {

--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -27,7 +27,6 @@ import { Crypto } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
 import {
   createLocalDemoFullDidFromKeypair,
-  makeDidSignature,
   makeSigningKeyTool,
 } from '@kiltprotocol/testing'
 import * as CType from '../ctype'
@@ -142,10 +141,15 @@ describe('Quote', () => {
 
   it('tests created quote data against given data', async () => {
     expect(validQuoteData.attesterDid).toEqual(attesterIdentity.uri)
-    const signature = await makeDidSignature(
-      Crypto.hashStr(Crypto.encodeObjectAsStr(validAttesterSignedQuote)),
-      claimerIdentity.uri,
-      claimer.getSignCallback(claimerIdentity)
+    const sign = claimer.getSignCallback(claimerIdentity)
+    const signature = Did.signatureToJson(
+      await sign({
+        data: Crypto.coToUInt8(
+          Crypto.hashStr(Crypto.encodeObjectAsStr(validAttesterSignedQuote))
+        ),
+        did: claimerIdentity.uri,
+        keyRelationship: 'authentication',
+      })
     )
     expect(signature).toEqual(quoteBothAgreed.claimerSignature)
 

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -23,6 +23,7 @@ import type {
   SignCallback,
   DidResolveKey,
   DidUri,
+  DidResourceUri,
 } from '@kiltprotocol/types'
 import { Crypto, JsonSchema, SDKErrors } from '@kiltprotocol/utils'
 import { resolveKey, verifyDidSignature } from '@kiltprotocol/did'
@@ -103,7 +104,11 @@ export async function verifyAttesterSignedQuote(
 ): Promise<void> {
   const { attesterSignature, ...basicQuote } = quote
   await verifyDidSignature({
-    signature: attesterSignature,
+    signature: Crypto.coToUInt8(attesterSignature.signature),
+    keyUri:
+      attesterSignature.keyUri ??
+      // accept the old did signature format where keyUri was keyId
+      (attesterSignature as unknown as { keyId: DidResourceUri }).keyId,
     message: Crypto.hashStr(Crypto.encodeObjectAsStr(basicQuote)),
     expectedVerificationMethod: 'authentication',
     didResolveKey,
@@ -140,7 +145,11 @@ export async function createQuoteAgreement(
   const { attesterSignature, ...basicQuote } = attesterSignedQuote
 
   await verifyDidSignature({
-    signature: attesterSignature,
+    signature: Crypto.coToUInt8(attesterSignature.signature),
+    keyUri:
+      attesterSignature.keyUri ??
+      // accept the old did signature format where keyUri was keyId
+      (attesterSignature as unknown as { keyId: DidResourceUri }).keyId,
     message: Crypto.hashStr(Crypto.encodeObjectAsStr(basicQuote)),
     expectedVerificationMethod: 'authentication',
     didResolveKey,

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -23,13 +23,13 @@ import type {
   SignCallback,
   DidResolveKey,
   DidUri,
-  DidResourceUri,
 } from '@kiltprotocol/types'
 import { Crypto, JsonSchema, SDKErrors } from '@kiltprotocol/utils'
 import {
   resolveKey,
   verifyDidSignature,
   signatureToJson,
+  signatureFromJson,
 } from '@kiltprotocol/did'
 import { QuoteSchema } from './QuoteSchema.js'
 
@@ -105,11 +105,7 @@ export async function verifyAttesterSignedQuote(
 ): Promise<void> {
   const { attesterSignature, ...basicQuote } = quote
   await verifyDidSignature({
-    signature: Crypto.coToUInt8(attesterSignature.signature),
-    keyUri:
-      attesterSignature.keyUri ??
-      // accept the old did signature format where keyUri was keyId
-      (attesterSignature as unknown as { keyId: DidResourceUri }).keyId,
+    ...signatureFromJson(attesterSignature),
     message: Crypto.hashStr(Crypto.encodeObjectAsStr(basicQuote)),
     expectedVerificationMethod: 'authentication',
     didResolveKey,
@@ -146,11 +142,7 @@ export async function createQuoteAgreement(
   const { attesterSignature, ...basicQuote } = attesterSignedQuote
 
   await verifyDidSignature({
-    signature: Crypto.coToUInt8(attesterSignature.signature),
-    keyUri:
-      attesterSignature.keyUri ??
-      // accept the old did signature format where keyUri was keyId
-      (attesterSignature as unknown as { keyId: DidResourceUri }).keyId,
+    ...signatureFromJson(attesterSignature),
     message: Crypto.hashStr(Crypto.encodeObjectAsStr(basicQuote)),
     expectedVerificationMethod: 'authentication',
     didResolveKey,

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -26,7 +26,11 @@ import type {
   DidResourceUri,
 } from '@kiltprotocol/types'
 import { Crypto, JsonSchema, SDKErrors } from '@kiltprotocol/utils'
-import { resolveKey, verifyDidSignature } from '@kiltprotocol/did'
+import {
+  resolveKey,
+  verifyDidSignature,
+  signatureToJson,
+} from '@kiltprotocol/did'
 import { QuoteSchema } from './QuoteSchema.js'
 
 /**
@@ -80,10 +84,7 @@ export async function createAttesterSignedQuote(
   })
   return {
     ...quoteInput,
-    attesterSignature: {
-      keyUri: signature.keyUri,
-      signature: Crypto.u8aToHex(signature.signature),
-    },
+    attesterSignature: signatureToJson(signature),
   }
 }
 
@@ -155,7 +156,7 @@ export async function createQuoteAgreement(
     didResolveKey,
   })
 
-  const { signature, keyUri } = await sign({
+  const signature = await sign({
     data: Crypto.hash(Crypto.encodeObjectAsStr(attesterSignedQuote)),
     did: claimerDid,
     keyRelationship: 'authentication',
@@ -164,10 +165,7 @@ export async function createQuoteAgreement(
   return {
     ...attesterSignedQuote,
     rootHash: credentialRootHash,
-    claimerSignature: {
-      signature: Crypto.u8aToHex(signature),
-      keyUri,
-    },
+    claimerSignature: signatureToJson(signature),
   }
 }
 

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '@kiltprotocol/types'
 import { randomAsHex, randomAsU8a } from '@polkadot/util-crypto'
 import { Crypto } from '@kiltprotocol/utils'
-import { makeSigningKeyTool, makeDidSignature } from '@kiltprotocol/testing'
+import { makeSigningKeyTool } from '@kiltprotocol/testing'
 import * as Did from './index.js'
 import { verifyDidSignature, isDidSignature } from './Did.signature'
 import { resolveKey, keyToResolvedKey } from './DidResolver'
@@ -55,34 +55,16 @@ describe('light DID', () => {
 
   it('verifies did signature over string', async () => {
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        expectedVerificationMethod: 'authentication',
-      })
-    ).resolves.not.toThrow()
-  })
-
-  it('verifies old did signature (with `keyId` property) over string', async () => {
-    const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
-    const oldSignature: any = {
-      ...signature,
-      keyId: signature.keyUri,
-    }
-    delete oldSignature.keyUri
-
-    // Test the old signature is correctly crafted
-    expect(oldSignature.signature).toBeDefined()
-    expect(oldSignature.keyId).toBeDefined()
-    expect(oldSignature.keyUri).toBeUndefined()
-
-    await expect(
-      verifyDidSignature({
-        message: SIGNED_STRING,
-        signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).resolves.not.toThrow()
@@ -90,15 +72,16 @@ describe('light DID', () => {
 
   it('verifies did signature over bytes', async () => {
     const SIGNED_BYTES = Uint8Array.from([1, 2, 3, 4, 5])
-    const signature = await makeDidSignature(
-      Crypto.u8aToHex(SIGNED_BYTES),
-      did.uri,
-      sign
-    )
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(Crypto.u8aToHex(SIGNED_BYTES)),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(
       verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).resolves.not.toThrow()
@@ -106,11 +89,16 @@ describe('light DID', () => {
 
   it('fails if relationship does not match', async () => {
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'assertionMethod',
       })
     ).rejects.toThrow()
@@ -118,13 +106,19 @@ describe('light DID', () => {
 
   it('fails if key id does not match', async () => {
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
-    signature.keyUri += '1a'
+    // eslint-disable-next-line prefer-const
+    let { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
+    keyUri += '1a'
     jest.mocked(resolveKey).mockRejectedValue(new Error('Key not found'))
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()
@@ -132,11 +126,16 @@ describe('light DID', () => {
 
   it('fails if signature does not match', async () => {
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING.substring(1),
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()
@@ -144,13 +143,19 @@ describe('light DID', () => {
 
   it('fails if key id malformed', async () => {
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    // eslint-disable-next-line prefer-const
+    let { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     // @ts-expect-error
-    signature.keyUri = signature.keyUri.replace('#', '?')
+    keyUri = keyUri.replace('#', '?')
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()
@@ -159,11 +164,16 @@ describe('light DID', () => {
   it('does not verify if migrated to Full DID', async () => {
     jest.mocked(resolveKey).mockRejectedValue(new Error('Migrated'))
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()
@@ -214,11 +224,16 @@ describe('full DID', () => {
 
   it('verifies did signature over string', async () => {
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).resolves.not.toThrow()
@@ -226,15 +241,16 @@ describe('full DID', () => {
 
   it('verifies did signature over bytes', async () => {
     const SIGNED_BYTES = Uint8Array.from([1, 2, 3, 4, 5])
-    const signature = await makeDidSignature(
-      Crypto.u8aToHex(SIGNED_BYTES),
-      did.uri,
-      sign
-    )
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(Crypto.u8aToHex(SIGNED_BYTES)),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(
       verifyDidSignature({
         message: SIGNED_BYTES,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).resolves.not.toThrow()
@@ -243,11 +259,16 @@ describe('full DID', () => {
   it('does not verify if deactivated', async () => {
     jest.mocked(resolveKey).mockRejectedValue(new Error('Deactivated'))
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()
@@ -256,11 +277,16 @@ describe('full DID', () => {
   it('does not verify if not on chain', async () => {
     jest.mocked(resolveKey).mockRejectedValue(new Error('Not on chain'))
     const SIGNED_STRING = 'signed string'
-    const signature = await makeDidSignature(SIGNED_STRING, did.uri, sign)
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
     await expect(() =>
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        keyUri,
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -73,7 +73,7 @@ describe('light DID', () => {
   it('verifies did signature over bytes', async () => {
     const SIGNED_BYTES = Uint8Array.from([1, 2, 3, 4, 5])
     const { signature, keyUri } = await sign({
-      data: Crypto.coToUInt8(Crypto.u8aToHex(SIGNED_BYTES)),
+      data: SIGNED_BYTES,
       did: did.uri,
       keyRelationship: 'authentication',
     })
@@ -242,7 +242,7 @@ describe('full DID', () => {
   it('verifies did signature over bytes', async () => {
     const SIGNED_BYTES = Uint8Array.from([1, 2, 3, 4, 5])
     const { signature, keyUri } = await sign({
-      data: Crypto.coToUInt8(Crypto.u8aToHex(SIGNED_BYTES)),
+      data: SIGNED_BYTES,
       did: did.uri,
       keyRelationship: 'authentication',
     })

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -9,7 +9,9 @@ import { u8aToHex, isHex } from '@polkadot/util'
 
 import {
   DidResolveKey,
+  DidResourceUri,
   DidSignature,
+  SignResponseData,
   VerificationKeyRelationship,
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
@@ -19,7 +21,8 @@ import { parse, validateUri } from './Did.utils.js'
 
 export type DidSignatureVerificationInput = {
   message: string | Uint8Array
-  signature: DidSignature
+  signature: Uint8Array
+  keyUri: DidResourceUri
   expectedVerificationMethod?: VerificationKeyRelationship
   didResolveKey?: DidResolveKey
 }
@@ -54,32 +57,28 @@ function verifyDidSignatureDataStructure(
  *
  * @param input Object wrapping all input.
  * @param input.message The message that was signed.
- * @param input.signature An object containing signature and signer key.
+ * @param input.signature Signature bytes.
+ * @param input.keyUri DID URI of the key used for signing.
  * @param input.expectedVerificationMethod Which relationship to the signer DID the key must have.
  * @param input.didResolveKey Allows specifying a custom DID key resolve. Defaults to the built-in [[resolveKey]].
  */
 export async function verifyDidSignature({
   message,
   signature,
+  keyUri,
   expectedVerificationMethod,
   didResolveKey = resolveKey,
 }: DidSignatureVerificationInput): Promise<void> {
-  verifyDidSignatureDataStructure(signature)
-  // Add support for old signatures that had the `keyId` instead of the `keyUri`
-  const inputUri = signature.keyUri || (signature as any).keyId
   // Verification fails if the signature key URI is not valid
-  const { fragment } = parse(inputUri)
+  const { fragment } = parse(keyUri)
   if (!fragment)
     throw new SDKErrors.SignatureMalformedError(
-      `Signature key URI "${inputUri}" invalid`
+      `Signature key URI "${keyUri}" invalid`
     )
 
-  const { publicKey } = await didResolveKey(
-    inputUri,
-    expectedVerificationMethod
-  )
+  const { publicKey } = await didResolveKey(keyUri, expectedVerificationMethod)
 
-  Crypto.verify(message, signature.signature, u8aToHex(publicKey))
+  Crypto.verify(message, signature, u8aToHex(publicKey))
 }
 
 /**
@@ -98,4 +97,19 @@ export function isDidSignature(
   } catch (cause) {
     return false
   }
+}
+
+/**
+ * Transforms the output of a [[SignCallback]] into the [[DidSignature]] format suitable for json-based data exchange.
+ *
+ * @param input Signature data returned from the [[SignCallback]].
+ * @param input.signature Signature bytes.
+ * @param input.keyUri DID URI of the key used for signing.
+ * @returns A [[DidSignature]] object where signature is hex-encoded.
+ */
+export function signatureToJson({
+  signature,
+  keyUri,
+}: SignResponseData): DidSignature {
+  return { signature: Crypto.u8aToHex(signature), keyUri }
 }

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -113,3 +113,18 @@ export function signatureToJson({
 }: SignResponseData): DidSignature {
   return { signature: Crypto.u8aToHex(signature), keyUri }
 }
+
+/**
+ * Deserializes a [[DidSignature]] for signature verification.
+ * Handles backwards compatibility to an older version of the interface where the `keyUri` property was called `keyId`.
+ *
+ * @param input A [[DidSignature]] object.
+ * @returns The deserialized DidSignature where the signature is represented as a Uint8Array.
+ */
+export function signatureFromJson(
+  input: DidSignature | OldDidSignature
+): Pick<SignResponseData, 'keyUri' | 'signature'> {
+  const keyUri = 'keyUri' in input ? input.keyUri : input.keyId
+  const signature = Crypto.coToUInt8(input.signature)
+  return { signature, keyUri }
+}

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import { u8aToHex, isHex } from '@polkadot/util'
+import { isHex } from '@polkadot/util'
 
 import {
   DidResolveKey,
@@ -78,7 +78,7 @@ export async function verifyDidSignature({
 
   const { publicKey } = await didResolveKey(keyUri, expectedVerificationMethod)
 
-  Crypto.verify(message, signature, u8aToHex(publicKey))
+  Crypto.verify(message, signature, publicKey)
 }
 
 /**

--- a/packages/messaging/src/Message.spec.ts
+++ b/packages/messaging/src/Message.spec.ts
@@ -64,7 +64,6 @@ import {
   createLocalDemoFullDidFromKeypair,
   KeyTool,
   KeyToolSignCallback,
-  makeDidSignature,
 } from '@kiltprotocol/testing'
 import { u8aToHex } from '@polkadot/util'
 import { Crypto, SDKErrors } from '@kiltprotocol/utils'
@@ -890,10 +889,12 @@ describe('Error checking / Verification', () => {
       },
       metaData: {},
       signatures: {
-        inviter: await makeDidSignature(
-          'signature',
-          identityAlice.uri,
-          keyAlice.getSignCallback(identityAlice)
+        inviter: Did.signatureToJson(
+          await keyAlice.getSignCallback(identityAlice)({
+            data: Crypto.coToUInt8('signature'),
+            did: identityAlice.uri,
+            keyRelationship: 'authentication',
+          })
         ),
       },
     }
@@ -907,15 +908,19 @@ describe('Error checking / Verification', () => {
         isPCR: false,
       },
       signatures: {
-        inviter: await makeDidSignature(
-          'signature',
-          identityAlice.uri,
-          keyAlice.getSignCallback(identityAlice)
+        inviter: Did.signatureToJson(
+          await keyAlice.getSignCallback(identityAlice)({
+            data: Crypto.coToUInt8('signature'),
+            did: identityAlice.uri,
+            keyRelationship: 'authentication',
+          })
         ),
-        invitee: await makeDidSignature(
-          'signature',
-          identityBob.uri,
-          keyBob.getSignCallback(identityBob)
+        invitee: Did.signatureToJson(
+          await keyBob.getSignCallback(identityBob)({
+            data: Crypto.coToUInt8('signature'),
+            did: identityBob.uri,
+            keyRelationship: 'authentication',
+          })
         ),
       },
     }

--- a/packages/testing/src/TestUtils.ts
+++ b/packages/testing/src/TestUtils.ts
@@ -12,8 +12,6 @@ import type {
   DidDocument,
   DidKey,
   DidServiceEndpoint,
-  DidSignature,
-  DidUri,
   DidVerificationKey,
   EncryptCallback,
   KeyRelationship,
@@ -332,20 +330,4 @@ export async function createFullDidFromSeed(
   const lightDid = await createMinimalLightDidFromKeypair(keypair)
   const sign = makeStoreDidCallback(keypair)
   return createFullDidFromLightDid(payer, lightDid, sign)
-}
-
-export async function makeDidSignature(
-  data: string,
-  didUri: DidUri,
-  signCallback: SignCallback
-): Promise<DidSignature> {
-  const { signature, keyUri } = await signCallback({
-    data: Crypto.coToUInt8(data),
-    did: didUri,
-    keyRelationship: 'authentication',
-  })
-  return {
-    signature: Crypto.u8aToHex(signature),
-    keyUri,
-  }
 }

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -117,14 +117,14 @@ export function signStr(
  *
  * @param message Original signed message to be verified.
  * @param signature Signature as hex string or byte array.
- * @param address Substrate address or public key of the signer.
+ * @param addressOrPublicKey Substrate address or public key of the signer.
  */
 export function verify(
   message: CryptoInput,
   signature: CryptoInput,
-  address: Address
+  addressOrPublicKey: Address | HexString | Uint8Array
 ): void {
-  if (signatureVerify(message, signature, address).isValid !== true)
+  if (signatureVerify(message, signature, addressOrPublicKey).isValid !== true)
     throw new SDKErrors.SignatureUnverifiableError()
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2236

As per the ticket, this changes verifyDidSignature such that it takes signatures as a byte array instead of a hex string.
It also removes the makeDidSignature helper.

## How to test:

Unit tests have been adapted.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
