### PR TITLE
add: constant for well-Known-did-config context

### DIFF
--- a/packages/vc-export/src/constants.ts
+++ b/packages/vc-export/src/constants.ts
@@ -13,6 +13,9 @@ export const DEFAULT_VERIFIABLECREDENTIAL_CONTEXT =
 
 export const KILT_CREDENTIAL_CONTEXT_URL =
   'https://www.kilt.io/contexts/credentials'
+
+export const DID_CONFIGURATION_CONTEXT =
+      'https://identity.foundation/.well-known/did-configuration/v1';
 /**
  * Constant for default type.
  */


### PR DESCRIPTION
When creating a well-known-did-configuration VerifiableDomainLinkagePresentation, I can import all the required constants from here but one. That seems inconsistent to me. I suggest adding it.


