### PR TITLE
chore(deps): bump node to v18

### DIFF
--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
         node-version: [18.x, 20.x]
         required: ['required']
         include:
-          - node-version: 22.x
+          - node-version: 16.x
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -58,10 +58,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
         required: ['required']
         include:
-          - node-version: 20.x
+          - node-version: 22.x
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
         node-version: [18, 20]
         required: ['required']
         include:
-          - node-version: 22
+          - node-version: 16
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18, 20]
         required: ['required']
         include:
-          - node-version: 20
+          - node-version: 22
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/Gallium
+lts/Iron

--- a/packages/asset-credentials/package.json
+++ b/packages/asset-credentials/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/augment-api/package.json
+++ b/packages/augment-api/package.json
@@ -33,7 +33,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,7 +25,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/jsonld-suites/package.json
+++ b/packages/jsonld-suites/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/legacy-credentials/package.json
+++ b/packages/legacy-credentials/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -25,7 +25,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/type-definitions/package.json
+++ b/packages/type-definitions/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,7 +23,7 @@
   },
   "repository": "github:kiltprotocol/sdk-js",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "author": "",
   "license": "BSD-4-Clause",


### PR DESCRIPTION
## re https://github.com/KILTprotocol/ticket/issues/3081

Require at least node v18 (maintenance), CI uses node v20 (current). Testing against v16 has moved to optional.
https://nodejs.org/en/about/previous-releases

## How to test:

CI should not break.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
