### PR TITLE
feat: deprecate CType meta schema draft-01

### DIFF
--- a/packages/config/src/ConfigService.spec.ts
+++ b/packages/config/src/ConfigService.spec.ts
@@ -24,7 +24,7 @@ describe('Log Configuration', () => {
   it('Tests the default Log Level', () => {
     if (process.env.DEBUG === 'true') {
       expect(testLogger.getLogLevel()).toEqual(LogLevel.Debug)
-    } else expect(testLogger.getLogLevel()).toEqual(LogLevel.Error)
+    } else expect(testLogger.getLogLevel()).toEqual(LogLevel.Warn)
   })
 
   it('modifies the Log Level of all Loggers to the desired Level', () => {
@@ -44,7 +44,7 @@ describe('Log Configuration', () => {
 
 describe('Configuration Service', () => {
   it('has configuration Object with default values', () => {
-    expect(ConfigService.get('logLevel')).toEqual(LogLevel.Error)
+    expect(ConfigService.get('logLevel')).toEqual(LogLevel.Warn)
     expect(() => ConfigService.get('api')).toThrowErrorMatchingInlineSnapshot(
       `"The blockchain API is not set. Did you forget to call \`Kilt.connect(…)\` or \`Kilt.init(…)\`?"`
     )

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -24,12 +24,15 @@ import {
 } from 'typescript-logging'
 import type { SubscriptionPromise } from '@kiltprotocol/types'
 
-const DEFAULT_DEBUG_LEVEL =
-  typeof process !== 'undefined' &&
-  process.env?.DEBUG &&
-  process.env.DEBUG === 'true'
-    ? LogLevel.Debug
-    : LogLevel.Error
+const DEFAULT_DEBUG_LEVEL = (() => {
+  if (process?.env?.DEBUG === 'true') {
+    return LogLevel.Debug
+  }
+  if (process?.env?.NODE_ENV && process.env.NODE_ENV !== 'production') {
+    return LogLevel.Warn
+  }
+  return LogLevel.Error
+})()
 
 export type configOpts = {
   api: ApiPromise

--- a/packages/config/src/ConfigService.ts
+++ b/packages/config/src/ConfigService.ts
@@ -25,11 +25,13 @@ import {
 import type { SubscriptionPromise } from '@kiltprotocol/types'
 
 const DEFAULT_DEBUG_LEVEL = (() => {
-  if (process?.env?.DEBUG === 'true') {
-    return LogLevel.Debug
-  }
-  if (process?.env?.NODE_ENV && process.env.NODE_ENV !== 'production') {
-    return LogLevel.Warn
+  if (typeof process !== 'undefined') {
+    if (process.env.DEBUG === 'true') {
+      return LogLevel.Debug
+    }
+    if (process.env.NODE_ENV && process.env.NODE_ENV !== 'production') {
+      return LogLevel.Warn
+    }
   }
   return LogLevel.Error
 })()

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -33,7 +33,11 @@ import {
 let notifyDeprecated: (cTypeId: ICType['$id']) => void = () => {
   // do nothing
 }
-if (process?.env?.NODE_ENV && process.env.NODE_ENV !== 'production') {
+if (
+  typeof process !== 'undefined' &&
+  process.env?.NODE_ENV &&
+  process.env.NODE_ENV !== 'production'
+) {
   const logger = ConfigService.LoggingFactory.getLogger('deprecated')
   const alreadyNotified = new Set<ICType['$id']>()
   notifyDeprecated = (cTypeId) => {

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -30,6 +30,17 @@ import {
   CTypeModelV1,
 } from './CType.schemas.js'
 
+let notifyDeprecated: (cTypeId: ICType['$id']) => void = () => {
+  // do nothing
+}
+if (process?.env?.NODE_ENV && process.env.NODE_ENV !== 'production') {
+  const logger = ConfigService.LoggingFactory.getLogger('deprecated')
+  notifyDeprecated = (cTypeId) =>
+    logger.warn(
+      `Your application has processed the CType '${cTypeId}' which follows the meta schema '${CTypeModelDraft01.$id}'. This class of schemas has known issues that can result in unexpected properties being present in a credential. Consider switching to a CType based on meta schema ${CTypeModelV1.$id} which fixes this issue.`
+    )
+}
+
 /**
  * Utility for (re)creating CType hashes. Sorts the schema and strips the $id property (which contains the CType hash) before stringifying.
  *
@@ -136,6 +147,9 @@ export function verifyClaimAgainstSchema(
   messages?: string[]
 ): void {
   verifyObjectAgainstSchema(schema, CTypeModel, messages)
+  if (schema.$schema === CTypeModelDraft01.$id) {
+    notifyDeprecated(schema.$id)
+  }
   verifyObjectAgainstSchema(claimContents, schema, messages)
 }
 
@@ -162,6 +176,9 @@ export async function verifyStored(ctype: ICType): Promise<void> {
  */
 export function verifyDataStructure(input: ICType): void {
   verifyObjectAgainstSchema(input, CTypeModel)
+  if (input.$schema === CTypeModelDraft01.$id) {
+    notifyDeprecated(input.$id)
+  }
   const idFromSchema = getIdForSchema(input)
   if (idFromSchema !== input.$id) {
     throw new SDKErrors.CTypeIdMismatchError(idFromSchema, input.$id)

--- a/packages/core/src/ctype/CType.ts
+++ b/packages/core/src/ctype/CType.ts
@@ -35,10 +35,16 @@ let notifyDeprecated: (cTypeId: ICType['$id']) => void = () => {
 }
 if (process?.env?.NODE_ENV && process.env.NODE_ENV !== 'production') {
   const logger = ConfigService.LoggingFactory.getLogger('deprecated')
-  notifyDeprecated = (cTypeId) =>
+  const alreadyNotified = new Set<ICType['$id']>()
+  notifyDeprecated = (cTypeId) => {
+    if (alreadyNotified.has(cTypeId)) {
+      return
+    }
     logger.warn(
       `Your application has processed the CType '${cTypeId}' which follows the meta schema '${CTypeModelDraft01.$id}'. This class of schemas has known issues that can result in unexpected properties being present in a credential. Consider switching to a CType based on meta schema ${CTypeModelV1.$id} which fixes this issue.`
     )
+    alreadyNotified.add(cTypeId)
+  }
 }
 
 /**


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2379

Prints a deprecation message if CTypes following the legacy meta schema are being used.
Also adjusts the default log level in non-production environments so that these messages are actually shown.

## How to test:

Unit tests now started printing these deprecation messages.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
