### PR TITLE
fix: fromFemtoKilt fails for non-english locales

### DIFF
--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -43,7 +43,7 @@ export const Prefixes = new Map<MetricPrefix, number>([
  * @returns String representation of the given BN with prefix and unit ('KILT' as default).
  */
 export function formatKiltBalance(
-  amount: BN,
+  amount: BalanceNumber,
   additionalOptions?: BalanceOptions
 ): string {
   const options = {
@@ -144,17 +144,15 @@ export function toFemtoKilt(
 export function fromFemtoKilt(
   input: BalanceNumber,
   decimals = 4,
-  options?: BalanceOptions
+  options: BalanceOptions = {}
 ): string {
+  const { locale, ...opts } = options
   const inputBN = new BN(balanceNumberToString(input))
-  const formatted = formatKiltBalance(inputBN, options)
+  const formatted = formatKiltBalance(inputBN, opts)
   const [number, ...rest] = formatted.split(' ')
-  const negative = number.startsWith('-')
-  const localeNumber = new Intl.NumberFormat(options?.locale, {
-    minimumFractionDigits: 4,
-  }).format(Number(negative ? number.slice(1) : number))
-  return `${negative ? '-' : ''}${localeNumber.slice(
-    0,
-    localeNumber.length - 4 + decimals
-  )} ${rest.join(' ')}`
+  const localeNumber = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: decimals + 1,
+    maximumFractionDigits: decimals + 1,
+  }).format(Number(number))
+  return `${localeNumber.slice(0, localeNumber.length - 1)} ${rest.join(' ')}`
 }

--- a/packages/core/src/balance/Balance.utils.ts
+++ b/packages/core/src/balance/Balance.utils.ts
@@ -146,11 +146,11 @@ export function fromFemtoKilt(
   decimals = 4,
   options: BalanceOptions = {}
 ): string {
-  const { locale, ...opts } = options
   const inputBN = new BN(balanceNumberToString(input))
-  const formatted = formatKiltBalance(inputBN, opts)
+  // overwriting the locale as parsing a number from a string only works with English locale formatted numbers
+  const formatted = formatKiltBalance(inputBN, { ...options, locale: 'en' })
   const [number, ...rest] = formatted.split(' ')
-  const localeNumber = new Intl.NumberFormat(locale, {
+  const localeNumber = new Intl.NumberFormat(options.locale, {
     minimumFractionDigits: decimals + 1,
     maximumFractionDigits: decimals + 1,
   }).format(Number(number))


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/sdk-js/issues/736

In the most recent version(s), Polkadot-js has started to do an odd locale-based formatting of balances where only the separators change but the numerals remain unchanged. This broke our formatting for locales using different numerals.

## How to test:
- delete yarn.lock and run `yarn install`
- run tests

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
