### PR TITLE
feat: credential verification derives

### DIFF
--- a/packages/core/src/credential/derives.ts
+++ b/packages/core/src/credential/derives.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018-2023, BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import { ICredential } from '@kiltprotocol/types'
+import { Observable } from '@polkadot/types/types'
+import { map } from 'rxjs'
+import type { DeriveApi } from '@polkadot/api-derive/types'
+import { memo } from '@polkadot/api-derive/util'
+import * as Attestation from '../attestation/index.js'
+
+type DeriveCreator<P extends any[], R> = (
+  instanceId: string,
+  api: DeriveApi
+) => (...args: P) => Observable<R>
+
+function makeDeriveCreator<P extends any[], R>(
+  implementationFactory: (api: DeriveApi) => (...args: P) => Observable<R>
+): DeriveCreator<P, R> {
+  return (instanceId, api) => {
+    return memo(instanceId, implementationFactory(api))
+  }
+}
+
+export const verifyAttested = makeDeriveCreator((api) => {
+  return (credential: ICredential) => {
+    return api.query.attestation.attestations(credential.rootHash).pipe(
+      map((attestationQueryResult) => {
+        try {
+          const attestation = Attestation.fromChain(
+            attestationQueryResult,
+            credential.rootHash
+          )
+          const { revoked, owner: attester } = attestation
+          Attestation.verifyAgainstCredential(attestation, credential)
+          return { attester, revoked }
+        } catch (error) {
+          return { error }
+        }
+      })
+    )
+  }
+})

--- a/packages/core/src/kilt/Kilt.ts
+++ b/packages/core/src/kilt/Kilt.ts
@@ -18,6 +18,7 @@ import type { ApiOptions } from '@polkadot/api/types'
 
 import { ConfigService } from '@kiltprotocol/config'
 import { typesBundle } from '@kiltprotocol/type-definitions'
+import { derives } from './derives.js'
 
 /**
  * Prepares crypto modules (required for identity creation and others) and calls ConfigService.set().
@@ -53,6 +54,7 @@ export async function connect(
     provider,
     typesBundle,
     noInitWarn,
+    derives,
     ...apiOpts,
   })
   await init({ api })

--- a/packages/core/src/kilt/derives.ts
+++ b/packages/core/src/kilt/derives.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2018-2023, BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import { AnyFunction, DeriveCustom } from '@polkadot/types/types'
+import * as credentials from '../credential/derives.js'
+
+const allDerives = {
+  credentials,
+}
+
+export const derives: DeriveCustom = allDerives
+
+type DeriveSection<Section> = {
+  [M in keyof Section]: Section[M] extends AnyFunction
+    ? ReturnType<Section[M]>
+    : never
+}
+type DeriveAllSections<AllSections> = {
+  [S in keyof AllSections]: DeriveSection<AllSections[S]>
+}
+
+declare module '@polkadot/api-derive/derive' {
+  // extend, add our custom section
+  export interface ExactDerive extends DeriveAllSections<typeof allDerives> {}
+}

--- a/packages/core/src/kilt/derives.ts
+++ b/packages/core/src/kilt/derives.ts
@@ -23,7 +23,8 @@ type DeriveAllSections<AllSections> = {
   [S in keyof AllSections]: DeriveSection<AllSections[S]>
 }
 
+// extends the api augmentation of derives
 declare module '@polkadot/api-derive/derive' {
-  // extend, add our custom section
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface ExactDerive extends DeriveAllSections<typeof allDerives> {}
 }

--- a/testDerive.mjs
+++ b/testDerive.mjs
@@ -1,0 +1,46 @@
+import { connect, disconnect } from '@kiltprotocol/core'
+
+const credential = {
+  claim: {
+    cTypeHash:
+      '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
+    contents: { Email: 'ingo@kilt.io' },
+    owner: 'did:kilt:4sJm5Zsvdi32hU88xbL3v6VQ877P4HLaWVYUXgcSyQR8URTu',
+  },
+  claimHashes: [
+    '0x8113c20adf617adb9fe3a2c61cc2614bf02cd58e0e42cb31356e7f5c052e65de',
+    '0xa19685266e47579ecd72c30b31a928eef0bd71b7d297511c8bef952f2a5822a1',
+  ],
+  claimNonceMap: {
+    '0x02eaa62e144281c9f73355cdb5e1f4edf27adc4e0510c2e60dca793c794dba6a':
+      'e8f78c9e-70b5-48ea-990f-97782bc62c84',
+    '0x1767f2220a9b07e22b73c5b36fa90e6f14338b6198e7696daf464914942734ab':
+      '1f454fcc-dc73-46d4-9478-db5e4c8dda3b',
+  },
+  legitimations: [],
+  delegationId: null,
+  rootHash:
+    '0x4fb274ed275ae1c3a719428088ffde0bbc10e456eba8aedc9687178a4ce47c20',
+  claimerSignature: {
+    keyId:
+      'did:kilt:4sJm5Zsvdi32hU88xbL3v6VQ877P4HLaWVYUXgcSyQR8URTu#0xad991c68c9f1c6c4f869fa19a217db30aff0f74963ca7e26206f7102b229df5b',
+    signature:
+      '0xfa71e745c21d7b4ec6f8d54ac5b2fea9bacf91ffb8f56b359a3e5af0119957030a28944011690d404c59ea814c5324298db0ef5b3332868bbdcf33b25bb9f388',
+  },
+}
+
+const api = await connect('wss://spiritnet.kilt.io')
+
+await api.derive.credentials
+  .verifyAttested(credential)
+  .then((result) => console.log(result))
+  .catch((e) => console.error('verification failed with ', e))
+
+await api.derive.credentials
+  .verifyAttested(credential)
+  .then((result) => console.log(result))
+  .catch((e) => console.error('verification failed with ', e))
+
+api.derive.credentials.verifyAttested(credential, (r, e) => console.log(r, e))
+
+//disconnect()


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/2397

Potential alternative to #708 & #702.

Instead of changing how `verifyCredential` & `verifyPresentation` work, we add a `verifyAttested` function that is to be called after these. 

Uses api derives to add credential verification functionality to the api object, with the following signature:

```js
const { attester, revoked, error } = await api.derive.credential.verifyAttested(credential)
```

This fetches the attestation and checks it against the credential as well, returning `revoked` status and `attester` if successful, and `error` if there is an issue.

__Pros__

- Subscriptions are possible.
- verifyCredential & verifyPresentation are left untouched.
- Bundles credential verification with the api.

__Cons__

-  Ultimately doesn't differ much from a function-based approach that calls api.query internally.
- Derives need to be added during api initialisation, so if people construct the api themselves they could forget.

## How to test:
_tbd_

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
