### PR TITLE
feat: identity class

### DIFF
--- a/packages/credentials/src/issuer.ts
+++ b/packages/credentials/src/issuer.ts
@@ -13,6 +13,8 @@ import type { UnsignedVc, VerifiableCredential } from './V1/types.js'
 import type { CTypeLoader } from './ctype/index.js'
 import type { IssuerOptions } from './interfaces.js'
 
+export { IssuerOptions }
+
 /**
  * Creates a new credential document as a basis for issuing a credential.
  * This document can be shown to users as a preview or be extended with additional properties before moving on to the second step of credential issuance:

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -46,7 +46,8 @@
     "@kiltprotocol/credentials": "workspace:*",
     "@kiltprotocol/did": "workspace:*",
     "@kiltprotocol/type-definitions": "^0.35.0",
-    "@kiltprotocol/utils": "workspace:*"
+    "@kiltprotocol/utils": "workspace:*",
+    "@polkadot/util": "^12.0.0"
   },
   "peerDependencies": {
     "@kiltprotocol/augment-api": "^1.11210.0"

--- a/packages/sdk-js/src/Identity.ts
+++ b/packages/sdk-js/src/Identity.ts
@@ -5,6 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import type { GenericExtrinsic } from '@polkadot/types'
 import { u8aEq } from '@polkadot/util'
 import type { Keypair } from '@polkadot/util-crypto/types'
 
@@ -14,10 +15,12 @@ import type {
   DidDocument,
   DidUrl,
   KeyringPair,
+  KiltAddress,
   SignerInterface,
   UriFragment,
 } from '@kiltprotocol/types'
 import { SDKErrors, Signers } from '@kiltprotocol/utils'
+import type { TransactionResult } from '@kiltprotocol/credentials/src/V1/KiltAttestationProofV1'
 
 /**
  * An Identity represents a DID and signing keys associated with it.
@@ -73,6 +76,25 @@ export interface Identity {
     skipResolution?: boolean
     purgeSigners?: boolean
   }) => Promise<Identity>
+  /**
+   * The account that acts as the submitter account.
+   */
+  submitterAccount?: KiltAddress
+  /**
+   * Uses a verification method related signer to DID-authorize a call to be executed on-chain with the identity's DID as the origin.
+   *
+   * @param tx The call to be authorized.
+   * @returns The authorized (signed) call.
+   */
+  authorizeTx?: (tx: GenericExtrinsic) => Promise<GenericExtrinsic>
+  /**
+   * Takes care of submitting the transaction to node in the network and listening for execution results.
+   * This can consist of signing the tx using the signer associated with submitterAccount and interacting directly with a node, or can use an external service for this.
+   *
+   * @param tx The extrinsic ready to be (signed and) submitted.
+   * @returns A promise resolving to an object indicating the block of inclusion, or rejecting if the transaction failed to be included or execute correctly.
+   */
+  submitTx?: (tx: GenericExtrinsic) => Promise<TransactionResult>
 }
 
 async function loadDidDocument(

--- a/packages/sdk-js/src/Identity.ts
+++ b/packages/sdk-js/src/Identity.ts
@@ -320,7 +320,7 @@ function isTypedKeyPair(
     input !== null &&
     'type' in input &&
     'publicKey' in input &&
-    ['ed25519', 'sr25519', 'ecdsa'].includes(input.type as string) &&
+    ['ed25519', 'sr25519', 'ecdsa'].includes((input as any).type) &&
     ('secretKey' in input || 'sign' in input)
   )
 }

