### PR TITLE
refactor: rename types10900 to types10902

### DIFF
--- a/packages/type-definitions/src/index.ts
+++ b/packages/type-definitions/src/index.ts
@@ -24,7 +24,7 @@ import { types25 } from './types_25.js'
 import { types2700 } from './types_2700.js'
 import { types10720 } from './types_10720.js'
 import { types10800 } from './types_10800.js'
-import { types10900 } from './types_10900.js'
+import { types10902 } from './types_10902.js'
 
 // Custom runtime calls
 
@@ -47,8 +47,8 @@ export {
   types2700,
   types10720,
   types10800,
-  types10900,
-  types10900 as types,
+  types10902,
+  types10902 as types,
 }
 
 export { calls as didCalls } from './runtime/did.js'
@@ -109,12 +109,12 @@ const defaultTypesBundle: OverrideVersionedType[] = [
     types: types10720,
   },
   {
-    minmax: [10800, 10899],
+    minmax: [10800, 10901],
     types: types10800,
   },
   {
-    minmax: [10900, undefined],
-    types: types10900,
+    minmax: [10902, undefined],
+    types: types10902,
   },
 ]
 

--- a/packages/type-definitions/src/types_10902.ts
+++ b/packages/type-definitions/src/types_10902.ts
@@ -9,7 +9,7 @@ import type { RegistryTypes } from '@polkadot/types/types'
 
 import { types10800 } from './types_10800.js'
 
-export const types10900: RegistryTypes = {
+export const types10902: RegistryTypes = {
   ...types10800,
   // DID state_call v2
   DidApiAccountId: 'PalletDidLookupLinkableAccountLinkableAccountId',


### PR DESCRIPTION
## no ticket

Unfortunately, I used the incorrect WASM for the upgrade of Peregrine to 1.8.0. A WASM with spec version 10900 was used but without the Ethereum Migration. Since we cannot downgrade spec versions, I will fix the Peregrine spec version by bumping to 10901. As a result, Ethereum accounts will be supported from 10902 onwards instead of 10900.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
