### PR TITLE
fix: add peregrine stg chain to type decorations

### DIFF
--- a/packages/type-definitions/src/index.ts
+++ b/packages/type-definitions/src/index.ts
@@ -145,6 +145,14 @@ export const typesBundle: OverrideBundleType = {
       },
       types: defaultTypesBundle,
     },
+    'KILT Peregrine Stagenet': {
+      runtime: {
+        ...didCalls,
+        ...stakingCalls,
+        ...publicCredentialsCalls,
+      },
+      types: defaultTypesBundle,
+    },
     'KILT Peregrine Develop': {
       runtime: {
         ...didCalls,


### PR DESCRIPTION
## no ticket
* adds Peregrine Staging Chain name to type decorations

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