--- a/packages/sdk-js/src/Identity.ts
+++ b/packages/sdk-js/src/Identity.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2018-2023, BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import { u8aEq } from '@polkadot/util'
+import type { Keypair } from '@polkadot/util-crypto/types'
+
+import { multibaseKeyToDidKey, resolve } from '@kiltprotocol/did'
+import type {
+  Did,
+  DidDocument,
+  DidUrl,
+  KeyringPair,
+  SignerInterface,
+  UriFragment,
+} from '@kiltprotocol/types'
+import { SDKErrors, Signers } from '@kiltprotocol/utils'
+
+/**
+ * An Identity represents a DID and signing keys associated with it.
+ */
+export interface Identity {
+  did: Did
+  didDocument: DidDocument
+  signers: SignerInterface[]
+  /**
+   * Adds one or more signer interfaces to the `signers`.
+   *
+   * @param signers Signer Interface(s).
+   * @returns The (in-place) modified Identity object for chaining.
+   */
+  addSigner: (...signers: SignerInterface[]) => Promise<Identity>
+  /**
+   * Convenience function similar to {@link addSigner}, but creates signers for all matching known algorithms from a keypair.
+   *
+   * @param keypairs
+   * @returns The (in-place) modified Identity object for chaining.
+   */
+  addKeypair: (...keypairs: Array<Keypair | KeyringPair>) => Promise<Identity>
+  /**
+   * Helps filtering and selecting appropriate signers related to the DID's verification methods.
+   * Only returns signers that match a currently active verification method.
+   *
+   * @param filterBy Additional selection criteria, including which VM the signer relates to, which algorithm it uses, or which relationship it has to the DID.
+   * @returns A (potentially empty) array of signers, wrapped in a Promise because {@link Signers.selectSigners} is async.
+   */
+  getSigners: (filterBy: {
+    verificationMethod?: DidUrl | UriFragment
+    verificationRelationship?: string
+    algorithm?: string
+  }) => Promise<SignerInterface[]>
+  /**
+   * Same as {@link getSigners} but pre-selects a signer matching the criteria and throws if none are found.
+   *
+   * @param filterBy See {@link getSigners}.
+   * @returns A Promise of a signer, which rejects if none match the selection criteria.
+   */
+  getSigner: (filterBy: {
+    verificationMethod?: DidUrl | UriFragment
+    verificationRelationship?: string
+    algorithm?: string
+  }) => Promise<SignerInterface>
+  /**
+   * Refreshes the didDocument and/or purges signers that are not linked to a VM currently referenced in the document.
+   *
+   * @param opts Controls whether you want to only reload the document, or only purge signers. Defaults to doing both.
+   * @returns The (in-place) modified Identity object for chaining.
+   */
+  update: (opts: {
+    skipResolution?: boolean
+    purgeSigners?: boolean
+  }) => Promise<Identity>
+}
+
+async function loadDidDocument(
+  did: Did,
+  resolver: typeof resolve
+): Promise<DidDocument> {
+  const { didDocument } = await resolver(did)
+  if (!didDocument) {
+    throw new SDKErrors.DidNotFoundError(`failed to resolve ${did}`)
+  }
+  return didDocument
+}
+
+class IdentityClass implements Identity {
+  public did: Did
+  public resolver: typeof resolve
+  public didDocument: DidDocument
+  private didSigners: SignerInterface[]
+
+  constructor({
+    did,
+    didDocument,
+    signers,
+    resolver = resolve,
+  }: {
+    did: Did
+    didDocument: DidDocument
+    signers?: SignerInterface[]
+    resolver?: typeof resolve
+  }) {
+    this.did = did
+    this.didDocument = didDocument
+    this.didSigners = signers ? [...signers] : []
+    this.resolver = resolver
+  }
+
+  get signers(): SignerInterface[] {
+    return [...this.didSigners]
+  }
+
+  public async update({
+    skipResolution = false,
+    skipPurgeSigners = false,
+  }: {
+    skipResolution?: boolean
+    skipPurgeSigners?: boolean
+  } = {}): Promise<IdentityClass> {
+    if (skipResolution !== true) {
+      this.didDocument = await loadDidDocument(this.did, this.resolver)
+    }
+    if (skipPurgeSigners !== true) {
+      this.didSigners = await this.getSigners()
+    }
+    return this
+  }
+
+  public async addSigner(
+    ...signers: SignerInterface[]
+  ): Promise<IdentityClass> {
+    this.didSigners.push(...signers)
+    return this
+  }
+
+  public async addKeypair(
+    ...keypairs: Array<Keypair | KeyringPair>
+  ): Promise<IdentityClass> {
+    const didKeys = this.didDocument.verificationMethod?.map(
+      ({ publicKeyMultibase, id }) => ({
+        ...multibaseKeyToDidKey(publicKeyMultibase),
+        id,
+      })
+    )
+    if (didKeys && didKeys.length !== 0) {
+      await Promise.all(
+        keypairs.map(async (keypair) => {
+          const thisType = 'type' in keypair ? keypair.type : undefined
+          const matchingKey = didKeys?.find(({ publicKey, keyType }) => {
+            if (thisType && thisType !== keyType) {
+              return false
+            }
+            return u8aEq(publicKey, keypair.publicKey)
+          })
+          if (matchingKey) {
+            const id = matchingKey.id.startsWith('#')
+              ? this.did + matchingKey.id
+              : matchingKey.id
+            await this.addSigner(
+              ...(await Signers.getSignersForKeypair({
+                keypair,
+                id,
+                type: matchingKey.keyType,
+              }))
+            )
+          }
+        })
+      )
+    }
+    return this
+  }
+
+  public async getSigners({
+    verificationMethod,
+    verificationRelationship,
+    algorithm,
+  }: {
+    verificationMethod?: DidUrl | UriFragment
+    verificationRelationship?: string
+    algorithm?: string
+  } = {}): Promise<SignerInterface[]> {
+    const selectors = [
+      Signers.select.byDid(this.didDocument, { verificationRelationship }),
+    ]
+    if (algorithm) {
+      selectors.push(Signers.select.byAlgorithm([algorithm]))
+    }
+    if (verificationMethod) {
+      selectors.push(Signers.select.bySignerId([verificationMethod]))
+    }
+    return Signers.selectSigners(this.didSigners)
+  }
+
+  public async getSigner(
+    criteria: {
+      verificationMethod?: DidUrl | UriFragment
+      verificationRelationship?: string
+      algorithm?: string
+    } = {}
+  ): Promise<SignerInterface> {
+    const [signer] = await this.getSigners(criteria)
+    if (typeof signer === 'undefined') {
+      throw new SDKErrors.NoSuitableSignerError(undefined, {
+        signerRequirements: criteria,
+        availableSigners: this.didSigners,
+      })
+    }
+    return signer
+  }
+}
+
+export async function makeIdentity({
+  did,
+  didDocument,
+  keypairs,
+  signers,
+  resolver = resolve,
+}: {
+  did: Did
+  didDocument?: DidDocument
+  signers?: SignerInterface[]
+  keypairs?: Array<Keypair | KeyringPair>
+  resolver?: typeof resolve
+}): Promise<IdentityClass> {
+  const identity = new IdentityClass({
+    did,
+    didDocument: didDocument ?? (await loadDidDocument(did, resolver)),
+    signers,
+    resolver,
+  })
+  await identity.update({ skipResolution: true })
+  if (keypairs && keypairs.length !== 0) {
+    await identity.addKeypair(...keypairs)
+  }
+  return identity
+}

