### PR TITLE
chore: bump typescript-logging to v1

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,6 +37,6 @@
     "@kiltprotocol/types": "workspace:*",
     "@kiltprotocol/utils": "workspace:*",
     "@polkadot/api": "^9.4.1",
-    "typescript-logging": "^0.6.4"
+    "typescript-logging": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,7 +1272,7 @@ __metadata:
     "@polkadot/api": ^9.4.1
     rimraf: ^3.0.2
     typescript: ^4.8.3
-    typescript-logging: ^0.6.4
+    typescript-logging: ^1.0.0
   languageName: unknown
   linkType: soft
 
@@ -9871,12 +9871,12 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"typescript-logging@npm:^0.6.4":
-  version: 0.6.4
-  resolution: "typescript-logging@npm:0.6.4"
+"typescript-logging@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "typescript-logging@npm:1.0.1"
   dependencies:
     stacktrace-js: 1.3.1
-  checksum: 883304d1c8e5f57420f9b3d925c72e59bf1e65f248c2586a60eeec19a7ad46de52df5d915f1e53d202e8b6bb3e42be21c696bdf8ab1d392f56dc25f8b3a0e974
+  checksum: ded1936be380f20bbe0c82a34cf09b080513105eebd23d13d570e9fb3480d8995d731efec565cd47551e0d08cafa0a722e134bfb7e3a17491768e7468632ab3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We have been using a pre-v1 version of typescript-logging. By now v2 is out (which has breaking changes) but there seems to be no reason not to upgrade to v1.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
