### PR TITLE
fix: include encoded details in DID validation logic

### DIFF
--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -207,6 +207,17 @@ describe('When dereferencing a verification method', () => {
       dereferencingMetadata: { error: 'invalidDidUrl' },
     })
   })
+
+  it('throws for valid light URLs but with details that cannot be decoded', async () => {
+    const invalidLightDidUrl =
+      `did:kilt:light:00${addressWithAuthenticationKey}:z22222#auth` as DidUrl
+    expect(
+      await Did.dereference(invalidLightDidUrl)
+    ).toStrictEqual<DereferenceResult>({
+      contentMetadata: {},
+      dereferencingMetadata: { error: 'invalidDidUrl' },
+    })
+  })
 })
 
 describe('When resolving a service', () => {
@@ -646,6 +657,14 @@ describe('When resolving a light DID', () => {
       didDocument: {
         id: migratedDid,
       },
+    })
+  })
+
+  it('throws for valid a light DID but with details that cannot be decoded', async () => {
+    const invalidLightDid: KiltDid = `did:kilt:light:00${addressWithAuthenticationKey}:z22222`
+    expect(await Did.resolve(invalidLightDid)).toStrictEqual<ResolutionResult>({
+      didDocumentMetadata: {},
+      didResolutionMetadata: { error: 'invalidDid' },
     })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2568.

A light DID with encoded details that cannot be decoded to anything, is indeed an invalid DID and should be treated as such 😁😁😁