### PR TITLE
feat: enums and arrays on new ctype metaschema

### DIFF
--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -9,7 +9,7 @@ import { JsonSchema } from '@kiltprotocol/utils'
 
 export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
-  $id: 'ipfs://bafybeifzfxz6tfd2xo7ijxbfceaxo3l655yg7sovlsnpxgq2rwfl4kbfgm',
+  $id: 'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq',
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'CType Metaschema (V1)',
   description:
@@ -27,28 +27,11 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
       patternProperties: {
         '^.+$': {
           oneOf: [
-            {
-              additionalProperties: false,
-              properties: {
-                $ref: {
-                  pattern: '^kilt:ctype:0x[0-9a-f]+(#/properties/.+)?$',
-                  format: 'uri',
-                  type: 'string',
-                },
-              },
-              required: ['$ref'],
-            },
-            {
-              additionalProperties: false,
-              properties: {
-                format: { enum: ['date', 'time', 'uri'], type: 'string' },
-                type: {
-                  enum: ['boolean', 'integer', 'number', 'string'],
-                  type: 'string',
-                },
-              },
-              required: ['type'],
-            },
+            { $ref: '#/definitions/string' },
+            { $ref: '#/definitions/number' },
+            { $ref: '#/definitions/boolean' },
+            { $ref: '#/definitions/cTypeReference' },
+            { $ref: '#/definitions/array' },
           ],
           type: 'object',
         },
@@ -66,6 +49,89 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
     'title',
     'type',
   ],
+  definitions: {
+    cTypeReference: {
+      additionalProperties: false,
+      properties: {
+        $ref: {
+          pattern: '^kilt:ctype:0x[0-9a-f]+(#/properties/.+)?$',
+          format: 'uri',
+          type: 'string',
+        },
+      },
+      required: ['$ref'],
+    },
+    string: {
+      additionalProperties: false,
+      properties: {
+        type: {
+          const: 'string',
+        },
+        format: { enum: ['date', 'time', 'uri'] },
+        enum: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        minLength: {
+          type: 'number',
+        },
+        maxLength: {
+          type: 'number',
+        },
+      },
+      required: ['type'],
+    },
+    boolean: {
+      additionalProperties: false,
+      properties: {
+        type: {
+          const: 'boolean',
+        },
+      },
+      required: ['type'],
+    },
+    number: {
+      additionalProperties: false,
+      properties: {
+        type: {
+          enum: ['integer', 'number'],
+        },
+        enum: {
+          type: 'array',
+          items: { type: 'number' },
+        },
+        minimum: {
+          type: 'number',
+        },
+        maximum: {
+          type: 'number',
+        },
+      },
+      required: ['type'],
+    },
+    array: {
+      additionalProperties: false,
+      properties: {
+        type: { const: 'array' },
+        items: {
+          oneOf: [
+            { $ref: '#/definitions/string' },
+            { $ref: '#/definitions/number' },
+            { $ref: '#/definitions/boolean' },
+            // TODO: do we have reasons not to allow CType references in arrays?
+            { $ref: '#/definitions/cTypeReference' },
+          ],
+        },
+        minItems: {
+          type: 'number',
+        },
+        maxItems: {
+          type: 'number',
+        },
+      },
+      required: ['type', 'items'],
+    },
+  },
 }
 
 export const CTypeModelDraft01: JsonSchema.Schema & { $id: string } = {

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -118,7 +118,6 @@ export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
             { $ref: '#/definitions/string' },
             { $ref: '#/definitions/number' },
             { $ref: '#/definitions/boolean' },
-            // TODO: do we have reasons not to allow CType references in arrays?
             { $ref: '#/definitions/cTypeReference' },
           ],
         },

