### PR TITLE
refactor!: make all key ids absolute uris on conformant did doc

### DIFF
--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.spec.ts
@@ -116,10 +116,18 @@ describe('When exporting a DID Document from a full DID', () => {
           publicKeyBase58: '11111111111111111111111111111111',
         },
       ],
-      authentication: ['#auth'],
-      keyAgreement: ['#enc'],
-      assertionMethod: ['#att'],
-      capabilityDelegation: ['#del'],
+      authentication: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#auth',
+      ],
+      keyAgreement: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#enc',
+      ],
+      assertionMethod: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#att',
+      ],
+      capabilityDelegation: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#del',
+      ],
       service: [
         {
           id: 'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#id-1',
@@ -171,10 +179,18 @@ describe('When exporting a DID Document from a full DID', () => {
           publicKeyBase58: '11111111111111111111111111111111',
         },
       ],
-      authentication: ['#auth'],
-      keyAgreement: ['#enc'],
-      assertionMethod: ['#att'],
-      capabilityDelegation: ['#del'],
+      authentication: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#auth',
+      ],
+      keyAgreement: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#enc',
+      ],
+      assertionMethod: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#att',
+      ],
+      capabilityDelegation: [
+        'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#del',
+      ],
       service: [
         {
           id: 'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#id-1',
@@ -217,11 +233,11 @@ describe('When exporting a DID Document from a light DID', () => {
     expect(didDoc).toMatchInlineSnapshot(`
       Object {
         "authentication": Array [
-          "#authentication",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z16QMTH1Pc4A99Und9RZvzyikFR73Aepx9exPZPgXJX18upeuSpgXeat2LsjEQpXUBUtaRtdpSXpv42KitoFqySLjiuXVcghuoWviPci3QrnQMeD161howeWdF5GTbBFRHSVXpEu9PWbtUEsnLfDf2NQgu4LmktN8Ti6CAmdQtQiVNbJkB7TnyzLiJJ27rYayWj15mjJ9EoNyyu3rDJGomi2vUgt2DiSUXaJbnSzuuFf#authentication",
         ],
         "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z16QMTH1Pc4A99Und9RZvzyikFR73Aepx9exPZPgXJX18upeuSpgXeat2LsjEQpXUBUtaRtdpSXpv42KitoFqySLjiuXVcghuoWviPci3QrnQMeD161howeWdF5GTbBFRHSVXpEu9PWbtUEsnLfDf2NQgu4LmktN8Ti6CAmdQtQiVNbJkB7TnyzLiJJ27rYayWj15mjJ9EoNyyu3rDJGomi2vUgt2DiSUXaJbnSzuuFf",
         "keyAgreement": Array [
-          "#encryption",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z16QMTH1Pc4A99Und9RZvzyikFR73Aepx9exPZPgXJX18upeuSpgXeat2LsjEQpXUBUtaRtdpSXpv42KitoFqySLjiuXVcghuoWviPci3QrnQMeD161howeWdF5GTbBFRHSVXpEu9PWbtUEsnLfDf2NQgu4LmktN8Ti6CAmdQtQiVNbJkB7TnyzLiJJ27rYayWj15mjJ9EoNyyu3rDJGomi2vUgt2DiSUXaJbnSzuuFf#encryption",
         ],
         "service": Array [
           Object {
@@ -271,11 +287,11 @@ describe('When exporting a DID Document from a light DID', () => {
           "ipfs://QmU7QkuTCPz7NmD5bD7Z7mQVz2UsSPaEK58B5sYnjnPRNW",
         ],
         "authentication": Array [
-          "#authentication",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z16QMTH1Pc4A99Und9RZvzyikFR73Aepx9exPZPgXJX18upeuSpgXeat2LsjEQpXUBUtaRtdpSXpv42KitoFqySLjiuXVcghuoWviPci3QrnQMeD161howeWdF5GTbBFRHSVXpEu9PWbtUEsnLfDf2NQgu4LmktN8Ti6CAmdQtQiVNbJkB7TnyzLiJJ27rYayWj15mjJ9EoNyyu3rDJGomi2vUgt2DiSUXaJbnSzuuFf#authentication",
         ],
         "id": "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z16QMTH1Pc4A99Und9RZvzyikFR73Aepx9exPZPgXJX18upeuSpgXeat2LsjEQpXUBUtaRtdpSXpv42KitoFqySLjiuXVcghuoWviPci3QrnQMeD161howeWdF5GTbBFRHSVXpEu9PWbtUEsnLfDf2NQgu4LmktN8Ti6CAmdQtQiVNbJkB7TnyzLiJJ27rYayWj15mjJ9EoNyyu3rDJGomi2vUgt2DiSUXaJbnSzuuFf",
         "keyAgreement": Array [
-          "#encryption",
+          "did:kilt:light:014nv4phaKc4EcwENdRERuMF79ZSSB5xvnAk3zNySSbVbXhSwS:z16QMTH1Pc4A99Und9RZvzyikFR73Aepx9exPZPgXJX18upeuSpgXeat2LsjEQpXUBUtaRtdpSXpv42KitoFqySLjiuXVcghuoWviPci3QrnQMeD161howeWdF5GTbBFRHSVXpEu9PWbtUEsnLfDf2NQgu4LmktN8Ti6CAmdQtQiVNbJkB7TnyzLiJJ27rYayWj15mjJ9EoNyyu3rDJGomi2vUgt2DiSUXaJbnSzuuFf#encryption",
         ],
         "service": Array [
           Object {

--- a/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
+++ b/packages/did/src/DidDocumentExporter/DidDocumentExporter.ts
@@ -12,6 +12,7 @@ import type {
   ConformingDidDocument,
   DidResourceUri,
   JsonLDDidDocument,
+  UriFragment,
 } from '@kiltprotocol/types'
 import {
   encryptionKeyTypesMap,
@@ -30,6 +31,13 @@ function exportToJsonDidDocument(did: DidDocument): ConformingDidDocument {
     service = [],
   } = did
 
+  function toAbsoluteUri(keyId: UriFragment): DidResourceUri {
+    if (keyId.startsWith(controller)) {
+      return keyId as DidResourceUri
+    }
+    return `${controller}${keyId}`
+  }
+
   const verificationMethod: ConformingDidDocument['verificationMethod'] = [
     ...authentication,
     ...assertionMethod,
@@ -43,7 +51,7 @@ function exportToJsonDidDocument(did: DidDocument): ConformingDidDocument {
       }))
     )
     .map(({ id, type, publicKey }) => ({
-      id: `${controller}${id}` as DidResourceUri,
+      id: toAbsoluteUri(id),
       controller,
       type,
       publicKeyBase58: base58Encode(publicKey),
@@ -57,15 +65,15 @@ function exportToJsonDidDocument(did: DidDocument): ConformingDidDocument {
   return {
     id: controller,
     verificationMethod,
-    authentication: [authentication[0].id],
+    authentication: [toAbsoluteUri(authentication[0].id)],
     ...(assertionMethod[0] && {
-      assertionMethod: [assertionMethod[0].id],
+      assertionMethod: [toAbsoluteUri(assertionMethod[0].id)],
     }),
     ...(capabilityDelegation[0] && {
-      capabilityDelegation: [capabilityDelegation[0].id],
+      capabilityDelegation: [toAbsoluteUri(capabilityDelegation[0].id)],
     }),
     ...(keyAgreement.length > 0 && {
-      keyAgreement: [keyAgreement[0].id],
+      keyAgreement: [toAbsoluteUri(keyAgreement[0].id)],
     }),
     ...(service.length > 0 && {
       service: service.map((endpoint) => ({

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -625,7 +625,7 @@ describe('When resolving with the spec compliant resolver', () => {
     expect(didResolutionMetadata).toStrictEqual({})
 
     expect(didDocument.id).toStrictEqual<DidUri>(didWithAuthenticationKey)
-    expect(didDocument.authentication).toStrictEqual(['#auth'])
+    expect(didDocument.authentication).toStrictEqual([`${didDocument.id}#auth`])
     expect(didDocument.verificationMethod).toContainEqual<ConformingDidKey>({
       id: `${didWithAuthenticationKey}${'#auth'}`,
       controller: didWithAuthenticationKey,

--- a/packages/types/src/DidDocumentExporter.ts
+++ b/packages/types/src/DidDocumentExporter.ts
@@ -6,11 +6,9 @@
  */
 
 import {
-  DidEncryptionKey,
   DidResourceUri,
   DidServiceEndpoint,
   DidUri,
-  DidVerificationKey,
   EncryptionKeyType,
   VerificationKeyType,
 } from './DidDocument.js'
@@ -78,10 +76,10 @@ export type ConformingDidServiceEndpoint = Omit<DidServiceEndpoint, 'id'> & {
 export type ConformingDidDocument = {
   id: DidUri
   verificationMethod: ConformingDidKey[]
-  authentication: [DidVerificationKey['id']]
-  assertionMethod?: [DidVerificationKey['id']]
-  keyAgreement?: [DidEncryptionKey['id']]
-  capabilityDelegation?: [DidVerificationKey['id']]
+  authentication: [ConformingDidKey['id']]
+  assertionMethod?: [ConformingDidKey['id']]
+  keyAgreement?: [ConformingDidKey['id']]
+  capabilityDelegation?: [ConformingDidKey['id']]
   service?: ConformingDidServiceEndpoint[]
   alsoKnownAs?: [`w3n:${string}`]
 }


### PR DESCRIPTION
Makes all key ids on a (compliant) DID document absolute uris (i.e., starting with the DID).

See https://github.com/KILTprotocol/sdk-js/pull/734#discussion_r1149076735.