### PR TITLE
refactor!: nest ctype in ICTypeDetails

### DIFF
--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -84,12 +84,10 @@ describe('When there is an CtypeCreator and a verifier', () => {
     if (hasBlockNumbers) {
       const retrievedCType = await CType.fetchFromChain(ctype.$id)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { createdAt, creator, ...originalCtype } = retrievedCType
+      const { ctype: originalCtype, creator } = retrievedCType
       expect(originalCtype).toStrictEqual(ctype)
       expect(creator).toBe(ctypeCreator.uri)
-      await expect(
-        CType.verifyStored(retrievedCType.ctype)
-      ).resolves.not.toThrow()
+      await expect(CType.verifyStored(originalCtype)).resolves.not.toThrow()
     }
   }, 40_000)
 

--- a/packages/core/src/__integrationtests__/Ctypes.spec.ts
+++ b/packages/core/src/__integrationtests__/Ctypes.spec.ts
@@ -87,7 +87,9 @@ describe('When there is an CtypeCreator and a verifier', () => {
       const { createdAt, creator, ...originalCtype } = retrievedCType
       expect(originalCtype).toStrictEqual(ctype)
       expect(creator).toBe(ctypeCreator.uri)
-      await expect(CType.verifyStored(retrievedCType)).resolves.not.toThrow()
+      await expect(
+        CType.verifyStored(retrievedCType.ctype)
+      ).resolves.not.toThrow()
     }
   }, 40_000)
 

--- a/packages/core/src/ctype/CType.chain.ts
+++ b/packages/core/src/ctype/CType.chain.ts
@@ -83,7 +83,7 @@ export interface CTypeChainDetails {
   createdAt: BN
 }
 
-export type ICTypeDetails = ICType & CTypeChainDetails
+export type ICTypeDetails = { ctype: ICType } & CTypeChainDetails
 
 /**
  * Decodes the CType details returned by `api.query.ctype.ctypes()`.
@@ -226,8 +226,10 @@ export async function fetchFromChain(
   const [ctypeInput, creator] = lastRightCTypeCreationCall
 
   return {
-    ...ctypeInput,
-    $id: cTypeId,
+    ctype: {
+      ...ctypeInput,
+      $id: cTypeId,
+    },
     creator,
     createdAt,
   }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2698

Nests the CType in the ICTypeDetails so you can use it for credential validation without stripping its additional properties.

__Breaking:__ changes the return value of `fetchFromChain`.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
