### PR TITLE
refactor!: fetch attestation as part of verifyCredential

### DIFF
--- a/packages/core/src/__integrationtests__/Delegation.spec.ts
+++ b/packages/core/src/__integrationtests__/Delegation.spec.ts
@@ -195,7 +195,7 @@ describe('and attestation rights have been delegated', () => {
     await expect(
       Credential.verifySignature(presentation)
     ).resolves.not.toThrow()
-    await Credential.verifyPresentation(presentation)
+    Credential.verifyWellFormed(presentation, { ctype: driversLicenseCType })
 
     const attestation = Attestation.fromCredentialAndDid(
       credential,

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -138,7 +138,8 @@ export function verifyAgainstCredential(
 ): void {
   if (
     credential.claim.cTypeHash !== attestation.cTypeHash ||
-    credential.rootHash !== attestation.claimHash
+    credential.rootHash !== attestation.claimHash ||
+    credential.delegationId !== attestation.delegationId
   ) {
     throw new SDKErrors.CredentialUnverifiableError(
       'Attestation does not match credential'

--- a/packages/core/src/attestation/Attestation.ts
+++ b/packages/core/src/attestation/Attestation.ts
@@ -136,13 +136,22 @@ export function verifyAgainstCredential(
   attestation: IAttestation,
   credential: ICredential
 ): void {
-  if (
-    credential.claim.cTypeHash !== attestation.cTypeHash ||
-    credential.rootHash !== attestation.claimHash ||
+  const credentialMismatch =
+    credential.claim.cTypeHash !== attestation.cTypeHash
+  const ctypeMismatch = credential.rootHash !== attestation.claimHash
+  const delegationMismatch =
     credential.delegationId !== attestation.delegationId
-  ) {
+  if (credentialMismatch || ctypeMismatch || delegationMismatch) {
     throw new SDKErrors.CredentialUnverifiableError(
-      'Attestation does not match credential'
+      `Some attributes of the on-chain attestation diverge from the credential: ${[
+        'cTypeHash',
+        'delegationId',
+        'claimHash',
+      ]
+        .filter(
+          (_, i) => [ctypeMismatch, delegationMismatch, credentialMismatch][i]
+        )
+        .join(', ')}`
     )
   }
   Credential.verifyDataIntegrity(credential)

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -408,7 +408,7 @@ describe('Credential', () => {
     await expect(
       Credential.refreshRevocationStatus({ ...credential, revoked, attester })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Attestation does not match credential"`
+      `"Some attributes of the on-chain attestation diverge from the credential: claimHash"`
     )
 
     jest.mocked(api.query.attestation.attestations).mockResolvedValueOnce(
@@ -426,7 +426,7 @@ describe('Credential', () => {
     await expect(
       Credential.refreshRevocationStatus({ ...credential, revoked, attester })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Attestation does not match credential"`
+      `"Some attributes of the on-chain attestation diverge from the credential: delegationId"`
     )
   })
 })

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -365,7 +365,7 @@ describe('Credential', () => {
     await expect(
       Credential.refreshRevocationStatus(credential as any)
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Attester has changed since first verification"`
+      `"This function expects a VerifiedCredential with properties \`revoked\` (boolean) and \`attester\` (string)"`
     )
 
     jest

--- a/packages/core/src/credential/Credential.spec.ts
+++ b/packages/core/src/credential/Credential.spec.ts
@@ -28,14 +28,17 @@ import type {
 import { Crypto, SDKErrors, UUID } from '@kiltprotocol/utils'
 import * as Did from '@kiltprotocol/did'
 import {
+  ApiMocks,
   createLocalDemoFullDidFromKeypair,
   KeyTool,
   makeSigningKeyTool,
 } from '@kiltprotocol/testing'
+import { ConfigService } from '@kiltprotocol/config'
 import * as Attestation from '../attestation'
 import * as Claim from '../claim'
 import * as CType from '../ctype'
 import * as Credential from './Credential'
+import { init } from '../kilt'
 
 const testCType = CType.fromProperties('Credential', {
   a: { type: 'string' },
@@ -62,6 +65,20 @@ function buildCredential(
   return credential
 }
 
+beforeAll(async () => {
+  const api = ApiMocks.createAugmentedApi()
+  api.query.attestation = {
+    attestations: jest.fn().mockResolvedValue(
+      ApiMocks.mockChainQueryReturn('attestation', 'attestations', {
+        revoked: false,
+        attester: '4s5d7QHWSX9xx4DLafDtnTHK87n5e9G3UoKRrCDQ2gnrzYmZ',
+        ctypeHash: CType.idToHash(testCType.$id),
+      } as any)
+    ),
+  } as any
+  await init({ api })
+})
+
 describe('Credential', () => {
   const identityAlice =
     'did:kilt:4nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS'
@@ -85,9 +102,11 @@ describe('Credential', () => {
     )
     // check proof on complete data
     expect(() => Credential.verifyDataIntegrity(credential)).not.toThrow()
-    await Credential.verifyCredential(credential, {
-      ctype: testCType,
-    })
+    await expect(
+      Credential.verifyCredential(credential, {
+        ctype: testCType,
+      })
+    ).resolves.toMatchObject({ revoked: false, attester: identityBob })
 
     // just deleting a field will result in a wrong proof
     delete credential.claimNonceMap[Object.keys(credential.claimNonceMap)[0]]
@@ -287,11 +306,19 @@ describe('Credential', () => {
       []
     )
     expect(() =>
-      Credential.verifyAgainstCType(builtCredential, testCType)
+      Credential.verifyWellFormed(builtCredential, { ctype: testCType })
     ).not.toThrow()
-    builtCredential.claim.contents.name = 123
+    const builtCredentialWrong = buildCredential(
+      identityBob,
+      {
+        a: 'a',
+        b: 'b',
+        c: 1,
+      },
+      []
+    )
     expect(() =>
-      Credential.verifyAgainstCType(builtCredential, testCType)
+      Credential.verifyWellFormed(builtCredentialWrong, { ctype: testCType })
     ).toThrow()
   })
 
@@ -378,6 +405,16 @@ describe('Presentations', () => {
       [],
       keyAlice.getSignCallback(identityAlice)
     )
+
+    jest
+      .mocked(ConfigService.get('api').query.attestation.attestations)
+      .mockResolvedValue(
+        ApiMocks.mockChainQueryReturn('attestation', 'attestations', {
+          revoked: false,
+          attester: Did.toChain(identityBob.uri),
+          ctypeHash: CType.idToHash(testCType.$id),
+        } as any) as any
+      )
   })
 
   it('verify credentials signed by a full DID', async () => {
@@ -395,9 +432,11 @@ describe('Presentations', () => {
 
     // check proof on complete data
     expect(() => Credential.verifyDataIntegrity(presentation)).not.toThrow()
-    await Credential.verifyPresentation(presentation, {
-      didResolveKey,
-    })
+    await expect(
+      Credential.verifyPresentation(presentation, {
+        didResolveKey,
+      })
+    ).resolves.toMatchObject({ revoked: false, attester: identityBob.uri })
   })
   it('verify credentials signed by a light DID', async () => {
     const { getSignCallback, authentication } = makeSigningKeyTool('ed25519')
@@ -419,9 +458,11 @@ describe('Presentations', () => {
 
     // check proof on complete data
     expect(() => Credential.verifyDataIntegrity(presentation)).not.toThrow()
-    await Credential.verifyPresentation(presentation, {
-      didResolveKey,
-    })
+    await expect(
+      Credential.verifyPresentation(presentation, {
+        didResolveKey,
+      })
+    ).resolves.toMatchObject({ revoked: false, attester: identityBob.uri })
   })
 
   it('throws if signature is missing on credential presentation', async () => {
@@ -658,6 +699,16 @@ describe('create presentation', () => {
         migratedClaimerFullDid.uri
       )
     )
+
+    jest
+      .mocked(ConfigService.get('api').query.attestation.attestations)
+      .mockResolvedValue(
+        ApiMocks.mockChainQueryReturn('attestation', 'attestations', {
+          revoked: false,
+          attester: Did.toChain(attester.uri),
+          ctypeHash: CType.idToHash(ctype.$id),
+        } as any) as any
+      )
   })
 
   it('should create presentation and exclude specific attributes using a full DID', async () => {
@@ -670,9 +721,11 @@ describe('create presentation', () => {
       ),
       challenge,
     })
-    await Credential.verifyPresentation(presentation, {
-      didResolveKey,
-    })
+    await expect(
+      Credential.verifyPresentation(presentation, {
+        didResolveKey,
+      })
+    ).resolves.toMatchObject({ revoked: false, attester: attester.uri })
     expect(presentation.claimerSignature?.challenge).toEqual(challenge)
   })
   it('should create presentation and exclude specific attributes using a light DID', async () => {
@@ -697,9 +750,11 @@ describe('create presentation', () => {
       ),
       challenge,
     })
-    await Credential.verifyPresentation(presentation, {
-      didResolveKey,
-    })
+    await expect(
+      Credential.verifyPresentation(presentation, {
+        didResolveKey,
+      })
+    ).resolves.toMatchObject({ revoked: false, attester: attester.uri })
     expect(presentation.claimerSignature?.challenge).toEqual(challenge)
   })
   it('should create presentation and exclude specific attributes using a migrated DID', async () => {
@@ -726,9 +781,11 @@ describe('create presentation', () => {
       ),
       challenge,
     })
-    await Credential.verifyPresentation(presentation, {
-      didResolveKey,
-    })
+    await expect(
+      Credential.verifyPresentation(presentation, {
+        didResolveKey,
+      })
+    ).resolves.toMatchObject({ revoked: false, attester: attester.uri })
     expect(presentation.claimerSignature?.challenge).toEqual(challenge)
   })
 
@@ -795,9 +852,13 @@ describe('create presentation', () => {
   })
 
   it('should verify the credential claims structure against the ctype', () => {
-    expect(() => Credential.verifyAgainstCType(credential, ctype)).not.toThrow()
+    expect(() =>
+      CType.verifyClaimAgainstSchema(credential.claim.contents, ctype)
+    ).not.toThrow()
     credential.claim.contents.name = 123
 
-    expect(() => Credential.verifyAgainstCType(credential, ctype)).toThrow()
+    expect(() =>
+      CType.verifyClaimAgainstSchema(credential.claim.contents, ctype)
+    ).toThrow()
   })
 })

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -333,12 +333,16 @@ export async function verifyAttested(
     owner: attester,
     revoked,
   } = Attestation.fromChain(maybeAttestation, rootHash)
-  if (
-    credential.claim.cTypeHash !== cTypeHash ||
-    credential.delegationId !== delegationId
-  ) {
+  const ctypeMismatch = credential.claim.cTypeHash !== cTypeHash
+  const delegationMismatch = credential.delegationId !== delegationId
+  if (ctypeMismatch || delegationMismatch) {
     throw new SDKErrors.CredentialUnverifiableError(
-      'Attestation does not match credential'
+      `Some attributes of the on-chain attestation diverge from the credential: ${[
+        'cTypeHash',
+        'delegationId',
+      ]
+        .filter((_, i) => [ctypeMismatch, delegationMismatch][i])
+        .join(', ')})}`
     )
   }
   if (revoked && allowRevoked !== true) {

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -344,6 +344,14 @@ export interface VerifiedCredential extends ICredential {
 export async function refreshRevocationStatus(
   verifiedCredential: VerifiedCredential
 ): Promise<VerifiedCredential> {
+  if (
+    typeof verifiedCredential.attester !== 'string' ||
+    typeof verifiedCredential.revoked !== 'boolean'
+  ) {
+    throw new TypeError(
+      'This function expects a VerifiedCredential with properties `revoked` (boolean) and `attester` (string)'
+    )
+  }
   const { revoked, attester } = await verifyAttested(verifiedCredential)
   if (attester !== verifiedCredential.attester) {
     throw new SDKErrors.CredentialUnverifiableError(

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -286,7 +286,7 @@ type VerifyOptions = {
 /**
  * Verifies data structure & data integrity of a credential object.
  * This combines all offline sanity checks that can be performed on an ICredential object.
- * A credential is valid only iff it is well formed and there is an onchain attestation record referencing its root hash.
+ * A credential is valid only if it is well formed AND there is an on-chain attestation record referencing its root hash.
  * To check the latter condition as well, you need to call [[verifyCredential]] or [[verifyPresentation]].
  *
  * @param credential - The object to check.
@@ -306,10 +306,10 @@ export function verifyWellFormed(
 }
 
 /**
- * Queries the attestation record for a credential and matches their data. Fails if no attestation exists, if it is revoked, or if the attester is unknown.
+ * Queries the attestation record for a credential and matches their data. Fails if no attestation exists, if it is revoked, or if the attestation data does not match the credential.
  *
  * @param credential The [[ICredential]] whose attestation status should be checked.
- * @returns Information on the attester and revocation status of the on-chain attestation, as well as info on which trust policy led to acceptance of the credential.
+ * @returns Information on the attester and revocation status of the on-chain attestation.
  */
 export async function verifyAttested(credential: ICredential): Promise<{
   attester: DidUri
@@ -354,7 +354,9 @@ export async function refreshRevocationStatus(
 }
 
 /**
- * Verifies a credential, which includes looking up its attestation on the KILT blockchain.
+ * Performs all steps to verify a credential (unsigned), which includes verifying data structure, data integrity, and looking up its attestation on the KILT blockchain.
+ * In most cases, credentials submitted by a third party would be expected to be signed (a 'presentation').
+ * To verify the additional signature as well, use `verifyPresentation`.
  *
  * @param credential - The object to check.
  * @param options - Additional parameter for more verification steps.
@@ -374,9 +376,10 @@ export async function verifyCredential(
 }
 
 /**
- * Verifies data structure, data integrity and the claimer's signature of a credential presentation.
+ * Performs all steps to verify a credential presentation (signed).
+ * In addition to verifying data structure, data integrity, and looking up the attestation record on the KILT blockchain, this involves verifying the claimer's signature over the credential.
  *
- * Upon presentation of a credential, a verifier would call this function.
+ * This is the function verifiers would typically call upon receiving a credential presentation from a third party.
  *
  * @param presentation - The object to check.
  * @param options - Additional parameter for more verification steps.

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -309,7 +309,7 @@ export function verifyWellFormed(
  * Queries the attestation record for a credential and matches their data. Fails if no attestation exists, if it is revoked, or if the attestation data does not match the credential.
  *
  * @param credential The [[ICredential]] whose attestation status should be checked.
- * @returns Information on the attester and revocation status of the on-chain attestation.
+ * @returns An object containing the `attester` DID and `revoked` status of the on-chain attestation.
  */
 export async function verifyAttested(credential: ICredential): Promise<{
   attester: DidUri
@@ -339,7 +339,8 @@ export interface VerifiedCredential extends ICredential {
  * Updates the revocation status of a previously verified credential to allow checking if it is still valid.
  *
  * @param verifiedCredential The output of [[verifyCredential]] or [[verifyPresentation]], which adds a `revoked` and `attester` property.
- * @returns A promise of resolving to the same object but with the `revoked` property updated. The promise rejects if the attestation has been deleted or its data changed since verification.
+ * @returns A promise of resolving to the same object but with the `revoked` property updated.
+ * The promise rejects if the attestation has been deleted or its data changed since verification.
  */
 export async function refreshRevocationStatus(
   verifiedCredential: VerifiedCredential
@@ -369,6 +370,7 @@ export async function refreshRevocationStatus(
  * @param credential - The object to check.
  * @param options - Additional parameter for more verification steps.
  * @param options.ctype - CType which the included claim should be checked against.
+ * @returns A [[VerifiedCredential]] object, which is the orignal credential with two additional properties: a boolean `revoked` status flag and the `attester` DID.
  */
 export async function verifyCredential(
   credential: ICredential,
@@ -385,15 +387,21 @@ export async function verifyCredential(
 
 /**
  * Performs all steps to verify a credential presentation (signed).
- * In addition to verifying data structure, data integrity, and looking up the attestation record on the KILT blockchain, this involves verifying the claimer's signature over the credential.
+ * In addition to verifying data structure, data integrity, and looking up the attestation record on the KILT blockchain,
+ * this involves verifying the claimer's signature over the credential.
  *
  * This is the function verifiers would typically call upon receiving a credential presentation from a third party.
+ * The attester's identity and the credential revocation status returned by this function would then be either displayed to an end user
+ * or processed in application logic deciding whether to accept or reject a credential submission
+ * (e.g., by matching the attester DID against an allow-list of trusted attesters).
  *
  * @param presentation - The object to check.
  * @param options - Additional parameter for more verification steps.
  * @param options.ctype - CType which the included claim should be checked against.
  * @param options.challenge -  The expected value of the challenge. Verification will fail in case of a mismatch.
  * @param options.didResolveKey - The function used to resolve the claimer's key. Defaults to [[resolveKey]].
+ * @returns A [[VerifiedCredential]] object, which is the orignal credential presentation with two additional properties:
+ * a boolean `revoked` status flag and the `attester` DID.
  */
 export async function verifyPresentation(
   presentation: ICredentialPresentation,

--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -289,56 +289,6 @@ export function fromClaim(
   return credential
 }
 
-type VerifyOptions = {
-  ctype?: ICType
-  challenge?: string
-  didResolveKey?: DidResolveKey
-}
-
-/**
- * Verifies data structure & data integrity of a credential object.
- * THIS DOES NOT VERIFY THAT A CREDENTIAL HAS BEEN ATTESTED, OR BY WHOM!
- * For this, you need to call [[verifyAttestation]].
- *
- * @param credential - The object to check.
- * @param options - Additional parameter for more verification steps.
- * @param options.ctype - CType which the included claim should be checked against.
- */
-export async function verifyCredential(
-  credential: ICredential,
-  { ctype }: VerifyOptions = {}
-): Promise<void> {
-  verifyDataStructure(credential)
-  verifyDataIntegrity(credential)
-
-  if (ctype) {
-    verifyAgainstCType(credential, ctype)
-  }
-}
-
-/**
- * Verifies data structure, data integrity and the claimer's signature of a credential presentation.
- * THIS DOES NOT VERIFY THAT A CREDENTIAL HAS BEEN ATTESTED, OR BY WHOM!
- *
- * Upon presentation of a credential, a verifier would call this function, then call [[verifyAttestation]] to check the credential's attestation status.
- *
- * @param presentation - The object to check.
- * @param options - Additional parameter for more verification steps.
- * @param options.ctype - CType which the included claim should be checked against.
- * @param options.challenge -  The expected value of the challenge. Verification will fail in case of a mismatch.
- * @param options.didResolveKey - The function used to resolve the claimer's key. Defaults to [[resolveKey]].
- */
-export async function verifyPresentation(
-  presentation: ICredentialPresentation,
-  { ctype, challenge, didResolveKey = resolveKey }: VerifyOptions = {}
-): Promise<void> {
-  await verifyCredential(presentation, { ctype })
-  await verifySignature(presentation, {
-    challenge,
-    didResolveKey,
-  })
-}
-
 export interface TrustPolicy {
   /**
    * If set to true, attestations issued directly by this identity are accepted.
@@ -414,6 +364,61 @@ export async function verifyAttested(
   throw new SDKErrors.CredentialUnverifiableError(
     'This attestation does not match any given trust policy and thus is not trusted'
   )
+}
+
+type VerifyOptions = {
+  ctype?: ICType
+  challenge?: string
+  didResolveKey?: DidResolveKey
+  allowedAuthorities?: TrustPolicies
+  allowRevoked?: boolean
+}
+
+/**
+ * Verifies data structure & data integrity of a credential object and its on-chain attestation.
+ *
+ * @param credential - The object to check.
+ * @param options - Additional parameter for more verification steps.
+ * @param options.ctype - CType which the included claim should be checked against.
+ * @param options.allowedAuthorities A map from DIDs to trust policies to be applied for that DID. If the credential's attestation cannot be linked to one of the identies in this set, verifiation will fail. If omitted, the issuer of the attestation will not be checked.
+ * @param options.allowRevoked If true, a revoked attestation will not fail verification.
+ */
+export async function verifyCredential(
+  credential: ICredential,
+  { ctype, allowedAuthorities, allowRevoked }: VerifyOptions = {}
+): Promise<void> {
+  verifyDataStructure(credential)
+  verifyDataIntegrity(credential)
+
+  if (ctype) {
+    verifyAgainstCType(credential, ctype)
+  }
+
+  await verifyAttested(credential, allowedAuthorities, allowRevoked)
+}
+
+/**
+ * Verifies data structure, data integrity and the claimer's signature of a credential presentation.
+ *
+ * Upon presentation of a credential, a verifier would call this function.
+ *
+ * @param presentation - The object to check.
+ * @param options - Additional parameter for more verification steps.
+ * @param options.challenge -  The expected value of the challenge. Verification will fail in case of a mismatch.
+ * @param options.didResolveKey - The function used to resolve the claimer's key. Defaults to [[resolveKey]].
+ * @param options.ctype - CType which the included claim should be checked against.
+ * @param options.allowedAuthorities A map from DIDs to trust policies to be applied for that DID. If the credential's attestation cannot be linked to one of the identies in this set, verifiation will fail. If omitted, the issuer of the attestation will not be checked.
+ * @param options.allowRevoked If true, a revoked attestation will not fail verification.
+ */
+export async function verifyPresentation(
+  presentation: ICredentialPresentation,
+  { challenge, didResolveKey = resolveKey, ...passDownOpts }: VerifyOptions = {}
+): Promise<void> {
+  await verifyCredential(presentation, passDownOpts)
+  await verifySignature(presentation, {
+    challenge,
+    didResolveKey,
+  })
 }
 
 /**

--- a/packages/core/src/delegation/DelegationNode.ts
+++ b/packages/core/src/delegation/DelegationNode.ts
@@ -341,14 +341,15 @@ export class DelegationNode implements IDelegationNode {
   /**
    * Checks on chain whether an identity with the given DID is delegating to the current node.
    *
-   * @param did The DID to search for.
+   * @param dids A DID or an array of DIDs to search for.
    *
    * @returns An object containing a `node` owned by the identity if it is delegating, plus the number of `steps` traversed. `steps` is 0 if the DID is owner of the current node.
    */
   public async findAncestorOwnedBy(
-    did: DidUri
+    dids: DidUri | DidUri[]
   ): Promise<{ steps: number; node: DelegationNode | null }> {
-    if (this.account === did) {
+    const acceptedDids = Array.isArray(dids) ? dids : [dids]
+    if (acceptedDids.includes(this.account)) {
       return {
         steps: 0,
         node: this,
@@ -362,7 +363,7 @@ export class DelegationNode implements IDelegationNode {
     }
     try {
       const parent = await fetch(this.parentId)
-      const result = await parent.findAncestorOwnedBy(did)
+      const result = await parent.findAncestorOwnedBy(acceptedDids)
       result.steps += 1
       return result
     } catch {


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/2397
### also fixes https://github.com/KILTprotocol/ticket/issues/2305

This changes the function signature of `verifyCredential` and `verifyPresentation` so that all verification steps are covered, including querying the attestation. They now return the credential enriched with attester and revocation info. Assertions about both are __NOT__ made, but these depend a lot on your application logic and are trivial to do with the data returned from these functions.

I like the idea of having a data model for a `VerifiedCredential` bc it allows introducing another function, called `refreshRevocationStatus` here, which queries the attestation again and throws not only failing if the attestation has been deleted or has been recreated with incoherent data, but also if it has been recreated by a different attester. This avoids potential exploits where a verifier who only checks the revoked flag once a credential has been verified is tricked by a claimer who simply self-attests their credential after the original attester had deleted the attestation.

If preferred, I could return just revocation status and attester though, which would then mean `refreshRevocationStatus` would take both the credential and the last status as input parameters.

## Usage Example

```js
const didsWithAccess = new Set()
try {
  const verifiedCredential = await verifyPresentation(presentation, {
    ctype,
    challenge,
  })
  if(verifiedCredential.revoke === false) {
    // access granted
    didsWithAccess.add(presentation.claim.owner)
  }
  // periodically recheck if credential is still valid
  setInterval(() => {
    recheckRevocationStatus(verifiedCredential)
      .then(c => if(c.revoked !== false) throw new Error())
      .catch(
        () => {
          // access revoked
          didsWithAccess.delete(presentation.claim.owner)
        }
      )
  }, 60_000)
} catch {
  // access denied
}
```

## How to test:

Test coverage in unit tests and integration tests has been added.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
