### PR TITLE
feat: vite SSR cbor-web workaround

### DIFF
--- a/packages/core/src/publicCredential/PublicCredential.chain.ts
+++ b/packages/core/src/publicCredential/PublicCredential.chain.ts
@@ -22,7 +22,7 @@ import type {
   PublicCredentialsCredentialsCredentialEntry,
 } from '@kiltprotocol/augment-api'
 
-import { encode as cborEncode, decode as cborDecode } from 'cbor-web'
+import * as cbor from 'cbor-web'
 
 import { HexString } from '@polkadot/util/types'
 import { ConfigService } from '@kiltprotocol/config'
@@ -51,7 +51,7 @@ export function toChain(
 ): EncodedPublicCredential {
   const { cTypeHash, claims, subject, delegationId } = publicCredential
 
-  const cborSerializedClaims = cborEncode(claims)
+  const cborSerializedClaims = cbor.encode(claims)
 
   return {
     ctypeHash: cTypeHash,
@@ -72,7 +72,7 @@ function credentialInputFromChain({
   const credentialSubject = subject.toUtf8()
   validateUri(credentialSubject)
   return {
-    claims: cborDecode(claims),
+    claims: cbor.decode(claims),
     cTypeHash: ctypeHash.toHex(),
     delegationId: authorization.unwrapOr(undefined)?.toHex() ?? null,
     subject: credentialSubject as AssetDidUri,

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import { decode as cborDecode, encode as cborEncode } from 'cbor-web'
+import * as cbor from 'cbor-web'
 import {
   base58Decode,
   base58Encode,
@@ -147,7 +147,7 @@ function serializeAdditionalLightDidDetails({
   }
 
   const serializationVersion = 0x0
-  const serialized = cborEncode(objectToSerialize)
+  const serialized = cbor.encode(objectToSerialize)
   return base58Encode([serializationVersion, ...serialized], true)
 }
 
@@ -166,7 +166,7 @@ function deserializeAdditionalLightDidDetails(
   if (serializationVersion !== 0x0) {
     throw new SDKErrors.DidError('Serialization algorithm not supported')
   }
-  const deserialized: SerializableStructure = cborDecode(serialized)
+  const deserialized: SerializableStructure = cbor.decode(serialized)
 
   const keyAgreement = deserialized[KEY_AGREEMENT_MAP_KEY]
   return {


### PR DESCRIPTION
The bundler vite is unhappy when an SSR script attempts a named import from the CJS library cbor-web.

## How to test:

Try to build [this branch](https://github.com/galaniprojects/ctypehub/pull/97).

```
SyntaxError: Named export 'decode' not found. The requested module 'cbor-web' is a CommonJS module, which may not support all module.exports as named exports.
```

I have done a cursory test of the proposed fix in our projects and it seems to work for all the tools we have.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