--- a/packages/sdk-js/src/Identity.ts
+++ b/packages/sdk-js/src/Identity.ts
@@ -152,7 +152,11 @@ class IdentityClass implements Identity {
       this.didDocument = await loadDidDocument(this.did, this.resolver)
     }
     if (skipPurgeSigners !== true) {
-      this.didSigners = this.getSigners()
+      try {
+        this.didSigners = this.getSigners()
+      } catch {
+        this.didSigners = []
+      }
     }
     return this
   }
@@ -217,7 +221,7 @@ class IdentityClass implements Identity {
     if (verificationMethod) {
       selectors.push(Signers.select.bySignerId([verificationMethod]))
     }
-    return Signers.selectSigners(this.didSigners)
+    return Signers.selectSigners(this.didSigners, ...selectors)
   }
 
   public getSigner(

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -19,7 +19,12 @@ import {
   Blockchain,
 } from '@kiltprotocol/chain-helpers'
 import { resolver as DidResolver } from '@kiltprotocol/did'
-import { makeIdentity, Identity, withSubmitterAccount } from './Identity.js'
+import {
+  newIdentity,
+  makeIdentity,
+  Identity,
+  withSubmitterAccount,
+} from './Identity.js'
 
 const { signAndSubmitTx } = Blockchain // TODO: maybe we don't even need that if we have the identity class
 const { signerFromKeypair } = Signers
@@ -36,6 +41,7 @@ export {
   signAndSubmitTx,
   ConfigService,
   Identity,
+  newIdentity,
   makeIdentity,
   withSubmitterAccount,
 }

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -19,6 +19,7 @@ import {
   Blockchain,
 } from '@kiltprotocol/chain-helpers'
 import { resolver as DidResolver } from '@kiltprotocol/did'
+import { makeIdentity } from './Identity.js'
 
 const { signAndSubmitTx } = Blockchain // TODO: maybe we don't even need that if we have the identity class
 const { signerFromKeypair } = Signers
@@ -34,4 +35,5 @@ export {
   signerFromKeypair,
   signAndSubmitTx,
   ConfigService,
+  makeIdentity,
 }

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -19,7 +19,7 @@ import {
   Blockchain,
 } from '@kiltprotocol/chain-helpers'
 import { resolver as DidResolver } from '@kiltprotocol/did'
-import { makeIdentity } from './Identity.js'
+import { makeIdentity, Identity } from './Identity.js'
 
 const { signAndSubmitTx } = Blockchain // TODO: maybe we don't even need that if we have the identity class
 const { signerFromKeypair } = Signers
@@ -36,4 +36,5 @@ export {
   signAndSubmitTx,
   ConfigService,
   makeIdentity,
+  Identity,
 }

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -27,7 +27,7 @@ import {
 } from './Identity.js'
 
 const { signAndSubmitTx } = Blockchain // TODO: maybe we don't even need that if we have the identity class
-const { signerFromKeypair } = Signers
+const { signerFromKeypair, generateKeypair } = Signers
 
 export {
   init,
@@ -37,8 +37,9 @@ export {
   Holder,
   Verifier,
   Issuer,
-  signerFromKeypair,
   signAndSubmitTx,
+  generateKeypair,
+  signerFromKeypair,
   ConfigService,
   Identity,
   newIdentity,

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -19,7 +19,7 @@ import {
   Blockchain,
 } from '@kiltprotocol/chain-helpers'
 import { resolver as DidResolver } from '@kiltprotocol/did'
-import { makeIdentity, Identity } from './Identity.js'
+import { makeIdentity, Identity, withSubmitterAccount } from './Identity.js'
 
 const { signAndSubmitTx } = Blockchain // TODO: maybe we don't even need that if we have the identity class
 const { signerFromKeypair } = Signers
@@ -35,6 +35,7 @@ export {
   signerFromKeypair,
   signAndSubmitTx,
   ConfigService,
-  makeIdentity,
   Identity,
+  makeIdentity,
+  withSubmitterAccount,
 }

--- a/packages/types/src/Address.ts
+++ b/packages/types/src/Address.ts
@@ -30,6 +30,6 @@ declare module '@polkadot/keyring' {
   ): string
   function encodeAddress(
     key: HexString | Uint8Array | string,
-    ss58Format?: 38
+    ss58Format: 38
   ): KiltAddress
 }

--- a/packages/utils/src/Signers.ts
+++ b/packages/utils/src/Signers.ts
@@ -17,6 +17,7 @@ import {
 import {
   blake2AsU8a,
   encodeAddress,
+  randomAsHex,
   secp256k1Sign,
 } from '@polkadot/util-crypto'
 import type { Keypair } from '@polkadot/util-crypto/types'

--- a/packages/utils/src/Signers.ts
+++ b/packages/utils/src/Signers.ts
@@ -41,6 +41,7 @@ import type {
   DidUrl,
   KeyringPair,
   UriFragment,
+  KiltAddress,
 } from '@kiltprotocol/types'
 
 import { DidError, NoSuitableSignerError } from './SDKErrors.js'
@@ -153,7 +154,7 @@ const signerFactory = {
  */
 export async function signerFromKeypair<
   Alg extends KnownAlgorithms,
-  Id extends string
+  Id extends string = KiltAddress
 >({
   id,
   keypair,
@@ -226,7 +227,7 @@ function algsForKeyType(keyType: string): KnownAlgorithms[] {
  * @param input.type If `keypair` is not a {@link KeyringPair}, provide the key type here; otherwise, this is ignored.
  * @returns An array of signer interfaces based on the keypair and type.
  */
-export async function getSignersForKeypair<Id extends string>({
+export async function getSignersForKeypair<Id extends string = KiltAddress>({
   id,
   keypair,
   type = (keypair as KeyringPair).type,

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -29,7 +29,7 @@ const {
 async function createFullDidIdentity(
   payer: SignerInterface<'Ed25519', KiltAddress>,
   seed: string,
-  signKeyType: KiltKeyringPair['type'] = 'sr25519'
+  signKeyType: KiltKeyringPair['type'] = 'ed25519'
 ) {
   const keypair = generateKeypair({ seed, type: signKeyType })
 
@@ -59,7 +59,7 @@ async function runAll() {
   const FaucetSeed =
     'receive clutch item involve chaos clutch furnace arrest claw isolate okay together'
   const payerKp = generateKeypair({ seed: FaucetSeed, type: 'ed25519' })
-  const payerSigner = await signerFromKeypair<'Ed25519', KiltAddress>({
+  const payerSigner = await signerFromKeypair({
     keypair: payerKp,
     algorithm: 'Ed25519',
   })
@@ -81,16 +81,8 @@ async function runAll() {
 
   console.log('bob setup done')
 
-  const authPublicKey = new Uint8Array([
-    170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170,
-    170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170,
-    170, 170,
-  ])
-  const encPublicKey = new Uint8Array([
-    187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187,
-    187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187, 187,
-    187, 187,
-  ])
+  const authPublicKey = new Uint8Array(32).fill(170)
+  const encPublicKey = new Uint8Array(32).fill(187)
   const testDid = await newIdentity({
     keys: {
       authentication: [
@@ -172,7 +164,7 @@ async function runAll() {
     throw new Error('Claim content inside Credential mismatching')
   }
 
-  const issued = await Issuer.issue(credential, alice as any)
+  const issued = await Issuer.issue(credential, alice)
   console.info('Credential issued')
 
   const credentialResult = await Verifier.verifyCredential(

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -25,7 +25,7 @@ import type {
   SubmittableExtrinsic,
   SubscriptionPromise,
 } from '@kiltprotocol/types'
-import { Crypto } from '@kiltprotocol/utils'
+import { Crypto, ss58Format } from '@kiltprotocol/utils'
 
 import { makeSigningKeyTool } from '../testUtils/TestUtils.js'
 
@@ -110,7 +110,7 @@ export const devBob = Crypto.makeKeypairFromUri('//Bob')
 export const devCharlie = Crypto.makeKeypairFromUri('//Charlie')
 
 export function addressFromRandom(): KiltAddress {
-  return encodeAddress(randomAsU8a())
+  return encodeAddress(randomAsU8a(), ss58Format)
 }
 
 export async function isCtypeOnChain(cType: ICType): Promise<boolean> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,6 +2204,7 @@ __metadata:
     "@kiltprotocol/type-definitions": "npm:^0.35.0"
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/typegen": "npm:^10.7.3"
+    "@polkadot/util": "npm:^12.0.0"
     rimraf: "npm:^3.0.2"
     terser-webpack-plugin: "npm:^5.1.1"
     typescript: "npm:^4.8.3"


### PR DESCRIPTION
closes kiltprotocol/ticket#3043

# TODOs

- I ultimately envision this to have high-level support for managing an on-chain identity as well; but as-is, you can already make any DID operation (including those changing your DID document) through a combination of `authorizeTx`, `submitTx`, and `update`.
- creating a new DID should allow passing account signers instead of keypairs
- the vocabulary/terminology needs to be refined and finalised to make sure all methods and parameters communicate clearly what they are made for.
  