--- a/packages/core/src/ctype/CType.schemas.ts
+++ b/packages/core/src/ctype/CType.schemas.ts
@@ -9,7 +9,7 @@ import { JsonSchema } from '@kiltprotocol/utils'
 
 export const CTypeModelV1: JsonSchema.Schema & { $id: string } = {
   // $id is not contained in schema when fetched from ipfs bc that is impossible with a content-addressed system
-  $id: 'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq',
+  $id: 'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/',
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'CType Metaschema (V1)',
   description:

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -34,7 +34,7 @@ it('consistent CType id generation', () => {
   })
 
   expect(ctypeV1.$id).toMatchInlineSnapshot(
-    `"kilt:ctype:0x3e0a3b18e775d0b9789147b5d29c772f197b57986bb6d56604268980b530964a"`
+    `"kilt:ctype:0xc4145b9c5c7ae10f60c6a707b9dabf704ab65d7802a839854643a579c9bc80a5"`
   )
 
   const ctypeV0 = CType.fromProperties(

--- a/packages/core/src/ctype/CType.spec.ts
+++ b/packages/core/src/ctype/CType.spec.ts
@@ -34,7 +34,7 @@ it('consistent CType id generation', () => {
   })
 
   expect(ctypeV1.$id).toMatchInlineSnapshot(
-    `"kilt:ctype:0x12c8edb42b455aa6c29fabda8f3768bd1e8577f0618f122072828e41b6f4f728"`
+    `"kilt:ctype:0x3e0a3b18e775d0b9789147b5d29c772f197b57986bb6d56604268980b530964a"`
   )
 
   const ctypeV0 = CType.fromProperties(

--- a/packages/core/src/ctype/Ctype.nested.spec.ts
+++ b/packages/core/src/ctype/Ctype.nested.spec.ts
@@ -142,7 +142,7 @@ describe('Nested CTypes', () => {
         claimDeepContents
       )
     ).not.toThrow()
-    ;(claimDeepContents.passport as Record<string, unknown>).fullName = {}
+    ;(claimDeepContents.passport as any).fullName = {}
     expect(() =>
       CType.verifyClaimAgainstNestedSchemas(
         deeplyNestedCType,

--- a/packages/types/src/CType.ts
+++ b/packages/types/src/CType.ts
@@ -7,16 +7,55 @@
 
 import type { HexString } from '@polkadot/util/types'
 
-export type InstanceType = 'boolean' | 'integer' | 'number' | 'string'
+export type InstanceType = 'boolean' | 'integer' | 'number' | 'string' | 'array'
 
 export type CTypeHash = HexString
+
+interface TypePattern {
+  type: InstanceType
+}
+
+interface StringPattern extends TypePattern {
+  type: 'string'
+  format?: 'date' | 'time' | 'uri'
+  enum?: string[]
+  minLength?: number
+  maxLength?: number
+}
+
+interface NumberPattern extends TypePattern {
+  type: 'integer' | 'number'
+  enum?: number[]
+  minimum?: number
+  maximum?: number
+}
+
+interface BooleanPattern extends TypePattern {
+  type: 'boolean'
+}
+
+interface RefPattern {
+  $ref: string
+}
+
+interface ArrayPattern extends TypePattern {
+  type: 'array'
+  items: BooleanPattern | NumberPattern | StringPattern | RefPattern
+  minItems?: number
+  maxItems?: number
+}
 
 export interface ICType {
   $id: `kilt:ctype:${CTypeHash}`
   $schema: string
   title: string
   properties: {
-    [key: string]: { type: InstanceType; format?: string } | { $ref: string }
+    [key: string]:
+      | BooleanPattern
+      | NumberPattern
+      | StringPattern
+      | ArrayPattern
+      | RefPattern
   }
   type: 'object'
   additionalProperties?: false

--- a/packages/types/src/Claim.ts
+++ b/packages/types/src/Claim.ts
@@ -8,10 +8,15 @@
 import type { CTypeHash } from './CType'
 import type { DidUri } from './DidDocument'
 
-export type IClaimContents = Record<
-  string,
-  Record<string, unknown> | string | number | boolean
->
+type ClaimPrimitives = string | number | boolean
+
+export interface IClaimContents {
+  [key: string]:
+    | ClaimPrimitives
+    | IClaimContents
+    | Array<ClaimPrimitives | IClaimContents>
+}
+
 export interface IClaim {
   cTypeHash: CTypeHash
   contents: IClaimContents


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2456

Amends the new CType metaschema with new features:
- Allowable values for properties of string, number & integer types can be restricted with an enum validator.
- Arrays are allowed, with all items validating against a schema normally used to validate simple properties (i.e., boolean, string, or number, schema, or a CType reference).
- Length assertions are allowed for arrays and strings.
- Maximum and minimum value assertions are allowed for numbers and integers.

## How to test:

It's easiest to play with the metaschema (which you can also download from https://gateway.pinata.cloud/ipfs/bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq) by validating your desired CTypes against it on https://www.jsonschemavalidator.net.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
