### PR TITLE
refactor: remove kilt dependencies from config package

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@kiltprotocol/types": "workspace:*",
-    "@kiltprotocol/utils": "workspace:*",
     "@polkadot/api": "^10.4.0",
     "typescript-logging": "^1.0.0"
   }

--- a/packages/config/src/ConfigService.spec.ts
+++ b/packages/config/src/ConfigService.spec.ts
@@ -13,8 +13,6 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { LogLevel, Logger } from 'typescript-logging'
 
-import { SDKErrors } from '@kiltprotocol/utils'
-
 import * as ConfigService from './ConfigService'
 
 describe('Log Configuration', () => {
@@ -47,8 +45,8 @@ describe('Log Configuration', () => {
 describe('Configuration Service', () => {
   it('has configuration Object with default values', () => {
     expect(ConfigService.get('logLevel')).toEqual(LogLevel.Error)
-    expect(() => ConfigService.get('api')).toThrowError(
-      SDKErrors.BlockchainApiMissingError
+    expect(() => ConfigService.get('api')).toThrowErrorMatchingInlineSnapshot(
+      `"The blockchain API is not set. Did you forget to call \`Kilt.connect(…)\` or \`Kilt.init(…)\`?"`
     )
   })
   describe('set function for api instance, logLevel and any custom configuration prop', () => {
@@ -70,8 +68,8 @@ describe('Configuration Service', () => {
   describe('get function for api instance, logLevel and any other injected configuration prop', () => {
     it('throws if api not set', () => {
       ConfigService.unset('api')
-      expect(() => ConfigService.get('api')).toThrowError(
-        SDKErrors.BlockchainApiMissingError
+      expect(() => ConfigService.get('api')).toThrowErrorMatchingInlineSnapshot(
+        `"The blockchain API is not set. Did you forget to call \`Kilt.connect(…)\` or \`Kilt.init(…)\`?"`
       )
     })
     it('returns logLevel property', () => {

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -22,8 +22,7 @@ import {
   getLogControl,
   LogGroupControlSettings,
 } from 'typescript-logging'
-import { SDKErrors } from '@kiltprotocol/utils'
-import { SubscriptionPromise } from '@kiltprotocol/types'
+import type { SubscriptionPromise } from '@kiltprotocol/types'
 
 const DEFAULT_DEBUG_LEVEL =
   typeof process !== 'undefined' &&
@@ -72,7 +71,9 @@ export function get<K extends keyof configOpts>(configOpt: K): configOpts[K] {
   if (typeof configuration[configOpt] === 'undefined') {
     switch (configOpt) {
       case 'api':
-        throw new SDKErrors.BlockchainApiMissingError()
+        throw new Error(
+          'The blockchain API is not set. Did you forget to call `Kilt.connect(…)` or `Kilt.init(…)`?'
+        )
       default:
         throw new Error(`GENERIC NOT CONFIGURED ERROR FOR KEY: "${configOpt}"`)
     }

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -171,15 +171,6 @@ export class IdentityMismatchError extends SDKError {
   }
 }
 
-export class BlockchainApiMissingError extends SDKError {
-  constructor(options?: ErrorOptions) {
-    super(
-      'The blockchain API is not set. Did you forget to call `Kilt.connect(…)` or `Kilt.init(…)`?',
-      options
-    )
-  }
-}
-
 export class SubscriptionsNotSupportedError extends SDKError {
   constructor(options?: ErrorOptions) {
     super(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,7 +1927,6 @@ __metadata:
   resolution: "@kiltprotocol/config@workspace:packages/config"
   dependencies:
     "@kiltprotocol/types": "workspace:*"
-    "@kiltprotocol/utils": "workspace:*"
     "@polkadot/api": ^10.4.0
     rimraf: ^3.0.2
     typescript: ^4.8.3


### PR DESCRIPTION
Removes unnecessary imports on the config package to make sure we don't add additional cjs imports in an esm context. 

## How to test:

Test sporran bundle size with this.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
