### PR TITLE
chore: add workflow for manual dispatch against a Docker node tag

### DIFF
--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -35,52 +35,6 @@ jobs:
           name: build
           path: build.zip
 
-  lint:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Use Node.js 14
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - uses: actions/download-artifact@v2
-        with:
-          name: build
-      - name: unzip
-        run: unzip build.zip -d .
-      - name: lint
-        run: yarn lint
-      - name: check dependency duplication
-        run: if ! yarn dedupe --check; then echo "::warning ::Dependencies may be deduplicated"; fi;
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-
-    strategy:
-      matrix:
-        node-version: [14, 16]
-        required: ['required']
-        include:
-          - node-version: 18
-            required: 'optional'
-
-    continue-on-error: ${{ matrix.required == 'optional' }}
-
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/download-artifact@v2
-        with:
-          name: build
-      - name: unzip
-        run: unzip build.zip -d .
-      - name: unit tests
-        run: yarn test:ci
-
   cache_imgs:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -1,0 +1,216 @@
+name: Test latest node release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker-image-tag-name:
+        type: string
+        description: The tag of the kiltprotocol/prototype-chain Docker image to test against
+        required: true
+
+env:
+  TESTCONTAINERS_WATCHER_IMG: testcontainers/ryuk:0.3.2
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+      - name: yarn install
+        run: yarn install --immutable
+      - name: yarn build
+        run: yarn build
+      - name: zip build
+        run: zip -r build.zip .
+      - name: upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build.zip
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+      - name: unzip
+        run: unzip build.zip -d .
+      - name: lint
+        run: yarn lint
+      - name: check dependency duplication
+        run: if ! yarn dedupe --check; then echo "::warning ::Dependencies may be deduplicated"; fi;
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    strategy:
+      matrix:
+        node-version: [14, 16]
+        required: ['required']
+        include:
+          - node-version: 18
+            required: 'optional'
+
+    continue-on-error: ${{ matrix.required == 'optional' }}
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+      - name: unzip
+        run: unzip build.zip -d .
+      - name: unit tests
+        run: yarn test:ci
+
+  cache_imgs:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: make sure testcontainers image is in cache
+        uses: ./.github/actions/cached-image-pull
+        with:
+          image: ${{ env.TESTCONTAINERS_WATCHER_IMG }}
+
+  integration_test:
+    runs-on: ubuntu-latest
+
+    needs: cache_imgs
+
+    steps:
+      - name: Log out node version
+        run: node --version
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Log out node version
+        run: node --version
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+      - name: unzip
+        run: unzip build.zip -d .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: pull image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: kilt/prototype-chain
+          IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
+        run: |
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "TESTCONTAINERS_NODE_IMG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+
+      - name: get cached testcontainers image
+        uses: ./.github/actions/cached-image-pull
+        with:
+          image: ${{ env.TESTCONTAINERS_WATCHER_IMG }}
+
+      - name: run integration tests
+        timeout-minutes: 60
+        run: yarn test:integration:ci
+
+  bundle_cache:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+      - name: unzip
+        run: unzip build.zip -d .
+      - name: yarn bundle
+        run: yarn bundle
+      - name: upload bundle artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: checked-nonmin-bundle
+          path: packages/sdk-js/dist/sdk-js.umd.js
+
+  bundle_test:
+    runs-on: ubuntu-latest
+
+    needs: [cache_imgs, bundle_cache]
+
+    steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+      - name: unzip
+        run: unzip build.zip -d .
+      - uses: actions/download-artifact@v2
+        with:
+          name: checked-nonmin-bundle
+          path: packages/sdk-js/dist
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - run: basename /packages/sdk-js/dist/
+      - name: pull node image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: kilt/prototype-chain
+          IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
+        run: |
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "TESTCONTAINERS_NODE_IMG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+      - name: get cached testcontainers image
+        uses: ./.github/actions/cached-image-pull
+        with:
+          image: ${{ env.TESTCONTAINERS_WATCHER_IMG }}
+      - name: prepare bundle tests
+        run: |
+          yarn test:ci:bundle:preparation
+      - name: run bundle tests
+        timeout-minutes: 60
+        run: |
+          yarn test:bundle


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2405.

It adds a manual dispatch workflow which takes a `tag` parameter representing the tag of the `kiltprotocol/prototype-chain` Docker image to use for integration tests. We can think of more advanced setups in the future, but for now this should work, and make it at least possible to test the SDK with a release candidate without any workarounds.