### PR TITLE
chore: update type definitions

### DIFF
--- a/packages/type-definitions/src/index.ts
+++ b/packages/type-definitions/src/index.ts
@@ -24,6 +24,7 @@ import { types25 } from './types_25.js'
 import { types2700 } from './types_2700.js'
 import { types10720 } from './types_10720.js'
 import { types10800 } from './types_10800.js'
+import { types10900 } from './types_10900.js'
 
 // Custom runtime calls
 
@@ -45,7 +46,8 @@ export {
   types2700,
   types10720,
   types10800,
-  types10800 as types,
+  types10900,
+  types10900 as types,
 }
 
 export { calls as didCalls } from './runtime/did.js'
@@ -105,8 +107,12 @@ const defaultTypesBundle: OverrideVersionedType[] = [
     types: types10720,
   },
   {
-    minmax: [10800, undefined],
+    minmax: [10800, 10899],
     types: types10800,
+  },
+  {
+    minmax: [10900, undefined],
+    types: types10900,
   },
 ]
 

--- a/packages/type-definitions/src/types_10800.ts
+++ b/packages/type-definitions/src/types_10800.ts
@@ -11,8 +11,6 @@ import { types10720 } from './types_10720.js'
 
 export const types10800: RegistryTypes = {
   ...types10720,
-  // DID state_call v2
-  DidApiAccountId: 'PalletDidLookupLinkableAccountLinkableAccountId',
 
   // Staking get_staking_rates
   StakingRates: {

--- a/packages/type-definitions/src/types_10900.ts
+++ b/packages/type-definitions/src/types_10900.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2018-2022, BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import type { RegistryTypes } from '@polkadot/types/types'
+
+import { types10800 } from './types_10800.js'
+
+export const types10900: RegistryTypes = {
+  ...types10800,
+  // DID state_call v2
+  DidApiAccountId: 'PalletDidLookupLinkableAccountLinkableAccountId',
+}


### PR DESCRIPTION
Ethereum linking has been pushed to the next release 1.9.0, so this PR updates the types accordingly.