### PR TITLE
fix: current CType meta schema ignores additional properties in claim contents

### DIFF
--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -9,25 +9,33 @@ import { JsonSchema } from '@kiltprotocol/utils'
 
 export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
-  $id: 'ipfs://bafybeibjbq3tmmy7wuihhhwvbladjsd3gx3kfjepxzkq6wylik6wc3whzy',
+  $id: 'ipfs://bafybeifzfxz6tfd2xo7ijxbfceaxo3l655yg7sovlsnpxgq2rwfl4kbfgm',
   $schema: 'http://json-schema.org/draft-07/schema#',
-  additionalProperties: false,
+  title: 'CType Metaschema (V1)',
   description:
-    'Describes a CType, which is a json schema for validating KILT claim types.',
+    'Describes a CType, which is a JSON schema for validating KILT claim types.',
+  type: 'object',
   properties: {
     $id: { pattern: '^kilt:ctype:0x[0-9a-f]+$', type: 'string' },
     $schema: {
       type: 'string',
       // can't use a const referencing schema id for a content-addressed schema
     },
-    additionalProperties: { const: false, type: 'boolean' },
+    title: { type: 'string' },
+    type: { const: 'object', type: 'string' },
     properties: {
       patternProperties: {
-        '^.*$': {
+        '^.+$': {
           oneOf: [
             {
               additionalProperties: false,
-              properties: { $ref: { format: 'uri', type: 'string' } },
+              properties: {
+                $ref: {
+                  pattern: '^kilt:ctype:0x[0-9a-f]+(#/properties/.+)?$',
+                  format: 'uri',
+                  type: 'string',
+                },
+              },
               required: ['$ref'],
             },
             {
@@ -47,9 +55,9 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
       },
       type: 'object',
     },
-    title: { type: 'string' },
-    type: { const: 'object', type: 'string' },
+    additionalProperties: { const: false, type: 'boolean' },
   },
+  additionalProperties: false,
   required: [
     '$id',
     '$schema',
@@ -58,8 +66,6 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
     'title',
     'type',
   ],
-  title: 'CType Metaschema (V1)',
-  type: 'object',
 }
 
 export const CTypeModelDraft01: JsonSchema.Schema & { $id: string } = {

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -7,7 +7,7 @@
 
 import { JsonSchema } from '@kiltprotocol/utils'
 
-const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
+export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   $id: 'http://kilt-protocol.org/draft-01/ctype#',
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
@@ -65,7 +65,7 @@ const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   required: ['$id', 'title', '$schema', 'properties', 'type'],
 }
 
-const CTypeModelV2: JsonSchema.Schema & { $id: string } = {
+export const CTypeModelV2: JsonSchema.Schema & { $id: string } = {
   // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
   $id: 'ipfs://bafybeigphkblu3nvk5tpz4xog3flpv4h6o4x6fjml6haead3pul2mny3ee',
   $schema: 'http://json-schema.org/draft-07/schema#',

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -7,7 +7,7 @@
 
 import { JsonSchema } from '@kiltprotocol/utils'
 
-export const CTypeModel: JsonSchema.Schema = {
+const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   $id: 'http://kilt-protocol.org/draft-01/ctype#',
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
@@ -63,6 +63,101 @@ export const CTypeModel: JsonSchema.Schema = {
   },
   additionalProperties: false,
   required: ['$id', 'title', '$schema', 'properties', 'type'],
+}
+
+const CTypeModelV2: JsonSchema.Schema & { $id: string } = {
+  // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
+  $id: 'ipfs://bafybeigphkblu3nvk5tpz4xog3flpv4h6o4x6fjml6haead3pul2mny3ee',
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    $id: {
+      type: 'string',
+      pattern: '^kilt:ctype:0x[0-9a-f]+$',
+    },
+    $schema: {
+      type: 'string',
+      // can't use a const refercing schema id for a content-addressed schema
+    },
+    title: {
+      type: 'string',
+    },
+    type: {
+      type: 'string',
+      const: 'object',
+    },
+    additionalProperties: {
+      type: 'boolean',
+      const: false,
+    },
+    properties: {
+      type: 'object',
+      patternProperties: {
+        '^.*$': {
+          type: 'object',
+          oneOf: [
+            {
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: ['string', 'integer', 'number', 'boolean'],
+                },
+                format: {
+                  type: 'string',
+                  enum: ['date', 'time', 'uri'],
+                },
+              },
+              required: ['type'],
+              additionalProperties: false,
+            },
+            {
+              properties: {
+                $ref: {
+                  type: 'string',
+                  format: 'uri',
+                },
+              },
+              required: ['$ref'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+    },
+  },
+  additionalProperties: false,
+  required: [
+    '$id',
+    'title',
+    '$schema',
+    'properties',
+    'type',
+    'additionalProperties',
+  ],
+}
+
+export const CTypeModels: Record<string, JsonSchema.Schema> = Object.freeze({
+  [CTypeModelV1.$id]: CTypeModelV1,
+  [CTypeModelV2.$id]: CTypeModelV2,
+})
+
+export const CTypeModel: JsonSchema.Schema = {
+  oneOf: [
+    CTypeModelV1,
+    {
+      allOf: [
+        {
+          properties: {
+            $schema: {
+              type: 'string',
+              const: CTypeModelV2.$id,
+            },
+          },
+        },
+        CTypeModelV2,
+      ],
+    },
+  ],
 }
 
 export const MetadataModel = {

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -136,11 +136,6 @@ const CTypeModelV2: JsonSchema.Schema & { $id: string } = {
   ],
 }
 
-export const CTypeModels: Record<string, JsonSchema.Schema> = Object.freeze({
-  [CTypeModelV1.$id]: CTypeModelV1,
-  [CTypeModelV2.$id]: CTypeModelV2,
-})
-
 export const CTypeModel: JsonSchema.Schema = {
   oneOf: [
     CTypeModelV1,

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -18,7 +18,7 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
     $id: { pattern: '^kilt:ctype:0x[0-9a-f]+$', type: 'string' },
     $schema: {
       type: 'string',
-      // can't use a const refercing schema id for a content-addressed schema
+      // can't use a const referencing schema id for a content-addressed schema
     },
     additionalProperties: { const: false, type: 'boolean' },
     properties: {
@@ -66,7 +66,7 @@ export const CTypeModelDraft01: JsonSchema.Schema & { $id: string } = {
   $id: 'http://kilt-protocol.org/draft-01/ctype#',
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'CType Metaschema (draft-01)',
-  description: `Describes a CType, which is a json schema for validating KILT claim types. This version has known issues, the use of schema ${CTypeModelV1.$id} is recommended instead.`,
+  description: `Describes a CType, which is a JSON schema for validating KILT claim types. This version has known issues, the use of schema ${CTypeModelV1.$id} is recommended instead.`,
   type: 'object',
   properties: {
     $id: {

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -67,73 +67,54 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
 
 export const CTypeModelV2: JsonSchema.Schema & { $id: string } = {
   // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
-  $id: 'ipfs://bafybeigphkblu3nvk5tpz4xog3flpv4h6o4x6fjml6haead3pul2mny3ee',
+  $id: 'ipfs://bafybeigtj5ebagctpyfwl56sin54qwe4bltjcsu3j7nuq2uzrg6gs525fi',
   $schema: 'http://json-schema.org/draft-07/schema#',
-  type: 'object',
+  additionalProperties: false,
   properties: {
-    $id: {
-      type: 'string',
-      pattern: '^kilt:ctype:0x[0-9a-f]+$',
-    },
+    $id: { pattern: '^kilt:ctype:0x[0-9a-f]+$', type: 'string' },
     $schema: {
       type: 'string',
       // can't use a const refercing schema id for a content-addressed schema
     },
-    title: {
-      type: 'string',
-    },
-    type: {
-      type: 'string',
-      const: 'object',
-    },
-    additionalProperties: {
-      type: 'boolean',
-      const: false,
-    },
+    additionalProperties: { const: false, type: 'boolean' },
     properties: {
-      type: 'object',
       patternProperties: {
         '^.*$': {
-          type: 'object',
           oneOf: [
             {
+              additionalProperties: false,
+              properties: { $ref: { format: 'uri', type: 'string' } },
+              required: ['$ref'],
+            },
+            {
+              additionalProperties: false,
               properties: {
+                format: { enum: ['date', 'time', 'uri'], type: 'string' },
                 type: {
+                  enum: ['boolean', 'integer', 'number', 'string'],
                   type: 'string',
-                  enum: ['string', 'integer', 'number', 'boolean'],
-                },
-                format: {
-                  type: 'string',
-                  enum: ['date', 'time', 'uri'],
                 },
               },
               required: ['type'],
-              additionalProperties: false,
-            },
-            {
-              properties: {
-                $ref: {
-                  type: 'string',
-                  format: 'uri',
-                },
-              },
-              required: ['$ref'],
-              additionalProperties: false,
             },
           ],
+          type: 'object',
         },
       },
+      type: 'object',
     },
+    title: { type: 'string' },
+    type: { const: 'object', type: 'string' },
   },
-  additionalProperties: false,
   required: [
     '$id',
-    'title',
     '$schema',
-    'properties',
-    'type',
     'additionalProperties',
+    'properties',
+    'title',
+    'type',
   ],
+  type: 'object',
 }
 
 export const CTypeModel: JsonSchema.Schema = {

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -8,8 +8,65 @@
 import { JsonSchema } from '@kiltprotocol/utils'
 
 export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
+  // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
+  $id: 'ipfs://bafybeibjbq3tmmy7wuihhhwvbladjsd3gx3kfjepxzkq6wylik6wc3whzy',
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  additionalProperties: false,
+  description:
+    'Describes a CType, which is a json schema for validating KILT claim types.',
+  properties: {
+    $id: { pattern: '^kilt:ctype:0x[0-9a-f]+$', type: 'string' },
+    $schema: {
+      type: 'string',
+      // can't use a const refercing schema id for a content-addressed schema
+    },
+    additionalProperties: { const: false, type: 'boolean' },
+    properties: {
+      patternProperties: {
+        '^.*$': {
+          oneOf: [
+            {
+              additionalProperties: false,
+              properties: { $ref: { format: 'uri', type: 'string' } },
+              required: ['$ref'],
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                format: { enum: ['date', 'time', 'uri'], type: 'string' },
+                type: {
+                  enum: ['boolean', 'integer', 'number', 'string'],
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+            },
+          ],
+          type: 'object',
+        },
+      },
+      type: 'object',
+    },
+    title: { type: 'string' },
+    type: { const: 'object', type: 'string' },
+  },
+  required: [
+    '$id',
+    '$schema',
+    'additionalProperties',
+    'properties',
+    'title',
+    'type',
+  ],
+  title: 'CType Metaschema (V1)',
+  type: 'object',
+}
+
+export const CTypeModelDraft01: JsonSchema.Schema & { $id: string } = {
   $id: 'http://kilt-protocol.org/draft-01/ctype#',
   $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'CType Metaschema (draft-01)',
+  description: `Describes a CType, which is a json schema for validating KILT claim types. This version has known issues, the use of schema ${CTypeModelV1.$id} is recommended instead.`,
   type: 'object',
   properties: {
     $id: {
@@ -65,72 +122,20 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   required: ['$id', 'title', '$schema', 'properties', 'type'],
 }
 
-export const CTypeModelV2: JsonSchema.Schema & { $id: string } = {
-  // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
-  $id: 'ipfs://bafybeigtj5ebagctpyfwl56sin54qwe4bltjcsu3j7nuq2uzrg6gs525fi',
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  additionalProperties: false,
-  properties: {
-    $id: { pattern: '^kilt:ctype:0x[0-9a-f]+$', type: 'string' },
-    $schema: {
-      type: 'string',
-      // can't use a const refercing schema id for a content-addressed schema
-    },
-    additionalProperties: { const: false, type: 'boolean' },
-    properties: {
-      patternProperties: {
-        '^.*$': {
-          oneOf: [
-            {
-              additionalProperties: false,
-              properties: { $ref: { format: 'uri', type: 'string' } },
-              required: ['$ref'],
-            },
-            {
-              additionalProperties: false,
-              properties: {
-                format: { enum: ['date', 'time', 'uri'], type: 'string' },
-                type: {
-                  enum: ['boolean', 'integer', 'number', 'string'],
-                  type: 'string',
-                },
-              },
-              required: ['type'],
-            },
-          ],
-          type: 'object',
-        },
-      },
-      type: 'object',
-    },
-    title: { type: 'string' },
-    type: { const: 'object', type: 'string' },
-  },
-  required: [
-    '$id',
-    '$schema',
-    'additionalProperties',
-    'properties',
-    'title',
-    'type',
-  ],
-  type: 'object',
-}
-
 export const CTypeModel: JsonSchema.Schema = {
   oneOf: [
-    CTypeModelV1,
+    CTypeModelDraft01,
     {
       allOf: [
         {
           properties: {
             $schema: {
               type: 'string',
-              const: CTypeModelV2.$id,
+              const: CTypeModelV1.$id,
             },
           },
         },
-        CTypeModelV2,
+        CTypeModelV1,
       ],
     },
   ],

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -197,7 +197,6 @@ export const MetadataModel: JsonSchema.Schema = {
         },
         properties: {
           type: 'object',
-          properties: {},
           patternProperties: {
             '^.*$': {
               type: 'object',

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -159,7 +159,7 @@ export const CTypeModel: JsonSchema.Schema = {
   },
 }
 
-export const MetadataModel = {
+export const MetadataModel: JsonSchema.Schema = {
   $id: 'http://kilt-protocol.org/draft-01/ctype-metadata',
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -34,7 +34,7 @@ it('consistent CType id generation', () => {
   })
 
   expect(ctype.$id).toMatchInlineSnapshot(
-    `"kilt:ctype:0xdfe0fd007b86ef280f366d25547873da0305538d8190a2eae2f2d875cb5cf30d"`
+    `"kilt:ctype:0x12c8edb42b455aa6c29fabda8f3768bd1e8577f0618f122072828e41b6f4f728"`
   )
 })
 

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -28,13 +28,26 @@ const encodedAliceDid = ApiMocks.mockChainQueryReturn(
 const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
 
 it('consistent CType id generation', () => {
-  const ctype = CType.fromProperties('CtypeModel 1', {
+  const ctypeV1 = CType.fromProperties('CtypeModel 1', {
     'first-property': { type: 'integer' },
     'second-property': { type: 'string' },
   })
 
-  expect(ctype.$id).toMatchInlineSnapshot(
+  expect(ctypeV1.$id).toMatchInlineSnapshot(
     `"kilt:ctype:0x12c8edb42b455aa6c29fabda8f3768bd1e8577f0618f122072828e41b6f4f728"`
+  )
+
+  const ctypeV0 = CType.fromProperties(
+    'CtypeModel 1',
+    {
+      'first-property': { type: 'integer' },
+      'second-property': { type: 'string' },
+    },
+    'draft-01'
+  )
+
+  expect(ctypeV0.$id).toMatchInlineSnapshot(
+    `"kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84"`
   )
 })
 

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -34,7 +34,7 @@ it('consistent CType id generation', () => {
   })
 
   expect(ctype.$id).toMatchInlineSnapshot(
-    `"kilt:ctype:0x80b6203f477aa7454cfa10bd3900226e251398e8a9c47ecc526d718c47832e96"`
+    `"kilt:ctype:0x7ad15687b7e68a694c64cbe3b99a817e26a3bafc9aadb24d5fab19cff1eef319"`
   )
 })
 

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -15,7 +15,7 @@ import { ApiMocks } from '@kiltprotocol/testing'
 import type { ICType } from '@kiltprotocol/types'
 import * as Claim from '../claim'
 import * as CType from './CType.js'
-import { CTypeModel, CTypeModelV1 } from './CType.schemas'
+import { CTypeModel, CTypeModelDraft01 } from './CType.schemas'
 
 const mockedApi: any = ApiMocks.getMockedApi()
 ConfigService.set({ api: mockedApi })
@@ -34,7 +34,7 @@ it('consistent CType id generation', () => {
   })
 
   expect(ctype.$id).toMatchInlineSnapshot(
-    `"kilt:ctype:0x7ad15687b7e68a694c64cbe3b99a817e26a3bafc9aadb24d5fab19cff1eef319"`
+    `"kilt:ctype:0xdfe0fd007b86ef280f366d25547873da0305538d8190a2eae2f2d875cb5cf30d"`
   )
 })
 
@@ -84,7 +84,7 @@ describe('blank ctypes', () => {
   })
 })
 
-const cTypeV1: ICType = CType.fromProperties(
+const cTypeDraft01: ICType = CType.fromProperties(
   'name',
   {
     'first-property': { type: 'integer' },
@@ -93,12 +93,12 @@ const cTypeV1: ICType = CType.fromProperties(
   'draft-01'
 )
 
-const cTypeV2: ICType = CType.fromProperties('name', {
+const cTypeV1: ICType = CType.fromProperties('name', {
   'first-property': { type: 'integer' },
   'second-property': { type: 'string' },
 })
 
-describe.each([[cTypeV1], [cTypeV2]])(
+describe.each([[cTypeDraft01], [cTypeV1]])(
   'Claim verification with CType of schema version %#',
   (cType) => {
     const goodClaim = {
@@ -138,7 +138,7 @@ describe.each([[cTypeV1], [cTypeV2]])(
         SDKErrors.ObjectUnverifiableError
       )
       // only the CTypes following the newer model protect against additional properties
-      if (cType.$schema === CTypeModelV1.$id) {
+      if (cType.$schema === CTypeModelDraft01.$id) {
         expect(() =>
           CType.verifyClaimAgainstSchema(unexpectedPropsClaim, cType)
         ).not.toThrow()
@@ -151,7 +151,7 @@ describe.each([[cTypeV1], [cTypeV2]])(
   }
 )
 
-describe.each([[cTypeV1], [cTypeV2]])(
+describe.each([[cTypeDraft01], [cTypeV1]])(
   'CType verification with schema version %#',
   (cType) => {
     it('id verification', () => {

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -84,17 +84,14 @@ describe('blank ctypes', () => {
   })
 })
 
-const cTypeV1: ICType = {
-  $id: 'kilt:ctype:0x',
-  $schema: CTypeModelV1.$id,
-  title: 'Ctype Title',
-  properties: {
+const cTypeV1: ICType = CType.fromProperties(
+  'name',
+  {
     'first-property': { type: 'integer' },
     'second-property': { type: 'string' },
   },
-  type: 'object',
-}
-cTypeV1.$id = CType.getIdForSchema(cTypeV1)
+  'draft-01'
+)
 
 const cTypeV2: ICType = CType.fromProperties('name', {
   'first-property': { type: 'integer' },

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -12,11 +12,10 @@
 import { SDKErrors } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
 import { ApiMocks } from '@kiltprotocol/testing'
-import type { ICType, IClaim } from '@kiltprotocol/types'
+import type { ICType } from '@kiltprotocol/types'
 import * as Claim from '../claim'
-import * as Credential from '../credential'
 import * as CType from './CType.js'
-import { CTypeModel } from './CType.schemas'
+import { CTypeModel, CTypeModelV1 } from './CType.schemas'
 
 const mockedApi: any = ApiMocks.getMockedApi()
 ConfigService.set({ api: mockedApi })
@@ -28,76 +27,39 @@ const encodedAliceDid = ApiMocks.mockChainQueryReturn(
 )
 const didAlice = 'did:kilt:4p6K4tpdZtY3rNqM2uorQmsS6d3woxtnWMHjtzGftHmDb41N'
 
-describe('CType', () => {
-  let claimCtype: ICType
-  let claimContents: any
-  let claim: IClaim
-  beforeAll(async () => {
-    claimCtype = CType.fromProperties('CtypeModel 2', {
-      name: { type: 'string' },
-    })
-
-    claimContents = {
-      name: 'Bob',
-    }
-
-    claim = Claim.fromCTypeAndClaimContents(claimCtype, claimContents, didAlice)
+it('consistent CType id generation', () => {
+  const ctype = CType.fromProperties('CtypeModel 1', {
+    'first-property': { type: 'integer' },
+    'second-property': { type: 'string' },
   })
 
-  it('makes ctype object from schema without id', () => {
-    const ctype = CType.fromProperties('CtypeModel 1', {
-      'first-property': { type: 'integer' },
-      'second-property': { type: 'string' },
-    })
+  expect(ctype.$id).toMatchInlineSnapshot(
+    `"kilt:ctype:0x80b6203f477aa7454cfa10bd3900226e251398e8a9c47ecc526d718c47832e96"`
+  )
+})
 
-    expect(ctype.$id).toBe(
-      'kilt:ctype:0xba15bf4960766b0a6ad7613aa3338edce95df6b22ed29dd72f6e72d740829b84'
-    )
+it('e2e', () => {
+  const claimCtype = CType.fromProperties('CtypeModel 2', {
+    name: { type: 'string' },
   })
 
-  it('verifies the claim structure', () => {
-    expect(() =>
-      CType.verifyClaimAgainstSchema(claim.contents, claimCtype)
-    ).not.toThrow()
-    claim.contents.name = 123
-    expect(() =>
-      CType.verifyClaimAgainstSchema(claim.contents, claimCtype)
-    ).toThrow()
-  })
+  const claimContents = {
+    name: 'Bob',
+  }
 
-  it('throws error on faulty input', () => {
-    const wrongHashCtype: ICType = {
-      ...claimCtype,
-      $id: 'kilt:ctype:0x1234',
-    }
-    const faultySchemaCtype: ICType = {
-      ...claimCtype,
-      properties: null as unknown as ICType['properties'],
-    }
+  const claim = Claim.fromCTypeAndClaimContents(
+    claimCtype,
+    claimContents,
+    didAlice
+  )
 
-    const wrongSchemaIdCType: ICType = {
-      ...claimCtype,
-      $id: claimCtype.$id.replace('1', '2') as ICType['$id'],
-    }
-    expect(() => CType.verifyDataStructure(wrongHashCtype)).toThrowError(
-      SDKErrors.CTypeIdMismatchError
-    )
-    expect(() => CType.verifyDataStructure(faultySchemaCtype)).toThrowError(
-      SDKErrors.ObjectUnverifiableError
-    )
-    expect(() =>
-      CType.verifyDataStructure(wrongSchemaIdCType)
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Provided $id \\"kilt:ctype:0xd5302762c62114f6455e0b373cccce20631c2a717004a98f8953e738e17c5d3c\\" does not match schema $id \\"kilt:ctype:0xd5301762c62114f6455e0b373cccce20631c2a717004a98f8953e738e17c5d3c\\""`
-    )
-  })
-
-  it('verifies whether a ctype is registered on chain ', async () => {
-    await expect(CType.verifyStored(claimCtype)).rejects.toThrow()
-
-    mockedApi.query.ctype.ctypes.mockResolvedValueOnce(encodedAliceDid)
-    await expect(CType.verifyStored(claimCtype)).resolves.not.toThrow()
-  })
+  expect(() =>
+    CType.verifyClaimAgainstSchema(claim.contents, claimCtype)
+  ).not.toThrow()
+  claim.contents.name = 123
+  expect(() =>
+    CType.verifyClaimAgainstSchema(claim.contents, claimCtype)
+  ).toThrow()
 })
 
 describe('blank ctypes', () => {
@@ -109,83 +71,131 @@ describe('blank ctypes', () => {
     ctype2 = CType.fromProperties('claimedSomething', {})
   })
 
-  it('two ctypes with no properties have different hashes if id is different', () => {
+  it('two ctypes with no properties have different hashes if name is different', () => {
     expect(ctype1.$schema).toEqual(ctype2.$schema)
     expect(ctype1.properties).toEqual(ctype2.properties)
     expect(ctype1.title).not.toEqual(ctype2.title)
     expect(ctype1.$id).not.toEqual(ctype2.$id)
   })
 
-  it('two claims on an empty ctypes will have different root hash', async () => {
-    const claimA1 = Claim.fromCTypeAndClaimContents(ctype1, {}, didAlice)
-    const claimA2 = Claim.fromCTypeAndClaimContents(ctype2, {}, didAlice)
-
-    expect(Credential.fromClaim(claimA1).rootHash).not.toEqual(
-      Credential.fromClaim(claimA2).rootHash
-    )
-  })
   it('typeguard returns true or false for complete or incomplete CTypes', () => {
     expect(CType.isICType(ctype1)).toBe(true)
     expect(CType.isICType({ ...ctype2, owner: '' })).toBe(false)
   })
 })
 
-describe('CType verification', () => {
-  const ctypeInput = {
-    $id: 'kilt:ctype:0x1',
-    $schema: 'http://kilt-protocol.org/draft-01/ctype-input#',
-    title: 'Ctype Title',
-    properties: [
-      {
-        $id: 'kilt:ctype:0xfirst-property',
-        $ref: 'First Property',
-        type: 'integer',
-      },
-      {
-        $id: 'kilt:ctype:0xsecond-property',
-        $ref: 'Second Property',
-        type: 'string',
-      },
-    ],
-    type: 'object',
-    required: ['first-property', 'second-property'],
-  } as unknown as ICType
-
-  const ctypeWrapperModel: ICType = CType.fromProperties('name', {
+const cTypeV1: ICType = {
+  $id: 'kilt:ctype:0x',
+  $schema: CTypeModelV1.$id,
+  title: 'Ctype Title',
+  properties: {
     'first-property': { type: 'integer' },
     'second-property': { type: 'string' },
-  })
+  },
+  type: 'object',
+}
+cTypeV1.$id = CType.getIdForSchema(cTypeV1)
 
-  const goodClaim = {
-    'first-property': 10,
-    'second-property': '12',
-  }
-
-  const badClaim = {
-    'first-property': '1',
-    'second-property': '12',
-    'third-property': true,
-  }
-  it('verifies claims', () => {
-    expect(() =>
-      CType.verifyClaimAgainstSchema(goodClaim, ctypeWrapperModel)
-    ).not.toThrow()
-    expect(() =>
-      CType.verifyClaimAgainstSchema(badClaim, ctypeWrapperModel)
-    ).toThrow()
-    expect(() =>
-      CType.verifyObjectAgainstSchema(badClaim, CTypeModel, [])
-    ).toThrow()
-    expect(() => {
-      CType.verifyClaimAgainstSchema(badClaim, ctypeInput)
-    }).toThrow(SDKErrors.ObjectUnverifiableError)
-  })
-  it('verifies ctypes', () => {
-    expect(() =>
-      CType.verifyObjectAgainstSchema(ctypeWrapperModel, CTypeModel)
-    ).not.toThrow()
-  })
+const cTypeV2: ICType = CType.fromProperties('name', {
+  'first-property': { type: 'integer' },
+  'second-property': { type: 'string' },
 })
+
+describe.each([[cTypeV1], [cTypeV2]])(
+  'Claim verification with CType of schema version %#',
+  (cType) => {
+    const goodClaim = {
+      'first-property': 10,
+      'second-property': '12',
+    }
+    const partialClaim = {
+      'first-property': 10,
+    }
+    const badClaim = {
+      ...goodClaim,
+      'first-property': '1',
+    }
+    const unexpectedPropsClaim = {
+      ...goodClaim,
+      'third-property': true,
+    }
+
+    it('accepts good CType', () => {
+      expect(() => CType.verifyDataStructure(cType)).not.toThrow()
+      expect(() =>
+        CType.verifyObjectAgainstSchema(cType, CTypeModel)
+      ).not.toThrow()
+    })
+
+    it('accepts correct & partial claims', () => {
+      expect(() =>
+        CType.verifyClaimAgainstSchema(goodClaim, cType)
+      ).not.toThrow()
+      expect(() =>
+        CType.verifyClaimAgainstSchema(partialClaim, cType)
+      ).not.toThrow()
+      expect(() => CType.verifyClaimAgainstSchema({}, cType)).not.toThrow()
+    })
+    it('rejects incorrect claims', () => {
+      expect(() => CType.verifyClaimAgainstSchema(badClaim, cType)).toThrow(
+        SDKErrors.ObjectUnverifiableError
+      )
+      // only the CTypes following the newer model protect against additional properties
+      if (cType.$schema === CTypeModelV1.$id) {
+        expect(() =>
+          CType.verifyClaimAgainstSchema(unexpectedPropsClaim, cType)
+        ).not.toThrow()
+      } else {
+        expect(() =>
+          CType.verifyClaimAgainstSchema(unexpectedPropsClaim, cType)
+        ).toThrow(SDKErrors.ObjectUnverifiableError)
+      }
+    })
+  }
+)
+
+describe.each([[cTypeV1], [cTypeV2]])(
+  'CType verification with schema version %#',
+  (cType) => {
+    it('id verification', () => {
+      const wrongIdCtype: ICType = {
+        ...cType,
+        $id: cType.$id.substring(11) as ICType['$id'],
+      }
+      const wrongHashCType: ICType = {
+        ...cType,
+        $id: cType.$id.replace(/[1-9]/, (i) =>
+          String(Number(i) - 1)
+        ) as ICType['$id'],
+      }
+      expect(() => CType.verifyDataStructure(wrongIdCtype)).toThrowError(
+        SDKErrors.ObjectUnverifiableError
+      )
+      expect(() => CType.verifyDataStructure(wrongHashCType)).toThrowError(
+        SDKErrors.CTypeIdMismatchError
+      )
+    })
+    it('throws error on faulty input', () => {
+      const faultySchemaCtype: ICType = {
+        ...cType,
+        properties: null as unknown as ICType['properties'],
+      }
+      const wrongSchemaIdCType: ICType = {
+        ...cType,
+        $schema: cType.$schema.replace(/[1-9]/, (i) =>
+          String(Number(i) - 1)
+        ) as ICType['$id'],
+      }
+
+      expect(() => CType.verifyDataStructure(faultySchemaCtype)).toThrowError(
+        SDKErrors.ObjectUnverifiableError
+      )
+      expect(() => CType.verifyDataStructure(wrongSchemaIdCType)).toThrowError(
+        SDKErrors.ObjectUnverifiableError
+      )
+    })
+  }
+)
 
 describe('CType registration verification', () => {
   const ctype = CType.fromProperties('CtypeModel 2', {

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -195,7 +195,7 @@ export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
   verifyObjectAgainstSchema(metadata, MetadataModel)
 }
 
-const cTypeVersionToSchema = {
+const cTypeVersionToSchemaId = {
   'draft-01': CTypeModelDraft01.$id,
   V1: CTypeModelV1.$id,
 }
@@ -207,7 +207,7 @@ const cTypeVersionToSchema = {
  * @param title The new CType's title as a string.
  * @param properties Key-value pairs describing the admissible atomic claims for a credential with this CType. The value of each property is a json-schema (for example `{ "type": "number" }`) used to validate that property.
  * @param version Use 'V1' to create a CType according to the latest metaschema version (default) and 'draft-01' to produce a legacy CType. Included for backwards-compatibility.
- * @returns A complete json schema (CType) with an $id derived from the hashed schema. The referenced meta $schema varies by CType version.
+ * @returns A complete JSON schema (CType) with an $id derived from the hashed schema. Each CType references a meta schema that applies to it via the $schema property; its value depends on the `version` parameter.
  */
 export function fromProperties(
   title: ICType['title'],
@@ -217,7 +217,7 @@ export function fromProperties(
   const schema: Omit<ICType, '$id'> = {
     properties,
     title,
-    $schema: cTypeVersionToSchema[version],
+    $schema: cTypeVersionToSchemaId[version],
     type: 'object',
   }
   if (version === 'V1') {

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -102,9 +102,9 @@ export function getIdForSchema(
  */
 export function verifyObjectAgainstSchema(
   object: Record<string, any>,
-  schema: Record<string, any>,
+  schema: JsonSchema.Schema,
   messages?: string[],
-  referencedSchemas?: Array<Record<string, any>>
+  referencedSchemas?: JsonSchema.Schema[]
 ): void {
   const validator = new JsonSchema.Validator(schema, '7', false)
   if (referencedSchemas) {

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -135,7 +135,7 @@ export function verifyClaimAgainstSchema(
   schema: ICType,
   messages?: string[]
 ): void {
-  verifyObjectAgainstSchema(schema, CTypeModel)
+  verifyObjectAgainstSchema(schema, CTypeModel, messages)
   verifyObjectAgainstSchema(claimContents, schema, messages)
 }
 

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -26,7 +26,7 @@ import { ConfigService } from '@kiltprotocol/config'
 import {
   CTypeModel,
   MetadataModel,
-  CTypeModelV2,
+  CTypeModelDraft01,
   CTypeModelV1,
 } from './CType.schemas.js'
 
@@ -196,8 +196,8 @@ export function verifyCTypeMetadata(metadata: ICTypeMetadata): void {
 }
 
 const cTypeVersionToSchema = {
-  'draft-01': CTypeModelV1.$id,
-  V1: CTypeModelV2.$id,
+  'draft-01': CTypeModelDraft01.$id,
+  V1: CTypeModelV1.$id,
 }
 
 /**

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -23,7 +23,7 @@ import type {
 } from '@kiltprotocol/types'
 import { Crypto, SDKErrors, JsonSchema, jsonabc } from '@kiltprotocol/utils'
 import { ConfigService } from '@kiltprotocol/config'
-import { CTypeModel, MetadataModel } from './CType.schemas.js'
+import { CTypeModel, MetadataModel, CTypeModelV2 } from './CType.schemas.js'
 
 /**
  * Utility for (re)creating CType hashes. Sorts the schema and strips the $id property (which contains the CType hash) before stringifying.
@@ -205,8 +205,9 @@ export function fromProperties(
   const schema: Omit<ICType, '$id'> = {
     properties,
     title,
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    $schema: CTypeModelV2.$id,
     type: 'object',
+    additionalProperties: false,
   }
   const ctype = jsonabc.sortObj({ ...schema, $id: getIdForSchema(schema) })
   verifyDataStructure(ctype)

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -134,7 +134,7 @@ describe('Nested CTypes', () => {
         claimContents,
         didAlice
       )
-    ).toThrowError(SDKErrors.NestedClaimUnverifiableError)
+    ).toThrowError(SDKErrors.ObjectUnverifiableError)
     expect(() =>
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType,
@@ -164,6 +164,6 @@ describe('Nested CTypes', () => {
         claimDeepContents,
         didAlice
       )
-    ).toThrowError(SDKErrors.NestedClaimUnverifiableError)
+    ).toThrowError(SDKErrors.ObjectUnverifiableError)
   })
 })

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -7,14 +7,7 @@
 
 import type { HexString } from '@polkadot/util/types'
 
-export type InstanceType =
-  | 'array'
-  | 'boolean'
-  | 'integer'
-  | 'null'
-  | 'number'
-  | 'object'
-  | 'string'
+export type InstanceType = 'boolean' | 'integer' | 'number' | 'string'
 
 export type CTypeHash = HexString
 

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -23,7 +23,8 @@ export interface ICType {
   $schema: string
   title: string
   properties: {
-    [key: string]: { $ref?: string; type?: InstanceType; format?: string }
+    [key: string]: { type: InstanceType; format?: string } | { $ref: string }
   }
   type: 'object'
+  additionalProperties?: false
 }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -159,8 +159,6 @@ export class CredentialUnverifiableError extends SDKError {}
 
 export class ClaimUnverifiableError extends SDKError {}
 
-export class NestedClaimUnverifiableError extends SDKError {}
-
 export class IdentityMismatchError extends SDKError {
   constructor(context?: string, type?: string) {
     if (type && context) {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2378

Introduces a new meta schema to fix the issue that additional properties were not validated.
Newly created CTypes would use this meta schema by default; legacy CTypes are still validated against the old meta schema.

- [x] Makes sure that no additional properties are present on an IClaim
- [x] Allows for selective disclosure (does not require all allowable properties to be present)
- [x] Meta schema id uses content integrity protected URI, ideally uses decentralised solution
- [x] Comes with a strategy for expanding claims to URIs and for checking the same claims on the credentialSubject of a Verifiable Credential
   - Unfortunately it seems that the only viable strategy so far is deriving a schema from the CType.
   - Better compatibility could be achieved by defining an optional `@id` property on all CTypes (to avoid failing credentialSubjecct verification on VCs, where this would be present after expanding), but this comes at a cost; any IClaim would pass verification even with an extra `@id` property.
- [x] Upgrade path / interoperability strategy for credentials issued for the old CType version
   -  Because the currently used json schema version does not allow defining a CType which derives the full set of properties from another CType (you can only add references for each property individually) the recommended upgrade path would be to create a new CType with the same properties and publish proof that it is equivalent to the old e.g. by publishing code that reproduces the derivation. Creating a CType where each property is derived from the old CType is another option, but checking that no properties were omitted and that the property names are identical is still a manual process. Compound/nested CTypes are also a bit more complicated to handle, so this seems like the less preferable option.
   - If all properties on the new CType are identical, verifiers would only need to add the new CType to the set of accepted CTypes. The credential could then be processed as before, no matter which version of the CType was used. 

## How to test:

Updated tests to cover both the old and new meta schema and CTypes created based on them. 

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
