### PR TITLE
fix: ignore out-of-range log level in ConfigService.spec.ts

### DIFF
--- a/packages/config/src/ConfigService.spec.ts
+++ b/packages/config/src/ConfigService.spec.ts
@@ -31,6 +31,7 @@ describe('Log Configuration', () => {
       ConfigService.LoggingFactory.getLogger('test1').getLogLevel()
     ).toEqual(LogLevel.Info)
 
+    // @ts-ignore Only values 0-6 are valid. https://github.com/vauxite-org/typescript-logging/blob/cf0d3e7d52b1da0650b16308cc3f1a56bcb95b5b/core/src/typescript/main/core/api/LogLevel.ts#L5C1-L12C10
     ConfigService.modifyLogLevel(-100)
     expect(testLogger.getLogLevel()).toEqual(0)
     ConfigService.modifyLogLevel(initialLevel)


### PR DESCRIPTION
Added // @ts-ignore 

Only values 0-6 are valid. https://github.com/vauxite-org/typescript-logging/blob/cf0d3e7d52b1da0650b16308cc3f1a56bcb95b5b/core/src/typescript/main/core/api/LogLevel.ts#L5C1-L12C10

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
