### PR TITLE
feat: improve quote verification

### DIFF
--- a/packages/core/src/quote/Quote.spec.ts
+++ b/packages/core/src/quote/Quote.spec.ts
@@ -142,7 +142,13 @@ describe('Quote', () => {
     const sign = claimer.getSignCallback(claimerIdentity)
     const signature = Did.signatureToJson(
       await sign({
-        data: Crypto.hash(Crypto.encodeObjectAsStr(validAttesterSignedQuote)),
+        data: Crypto.hash(
+          Crypto.encodeObjectAsStr({
+            ...validAttesterSignedQuote,
+            claimerDid: claimerIdentity.uri,
+            rootHash: credential.rootHash,
+          })
+        ),
         did: claimerIdentity.uri,
         keyRelationship: 'authentication',
       })

--- a/packages/core/src/quote/Quote.ts
+++ b/packages/core/src/quote/Quote.ts
@@ -149,15 +149,19 @@ export async function createQuoteAgreement(
     didResolveKey,
   })
 
+  const quoteAgreement = {
+    ...attesterSignedQuote,
+    rootHash: credentialRootHash,
+    claimerDid,
+  }
   const signature = await sign({
-    data: Crypto.hash(Crypto.encodeObjectAsStr(attesterSignedQuote)),
+    data: Crypto.hash(Crypto.encodeObjectAsStr(quoteAgreement)),
     did: claimerDid,
     keyRelationship: 'authentication',
   })
 
   return {
-    ...attesterSignedQuote,
-    rootHash: credentialRootHash,
+    ...quoteAgreement,
     claimerSignature: signatureToJson(signature),
   }
 }

--- a/packages/types/src/Quote.ts
+++ b/packages/types/src/Quote.ts
@@ -28,5 +28,6 @@ export interface IQuoteAttesterSigned extends IQuote {
 
 export interface IQuoteAgreement extends IQuoteAttesterSigned {
   rootHash: ICredential['rootHash']
+  claimerDid: DidUri
   claimerSignature: DidSignature
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2181
## fixes KILTProtocol/ticket#2188

- Sign `claimerDid` and credential `rootHash` into quote agreement
- Check that attester signature can be matched to attesterDid and claimer signature to claimerDid
- Make Quote agreement verification easier with new `verifyQuoteAgreement` function. 

> __Note:__ This shares a commit (01bf6fd1a98d5a75a18d90491c97b220ca94bb68) with https://github.com/KILTprotocol/sdk-js/pull/674.

## How to test:

Unit tests included

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
