### PR TITLE
fix: DID API types

### DIFF
--- a/packages/type-definitions/src/index.ts
+++ b/packages/type-definitions/src/index.ts
@@ -113,27 +113,15 @@ const defaultTypesBundle: OverrideVersionedType[] = [
 // Current runtime version: 10730
 export const typesBundle: OverrideBundleType = {
   chain: {
-    'KILT Spiritnet': {
+    'kilt-spiritnet': {
       runtime: {
         ...didCalls,
         ...parachainStakingCalls,
       },
       types: defaultTypesBundle,
     },
-    'KILT Peregrine': {
-      runtime: {
-        ...didCalls,
-        ...parachainStakingCalls,
-      },
-      types: defaultTypesBundle,
-    },
-    'KILT Mashnet': {
-      runtime: {
-        ...didCalls,
-      },
-      types: defaultTypesBundle,
-    },
-    Development: {
+    // Includes Standalone and Peregrine runtimes
+    'mashnet-node': {
       runtime: {
         ...didCalls,
         ...parachainStakingCalls,

--- a/packages/type-definitions/src/types_10720.ts
+++ b/packages/type-definitions/src/types_10720.ts
@@ -14,8 +14,8 @@ export const types10720: RegistryTypes = {
     identifier: 'AccountId32',
     accounts: 'Vec<DidApiAccountId>',
     w3n: 'Option<Text>',
-    serviceEndpoints: 'Vec<RawServiceEndpoints>',
-    details: 'RawDidDetails',
+    serviceEndpoints: 'Vec<DidServiceEndpointsDidEndpoint>',
+    details: 'DidDidDetails',
   },
   RawServiceEndpoints: {
     id: 'Text',


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2235
* Fixes types for `RawDidLinkedInfo`
* Fixes runtime spec names. Unfortunately, `Peregrine` does not have a custom spec name 🙈 With the current ones, the type changes were not applied in my local tests.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
