### PR TITLE
test: make tests work with new kilt node cli

### DIFF
--- a/tests/bundle/bundle.spec.ts
+++ b/tests/bundle/bundle.spec.ts
@@ -7,10 +7,11 @@
 
 /// <reference lib="dom" />
 
-import { GenericContainer, Wait, StartedTestContainer } from 'testcontainers'
+import type { StartedTestContainer } from 'testcontainers'
 import { test, expect } from '@playwright/test'
 import url from 'url'
 import path from 'path'
+import { getStartedTestContainer } from '../integration/utils.js'
 
 declare global {
   interface Window {
@@ -24,13 +25,7 @@ const WS_PORT = 9944
 
 test.beforeAll(async () => {
   // start dev node with testcontainers
-  testcontainer = await new GenericContainer(
-    process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/mashnet-node:latest'
-  )
-    .withCommand(['--dev', `--ws-port=${WS_PORT}`, '--ws-external'])
-    .withExposedPorts({ container: WS_PORT, host: WS_PORT })
-    .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
-    .start()
+  testcontainer = await getStartedTestContainer(WS_PORT)
 })
 
 test('html bundle integration test', async ({ page }) => {

--- a/tests/integration/ErrorHandler.spec.ts
+++ b/tests/integration/ErrorHandler.spec.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
 it('records an extrinsic error when transferring less than the existential amount to new identity', async () => {
   const transferTx = api.tx.balances.transfer(addressFromRandom(), 1)
   const promise = submitTx(transferTx, paymentAccount)
-  if (api.runtimeVersion.specVersion.toBigInt() > 11_000n) {
+  if (api.runtimeVersion.specVersion.toBigInt() >= 11_200n) {
     await expect(promise).rejects.toMatchInlineSnapshot(`
       {
         "token": "BelowMinimum",

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -34,22 +34,36 @@ const ENDOWMENT = EXISTENTIAL_DEPOSIT.muln(10000)
 const WS_PORT = 9944
 
 async function getStartedTestContainer(): Promise<StartedTestContainer> {
-  try {
-    const image =
-      process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/mashnet-node'
-    console.log(`using testcontainer with image ${image}`)
-    const testcontainer = new GenericContainer(image)
-      .withCommand(['--dev', `--ws-port=${WS_PORT}`, '--ws-external'])
-      .withExposedPorts(WS_PORT)
-      .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
-    const started = await testcontainer.start()
-    return started
-  } catch (error) {
-    console.error(
-      'Could not start the docker container via testcontainers, run with DEBUG=testcontainers* to debug'
-    )
-    throw error
+  const image =
+    process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/mashnet-node'
+  console.log(`using testcontainer with image ${image}`)
+  const strategies = [
+    ['--dev', '--ws-external', `--ws-port=${WS_PORT}`],
+    ['--dev', '--rpc-external', `--rpc-port=${WS_PORT}`],
+  ]
+  // eslint-disable-next-line no-plusplus
+  for (let strategy = 0; strategy < strategies.length; strategy++) {
+    console.log(`attempting to launch container using strategy ${strategy}`)
+    try {
+      const testcontainer = new GenericContainer(image)
+        .withCommand(strategies[strategy])
+        .withExposedPorts(WS_PORT)
+        .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
+      // eslint-disable-next-line no-await-in-loop
+      const started = await testcontainer.start()
+      console.log('container started and ready')
+      return started
+    } catch (error) {
+      console.warn(
+        'Failed to start container due to the following error:\n',
+        error
+      )
+    }
   }
+  console.error(
+    'Could not start the docker container via testcontainers, run with DEBUG=testcontainers* to debug'
+  )
+  throw new Error('CONTAINER LAUNCH ERROR')
 }
 
 async function buildConnection(wsEndpoint: string): Promise<ApiPromise> {
@@ -69,7 +83,7 @@ export async function initializeApi(): Promise<ApiPromise> {
     return buildConnection(TEST_WS_ADDRESS)
   }
   const started = await getStartedTestContainer()
-  const port = started.getMappedPort(9944)
+  const port = started.getMappedPort(WS_PORT)
   const host = started.getHost()
   const WS_ADDRESS = `ws://${host}:${port}`
   console.log(`connecting to test container at ${WS_ADDRESS}`)

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -26,14 +26,16 @@ import type {
 } from '@kiltprotocol/types'
 import { Crypto } from '@kiltprotocol/utils'
 
-import { makeSigningKeyTool } from '../testUtils/index.js'
+import { makeSigningKeyTool } from '../testUtils/TestUtils.js'
 
 export const EXISTENTIAL_DEPOSIT = new BN(10 ** 13)
 const ENDOWMENT = EXISTENTIAL_DEPOSIT.muln(10000)
 
 const WS_PORT = 9944
 
-async function getStartedTestContainer(): Promise<StartedTestContainer> {
+export async function getStartedTestContainer(
+  hostPort?: number
+): Promise<StartedTestContainer> {
   const image =
     process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/mashnet-node'
   console.log(`using testcontainer with image ${image}`)
@@ -47,7 +49,11 @@ async function getStartedTestContainer(): Promise<StartedTestContainer> {
     try {
       const testcontainer = new GenericContainer(image)
         .withCommand(strategies[strategy])
-        .withExposedPorts(WS_PORT)
+        .withExposedPorts(
+          typeof hostPort === 'number'
+            ? { host: hostPort, container: WS_PORT }
+            : WS_PORT
+        )
         .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
       // eslint-disable-next-line no-await-in-loop
       const started = await testcontainer.start()

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -43,12 +43,12 @@ export async function getStartedTestContainer(
     ['--dev', '--ws-external', `--ws-port=${WS_PORT}`],
     ['--dev', '--rpc-external', `--rpc-port=${WS_PORT}`],
   ]
-  // eslint-disable-next-line no-plusplus
-  for (let strategy = 0; strategy < strategies.length; strategy++) {
-    console.log(`attempting to launch container using strategy ${strategy}`)
+  // eslint-disable-next-line no-restricted-syntax
+  for (const args of strategies) {
+    console.log(`attempting to launch container with arguments ${args}`)
     try {
       const testcontainer = new GenericContainer(image)
-        .withCommand(strategies[strategy])
+        .withCommand(args)
         .withExposedPorts(
           typeof hostPort === 'number'
             ? { host: hostPort, container: WS_PORT }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2835

A different startup strategy is required for kilt nodes based on polkadot v0.9.43 because the CLI has changed and arguments have been renamed.
This introduces a fallback strategy if the container can't be started, and will try again using a set of arguments which should work for the new CLI.

## How to test:

Latest currently uses the old CLI, while latest-develop uses the new CLI. If both integration test runs succeed, this works.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
