### PR TITLE
feat: allow passing additional arguments to ApiPromise.create

### DIFF
--- a/packages/core/src/__integrationtests__/utils.ts
+++ b/packages/core/src/__integrationtests__/utils.ts
@@ -9,7 +9,7 @@
 /* eslint-disable no-console */
 
 import { BN } from '@polkadot/util'
-import { ApiPromise, WsProvider } from '@polkadot/api'
+import { ApiPromise } from '@polkadot/api'
 import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers'
 
 import { Crypto } from '@kiltprotocol/utils'
@@ -23,11 +23,10 @@ import type {
   SubmittableExtrinsic,
   SubscriptionPromise,
 } from '@kiltprotocol/types'
-import { typesBundle } from '@kiltprotocol/type-definitions'
 import { ConfigService } from '@kiltprotocol/config'
 
 import * as CType from '../ctype'
-import { init } from '../kilt'
+import { connect, init } from '../kilt'
 
 export const EXISTENTIAL_DEPOSIT = new BN(10 ** 13)
 const ENDOWMENT = EXISTENTIAL_DEPOSIT.muln(10000)
@@ -54,10 +53,8 @@ async function getStartedTestContainer(): Promise<StartedTestContainer> {
 }
 
 async function buildConnection(wsEndpoint: string): Promise<ApiPromise> {
-  const provider = new WsProvider(wsEndpoint)
-  const api = new ApiPromise({ provider, typesBundle })
-  await init({ api, submitTxResolveOn: Blockchain.IS_IN_BLOCK })
-  return api.isReadyOrError
+  await init({ submitTxResolveOn: Blockchain.IS_IN_BLOCK })
+  return connect(wsEndpoint)
 }
 
 export async function initializeApi(): Promise<ApiPromise> {

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -37,7 +37,8 @@ export async function init<K extends Partial<ConfigService.configOpts>>(
  *
  * @param blockchainRpcWsUrl WebSocket URL of the RPC endpoint exposed by a node that is part of the Kilt blockchain network you wish to connect to.
  * @param apiOpts Additional parameters to be passed to ApiPromise.create().
- * @param apiOpts.noInitWarn Allows suppressing warnings related to runtime types and augmentation. Enabled by default if the global log level is 'error' or higher.
+ * @param apiOpts.noInitWarn Allows suppressing warnings related to runtime types and augmentation.
+ * By default warnings are shown if the global log level is 'warn' or lower and disabled on 'error' or higher.
  * @returns An instance of ApiPromise.
  */
 export async function connect(

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -14,6 +14,7 @@
 
 import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { ApiPromise, WsProvider } from '@polkadot/api'
+import type { ApiOptions } from '@polkadot/api/types'
 
 import { ConfigService } from '@kiltprotocol/config'
 import { typesBundle } from '@kiltprotocol/type-definitions'
@@ -35,13 +36,23 @@ export async function init<K extends Partial<ConfigService.configOpts>>(
  * Connects to the KILT Blockchain and passes the initialized api instance to `init()`, making it available for functions in the sdk.
  *
  * @param blockchainRpcWsUrl WebSocket URL of the RPC endpoint exposed by a node that is part of the Kilt blockchain network you wish to connect to.
+ * @param apiOpts Additional parameters to be passed to ApiPromise.create().
+ * @param apiOpts.noInitWarn Allows suppressing warnings related to runtime types and augmentation. Enabled by default if the global log level is 'error' or higher.
  * @returns An instance of ApiPromise.
  */
-export async function connect(blockchainRpcWsUrl: string): Promise<ApiPromise> {
+export async function connect(
+  blockchainRpcWsUrl: string,
+  {
+    noInitWarn = ConfigService.get('logLevel') > 3, // by default warnings are disabled on log level error and higher
+    ...apiOpts
+  }: Omit<ApiOptions, 'provider'> = {}
+): Promise<ApiPromise> {
   const provider = new WsProvider(blockchainRpcWsUrl)
   const api = await ApiPromise.create({
     provider,
     typesBundle,
+    noInitWarn,
+    ...apiOpts,
   })
   await init({ api })
   return api.isReadyOrError


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2385

Allows passing additional arguments for ApiPromise.create in `connect()` via a second parameter.
Furthermore, sets the default value of one of them (`noInitWarn`) based on the current log level.

## How to test:

Calling `connect` should produce more log output concerning types and augmentation if the log level had been set to 3 and below compared to setting it to 4 or 5.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
