### PR TITLE
ci: fix test polkadot deps wf

### DIFF
--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: build-14.x
+          name: build-16.x
       - name: unzip
         run: unzip build.zip -d .
 
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: deps-14.x
+          name: deps-16.x
       - name: set dependencies env
         run: |
           echo 'DEPS<<EOF' >> $GITHUB_ENV


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/sdk-js/issues/761

The polkadot dependency upgrade workflow is broken. This fixes it.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
