### PR TITLE
feat: backwards-compatible ctype data decoding

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,6 +149,7 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
+        'no-console': 'off',
       },
     },
     {
@@ -156,6 +157,7 @@ module.exports = {
       rules: {
         'import/extensions': 'off',
         'jsdoc/require-jsdoc': 'off',
+        'no-console': 'off',
       },
     },
     {

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -27,8 +27,13 @@ let api: ApiPromise
 let hasBlockNumbers: boolean
 beforeAll(async () => {
   api = await initializeApi()
-  // @ts-ignore not decorated for some reason
+  // this extrinsic should only exist in the new pallet version
   hasBlockNumbers = typeof api.tx.ctype.setBlockNumber !== 'undefined'
+  if (!hasBlockNumbers) {
+    console.warn(
+      'detected pallet version 1, skipping CType fetching which is not yet supported'
+    )
+  }
 }, 30_000)
 
 describe('When there is an CtypeCreator and a verifier', () => {

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -27,11 +27,11 @@ let api: ApiPromise
 let hasBlockNumbers: boolean
 beforeAll(async () => {
   api = await initializeApi()
-  // this extrinsic should only exist in the new pallet version
-  hasBlockNumbers = typeof api.tx.ctype.setBlockNumber !== 'undefined'
+  // @ts-ignore Not augmented for some reason
+  hasBlockNumbers = (await api.query.ctype.palletVersion()).toNumber() >= 2
   if (!hasBlockNumbers) {
     console.warn(
-      'detected pallet version 1, skipping CType fetching which is not yet supported'
+      'detected pallet version < 2, skipping CType fetching which is not yet supported'
     )
   }
 }, 30_000)

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -157,6 +157,10 @@ export async function fetchFromChain(
 
   const cTypeEntry = await api.query.ctype.ctypes(cTypeHash)
   const { createdAt } = fromChain(cTypeEntry)
+  if (typeof createdAt === 'undefined')
+    throw new SDKErrors.CTypeError(
+      'Cannot fetch CType definitions on a chain that does not store the createdAt block'
+    )
 
   const extrinsic = await retrieveExtrinsicFromBlock(
     api,


### PR DESCRIPTION
Makes sure the sdk still decodes CType records from before the chain upgrade to 0.9.0 / 0.8.5.
Adjust tests so that CType fetching is skipped where not available.

## How to test:

We should no longer see the `Invalid empty address passed` errors in integration tests against `latest` (e.g., https://github.com/KILTprotocol/sdk-js/actions/runs/4003744234/jobs/6872161008).
~Fetching CType data will still fail with `Cannot fetch CType definitions on a chain that does not store the createdAt block`.~

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
