### PR TITLE
feat: compare owner and signer of credential on signature verification

### DIFF
--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -71,8 +71,6 @@ describe('Credential', () => {
     legitimation = buildCredential(identityAlice, {}, [])
   })
 
-  it.todo('signing and verification')
-
   it('verify credential', async () => {
     const credential = buildCredential(
       identityBob,

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -481,10 +481,7 @@ describe('Credential', () => {
       signCallback: keyAlice.getSignCallback(identityAlice),
     })
     // but replace signer key reference with authentication key of light did
-    presentation.claimerSignature.keyUri = `${
-      Did.createLightDidDocument({ authentication: keyAlice.authentication })
-        .uri
-    }${identityAlice.authentication[0].id}`
+    presentation.claimerSignature.keyUri = `${identityDave.uri}${identityDave.authentication[0].id}`
 
     // signature would check out but mismatch should be detected
     await expect(

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -362,13 +362,13 @@ describe('Credential', () => {
     identityCharlie = await createLocalDemoFullDidFromKeypair(
       keyCharlie.keypair
     )
-      ;[legitimation] = await buildPresentation(
-        identityAlice,
-        identityBob.uri,
-        {},
-        [],
-        keyAlice.getSignCallback(identityAlice)
-      )
+    ;[legitimation] = await buildPresentation(
+      identityAlice,
+      identityBob.uri,
+      {},
+      [],
+      keyAlice.getSignCallback(identityAlice)
+    )
   })
 
   it('verify credentials signed by a full DID', async () => {
@@ -392,7 +392,7 @@ describe('Credential', () => {
   })
   it('verify credentials signed by a light DID', async () => {
     const { getSignCallback, authentication } = makeSigningKeyTool('ed25519')
-    identityDave = await Did.createLightDidDocument({
+    identityDave = Did.createLightDidDocument({
       authentication,
     })
 
@@ -449,14 +449,24 @@ describe('Credential', () => {
       [legitimation]
     )
 
-    const presentation = await Credential.createPresentation({ credential, signCallback: getSignCallback(identityDave) })
+    const presentation = await Credential.createPresentation({
+      credential,
+      signCallback: getSignCallback(identityDave),
+    })
 
-    await expect(Credential.verifySignature(presentation, {
-      didResolveKey,
-    })).resolves.toThrow()
+    await expect(
+      Credential.verifySignature(presentation, {
+        didResolveKey,
+      })
+    ).rejects.toThrow(SDKErrors.DidSubjectMismatchError)
   })
 
   it('throws if signature is by corresponding light did', async () => {
+    // make mock resolver resolve corresponding light did by assigning it to dave identity
+    identityDave = Did.createLightDidDocument({
+      authentication: keyAlice.authentication,
+    })
+
     const credential = buildCredential(
       identityAlice.uri,
       {
@@ -467,13 +477,23 @@ describe('Credential', () => {
       [legitimation]
     )
 
-    const presentation = await Credential.createPresentation({ credential, signCallback: keyAlice.getSignCallback(identityAlice) })
+    // sign presentation using Alice's authenication key
+    const presentation = await Credential.createPresentation({
+      credential,
+      signCallback: keyAlice.getSignCallback(identityAlice),
+    })
+    // but replace signer key reference with authentication key of light did
+    presentation.claimerSignature.keyUri = `${
+      Did.createLightDidDocument({ authentication: keyAlice.authentication })
+        .uri
+    }${identityAlice.authentication[0].id}`
 
-    presentation.claimerSignature.keyUri = `${Did.createLightDidDocument({ authentication: keyAlice.authentication }).uri}${identityAlice.authentication[0].id}`
-
-    await expect(Credential.verifySignature(presentation, {
-      didResolveKey,
-    })).resolves.toThrow()
+    // signature would check out but mismatch should be detected
+    await expect(
+      Credential.verifySignature(presentation, {
+        didResolveKey,
+      })
+    ).rejects.toThrow(SDKErrors.DidSubjectMismatchError)
   })
 
   it('fail to verify credentials signed by a light DID after it has been migrated and deleted', async () => {
@@ -606,7 +626,7 @@ describe('create presentation', () => {
     // Change also the authentication key of the full DID to properly verify signature verification,
     // so that it uses a completely different key and the credential is still correctly verified.
     newKeyForMigratedClaimerDid = makeSigningKeyTool()
-    migratedClaimerFullDid = await createMinimalFullDidFromLightDid(
+    migratedClaimerFullDid = createMinimalFullDidFromLightDid(
       migratedClaimerLightDid,
       {
         ...newKeyForMigratedClaimerDid.authentication[0],

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -23,7 +23,6 @@ import {
   resolveKey,
   signatureToJson,
   signatureFromJson,
-  parse,
 } from '@kiltprotocol/did'
 import type {
   DidResolveKey,
@@ -234,38 +233,14 @@ export async function verifySignature(
       'Challenge differs from expected'
     )
 
-  // check if credential owner matches signer
-  const { owner } = input.claim
-  const {
-    did: signer,
-    address: signerAddress,
-    type: signerType,
-    authKeyTypeEncoding: signerKeyType,
-  } = parse(input.claimerSignature.keyUri)
-  if (owner !== signer) {
-    const {
-      address: ownerAddress,
-      type: ownerType,
-      authKeyTypeEncoding: ownerKeyType,
-    } = parse(owner)
-
-    if (ownerType === 'full') {
-      // owner did is full did -> exact match required (signer cannot be light did)
-      throw new SDKErrors.DidSubjectMismatchError(signer, owner)
-    } else {
-      // owner did is light did -> full- or light did with same subject may sign
-      if (ownerAddress !== signerAddress)
-        throw new SDKErrors.DidSubjectMismatchError(signer, owner)
-      // if signer is also a light did, require both to use the same key type
-      if (signerType === 'light' && ownerKeyType !== signerKeyType)
-        throw new SDKErrors.DidSubjectMismatchError(signer, owner)
-    }
-  }
-
   const signingData = makeSigningData(input, claimerSignature.challenge)
   await verifyDidSignature({
     ...signatureFromJson(claimerSignature),
     message: signingData,
+    // check if credential owner matches signer
+    expectedSigner: input.claim.owner,
+    // allow full did to sign presentation if owned by corresponding light did
+    allowUpgraded: true,
     expectedVerificationMethod: 'authentication',
     didResolveKey,
   })

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -107,6 +107,7 @@ export async function verifyAttesterSignedQuote(
   await verifyDidSignature({
     ...signatureFromJson(attesterSignature),
     message: Crypto.hashStr(Crypto.encodeObjectAsStr(basicQuote)),
+    expectedSigner: basicQuote.attesterDid,
     expectedVerificationMethod: 'authentication',
     didResolveKey,
   })

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -9,16 +9,17 @@
  * @group unit/did
  */
 
-import {
+import type {
   DidDocument,
   DidResourceUri,
   DidSignature,
   KeyringPair,
   KiltKeyringPair,
+  NewLightDidVerificationKey,
   SignCallback,
 } from '@kiltprotocol/types'
 import { randomAsHex, randomAsU8a } from '@polkadot/util-crypto'
-import { Crypto } from '@kiltprotocol/utils'
+import { Crypto, SDKErrors } from '@kiltprotocol/utils'
 import { makeSigningKeyTool } from '@kiltprotocol/testing'
 import * as Did from './index.js'
 import {
@@ -119,7 +120,7 @@ describe('light DID', () => {
       did: did.uri,
       keyRelationship: 'authentication',
     })
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
@@ -139,10 +140,11 @@ describe('light DID', () => {
     })
     keyUri += '1a'
     jest.mocked(resolveKey).mockRejectedValue(new Error('Key not found'))
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
+        // @ts-ignore Appending the uri has changed its type
         keyUri,
         expectedVerificationMethod: 'authentication',
       })
@@ -156,7 +158,7 @@ describe('light DID', () => {
       did: did.uri,
       keyRelationship: 'authentication',
     })
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING.substring(1),
         signature,
@@ -176,7 +178,7 @@ describe('light DID', () => {
     })
     // @ts-expect-error
     keyUri = keyUri.replace('#', '?')
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
@@ -194,7 +196,7 @@ describe('light DID', () => {
       did: did.uri,
       keyRelationship: 'authentication',
     })
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
@@ -210,6 +212,60 @@ describe('light DID', () => {
       signature: randomAsHex(32),
     }
     expect(isDidSignature(signature)).toBe(true)
+  })
+
+  it('detects signer expectation mismatch if signature is by unrelated did', async () => {
+    const SIGNED_STRING = 'signed string'
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
+
+    const expectedSigner = Did.createLightDidDocument({
+      authentication: makeSigningKeyTool().authentication,
+    }).uri
+
+    await expect(
+      verifyDidSignature({
+        message: SIGNED_STRING,
+        signature,
+        keyUri,
+        expectedSigner,
+        expectedVerificationMethod: 'authentication',
+      })
+    ).rejects.toThrow(SDKErrors.DidSubjectMismatchError)
+  })
+
+  it('allows variations of the same light did', async () => {
+    const SIGNED_STRING = 'signed string'
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
+
+    const expectedSigner = Did.createLightDidDocument({
+      authentication: did.authentication as [NewLightDidVerificationKey],
+      keyAgreement: [{ type: 'x25519', publicKey: new Uint8Array(32).fill(1) }],
+      service: [
+        {
+          id: '#service',
+          type: ['servingService'],
+          serviceEndpoint: ['http://example.com'],
+        },
+      ],
+    }).uri
+
+    await expect(
+      verifyDidSignature({
+        message: SIGNED_STRING,
+        signature,
+        keyUri,
+        expectedSigner,
+        expectedVerificationMethod: 'authentication',
+      })
+    ).resolves.not.toThrow()
   })
 })
 
@@ -289,7 +345,7 @@ describe('full DID', () => {
       did: did.uri,
       keyRelationship: 'authentication',
     })
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
@@ -307,7 +363,7 @@ describe('full DID', () => {
       did: did.uri,
       keyRelationship: 'authentication',
     })
-    await expect(() =>
+    await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
@@ -315,6 +371,40 @@ describe('full DID', () => {
         expectedVerificationMethod: 'authentication',
       })
     ).rejects.toThrow()
+  })
+
+  it('accepts signature of full did for light did if enabled', async () => {
+    const SIGNED_STRING = 'signed string'
+    const { signature, keyUri } = await sign({
+      data: Crypto.coToUInt8(SIGNED_STRING),
+      did: did.uri,
+      keyRelationship: 'authentication',
+    })
+
+    const expectedSigner = Did.createLightDidDocument({
+      authentication: did.authentication as [NewLightDidVerificationKey],
+    }).uri
+
+    await expect(
+      verifyDidSignature({
+        message: SIGNED_STRING,
+        signature,
+        keyUri,
+        expectedSigner,
+        expectedVerificationMethod: 'authentication',
+      })
+    ).rejects.toThrow(SDKErrors.DidSubjectMismatchError)
+
+    await expect(
+      verifyDidSignature({
+        message: SIGNED_STRING,
+        signature,
+        keyUri,
+        expectedSigner,
+        allowUpgraded: true,
+        expectedVerificationMethod: 'authentication',
+      })
+    ).resolves.not.toThrow()
   })
 
   it('typeguard accepts legal signature objects', () => {

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -138,13 +138,12 @@ describe('light DID', () => {
       did: did.uri,
       keyRelationship: 'authentication',
     })
-    keyUri += '1a'
+    keyUri = `${keyUri}1a`
     jest.mocked(resolveKey).mockRejectedValue(new Error('Key not found'))
     await expect(
       verifyDidSignature({
         message: SIGNED_STRING,
         signature,
-        // @ts-ignore Appending the uri has changed its type
         keyUri,
         expectedVerificationMethod: 'authentication',
       })

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -168,6 +168,7 @@ describe('light DID', () => {
   })
 
   it('fails if key id malformed', async () => {
+    jest.mocked(resolveKey).mockRestore()
     const SIGNED_STRING = 'signed string'
     // eslint-disable-next-line prefer-const
     let { signature, keyUri } = await sign({

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -76,14 +76,8 @@ export async function verifyDidSignature({
   expectedVerificationMethod,
   didResolveKey = resolveKey,
 }: DidSignatureVerificationInput): Promise<void> {
-  // Verification fails if the signature key URI is not valid
-  const signer = parse(keyUri)
-  if (!signer.fragment)
-    throw new SDKErrors.SignatureMalformedError(
-      `Signature key URI "${keyUri}" invalid`
-    )
-
   // checks if key uri points to the right did; alternatively we could check the key's controller
+  const signer = parse(keyUri)
   if (expectedSigner && expectedSigner !== signer.did) {
     // check for allowable exceptions
     const expected = parse(expectedSigner)

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -147,7 +147,9 @@ export async function resolveKey(
 
   // A fragment (keyId) IS expected to resolve a key.
   if (!keyId) {
-    throw new SDKErrors.InvalidDidFormatError(keyUri)
+    throw new SDKErrors.DidError(
+      `Key URI "${keyUri}" is not a valid DID resource`
+    )
   }
 
   const resolved = await resolve(did)
@@ -199,7 +201,9 @@ export async function resolveService(
 
   // A fragment (serviceId) IS expected to resolve a key.
   if (!serviceId) {
-    throw new SDKErrors.InvalidDidFormatError(serviceUri)
+    throw new SDKErrors.DidError(
+      `Service URI "${serviceUri}" is not a valid DID resource`
+    )
   }
 
   const resolved = await resolve(did)


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1773

Checking whether the signer of a credential is (related to) the owner has is so far not happening as part of `verifyPresentation`.
This adds this feature to `verifyDidSignature`, which is called by `verifyPresentation`.

> __Note:__ This cherry-picks a commit (01bf6fd1a98d5a75a18d90491c97b220ca94bb68) originally included with  https://github.com/KILTprotocol/sdk-js/pull/675.

## How to test:

Unit tests related to that issue did not exist yet. I added these.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
