### PR TITLE
refactor: more flexible extrinsic unwrapping for ctype fetching

### DIFF
--- a/packages/asset-credentials/src/credentials/PublicCredential.chain.ts
+++ b/packages/asset-credentials/src/credentials/PublicCredential.chain.ts
@@ -152,7 +152,7 @@ export async function fetchCredentialFromChain(
     ({ events }) =>
       events.some(
         (event) =>
-          api.events.publicCredentials.CredentialStored.is(event) &&
+          api.events.publicCredentials?.CredentialStored?.is(event) &&
           event.data[1].toString() === credentialId
       ),
     api
@@ -170,7 +170,7 @@ export async function fetchCredentialFromChain(
   // only consider public_credentials::add calls
   const publicCredentialCalls = extrinsicCalls.filter(
     (c): c is GenericCall<typeof api.tx.publicCredentials.add.args> =>
-      api.tx.publicCredentials.add.is(c)
+      api.tx.publicCredentials?.add?.is(c)
   )
 
   // Re-create the issued public credential for each call identified to find the credential with the id we're looking for

--- a/packages/asset-credentials/src/credentials/PublicCredential.chain.ts
+++ b/packages/asset-credentials/src/credentials/PublicCredential.chain.ts
@@ -14,9 +14,7 @@ import type {
   Did,
   HexString,
 } from '@kiltprotocol/types'
-import type { ApiPromise } from '@polkadot/api'
 import type { GenericCall, Option } from '@polkadot/types'
-import type { Call } from '@polkadot/types/interfaces'
 import type { BN } from '@polkadot/util'
 import type {
   PublicCredentialsCredentialsCredential,
@@ -125,28 +123,6 @@ export function fromChain(
 }
 
 // Given a (nested) call, flattens them and filter by calls that are of type `api.tx.publicCredentials.add`.
-function extractPublicCredentialCreationCallsFromDidCall(
-  api: ApiPromise,
-  call: Call
-): Array<GenericCall<typeof api.tx.publicCredentials.add.args>> {
-  const extrinsicCalls = Blockchain.flattenCalls(call, api)
-  return extrinsicCalls.filter(
-    (c): c is GenericCall<typeof api.tx.publicCredentials.add.args> =>
-      api.tx.publicCredentials.add.is(c)
-  )
-}
-
-// Given a (nested) call, flattens them and filter by calls that are of type `api.tx.did.submitDidCall`.
-function extractDidCallsFromBatchCall(
-  api: ApiPromise,
-  call: Call
-): Array<GenericCall<typeof api.tx.did.submitDidCall.args>> {
-  const extrinsicCalls = Blockchain.flattenCalls(call, api)
-  return extrinsicCalls.filter(
-    (c): c is GenericCall<typeof api.tx.did.submitDidCall.args> =>
-      api.tx.did.submitDidCall.is(c)
-  )
-}
 
 /**
  * Retrieves from the blockchain the {@link IPublicCredential} that is identified by the provided identifier.
@@ -164,18 +140,32 @@ export async function fetchCredentialFromChain(
   const publicCredentialEntry = await api.call.publicCredentials.getById(
     credentialId
   )
-  const { blockNumber, revoked } = publicCredentialEntry.unwrap()
-
-  const extrinsic = await Blockchain.retrieveExtrinsicFromBlock(
+  const {
     blockNumber,
-    ({ events }) =>
-      events.some(
-        (event) =>
-          api.events.publicCredentials.CredentialStored.is(event) &&
-          event.data[1].toString() === credentialId
-      ),
-    api
+    revoked,
+    attester: attesterId,
+  } = publicCredentialEntry.unwrap()
+
+  const { extrinsics, events } = await api.derive.chain.getBlockByNumber(
+    blockNumber
   )
+
+  const createdEvent = events
+    .reverse()
+    .find(
+      ({ event }) =>
+        api.events.publicCredentials.CredentialStored.is(event) &&
+        event.data[1].toString() === credentialId
+    )
+
+  if (typeof createdEvent === 'undefined') {
+    throw new Error(
+      `A credential stored event was not found at the specified block`
+    )
+  }
+
+  const extrinsicIndex = createdEvent.phase.asApplyExtrinsic.toNumber()
+  const extrinsic = extrinsics[extrinsicIndex]
 
   if (extrinsic === null) {
     throw new SDKErrors.PublicCredentialError(
@@ -183,53 +173,32 @@ export async function fetchCredentialFromChain(
     )
   }
 
-  if (
-    !Blockchain.isBatch(extrinsic, api) &&
-    !api.tx.did.submitDidCall.is(extrinsic)
-  ) {
-    throw new SDKErrors.PublicCredentialError(
-      'Extrinsic should be either a `did.submitDidCall` extrinsic or a batch with at least a `did.submitDidCall` extrinsic'
-    )
-  }
+  // Unpack any nested calls, e.g., within a batch or `submit_did_call`
+  const extrinsicCalls = Blockchain.flattenCalls(extrinsic.extrinsic, api)
 
-  // If we're dealing with a batch, flatten any nested `submit_did_call` calls,
-  // otherwise the extrinsic is itself a submit_did_call, so just take it.
-  const didCalls = Blockchain.isBatch(extrinsic, api)
-    ? extrinsic.args[0].flatMap((batchCall) =>
-        extractDidCallsFromBatchCall(api, batchCall)
-      )
-    : [extrinsic]
+  // only consider public_credentials::add calls
+  const publicCredentialCalls = extrinsicCalls.filter(
+    (c): c is GenericCall<typeof api.tx.publicCredentials.add.args> =>
+      api.tx.publicCredentials.add.is(c)
+  )
 
-  // From the list of DID calls, only consider public_credentials::add calls, bundling each of them with their DID submitter.
-  // It returns a list of [reconstructedCredential, attesterDid].
-  const callCredentialsContent = didCalls.flatMap((didCall) => {
-    const publicCredentialCalls =
-      extractPublicCredentialCreationCallsFromDidCall(api, didCall.args[0].call)
-    // Re-create the issued public credential for each call identified.
-    return publicCredentialCalls.map(
-      (credentialCreationCall) =>
-        [
-          credentialInputFromChain(credentialCreationCall.args[0]),
-          didFromChain(didCall.args[0].did),
-        ] as const
-    )
-  })
-
-  // If more than one call is present, it always considers the last one as the valid one, and takes its attester.
-  const lastRightCredentialCreationCall = callCredentialsContent
+  // Re-create the issued public credential for each call identified.
+  const lastRightCredentialCreationCall = publicCredentialCalls
     .reverse()
-    .find(([credential, attester]) => {
-      const reconstructedId = getIdForCredential(credential, attester)
-      return reconstructedId === credentialId
-    })
+    .find((credentialCreationCall) =>
+      credentialInputFromChain(credentialCreationCall.args[0])
+    )
 
-  if (!lastRightCredentialCreationCall) {
+  if (typeof lastRightCredentialCreationCall === 'undefined') {
     throw new SDKErrors.PublicCredentialError(
       'Block should always contain the full credential, eventually.'
     )
   }
 
-  const [credentialInput, attester] = lastRightCredentialCreationCall
+  const credentialInput = credentialInputFromChain(
+    lastRightCredentialCreationCall.args[0]
+  )
+  const attester = didFromChain(attesterId)
 
   return {
     ...credentialInput,

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -34,6 +34,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
+    "@kiltprotocol/augment-api": "workspace:^",
     "@kiltprotocol/config": "workspace:*",
     "@kiltprotocol/type-definitions": "workspace:*",
     "@kiltprotocol/types": "workspace:*",

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -240,10 +240,16 @@ export function flattenCalls(call: IMethod, api?: ApiPromise): IMethod[] {
     return call.args[0].flatMap((c) => flattenCalls(c, apiObject))
   }
   if (apiObject.tx.did.submitDidCall.is(call)) {
-    return flattenCalls(call.args[0].call, api)
+    return flattenCalls(call.args[0].call, apiObject)
   }
   if (apiObject.tx.did.dispatchAs.is(call)) {
-    return flattenCalls(call.args[1], api)
+    return flattenCalls(call.args[1], apiObject)
+  }
+  if (apiObject.tx.proxy.proxy.is(call)) {
+    return flattenCalls(call.args[2], apiObject)
+  }
+  if (apiObject.tx.proxy.proxyAnnounced.is(call)) {
+    return flattenCalls(call.args[3], apiObject)
   }
   // Base case
   return [call]

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -224,9 +224,15 @@ export function isBatch(
 }
 
 /**
- * Flatten all calls into a single array following a DFS approach.
+ * Flatten all nested calls into a single array following a DFS approach.
  *
  * For example, given the calls [[N1, N2], [N3, [N4, N5], N6]], the final list will look like [N1, N2, N3, N4, N5, N6].
+ *
+ * The following extrinsics are recognized as containing nested calls and will be unpacked:
+ *
+ * - pallet `utility`: `batch`, `batchAll`, `forceBatch`.
+ * - pallet `did`: `submitDidCall`, `dispatchAs`.
+ * - pallet `proxy`: `proxy`, `proxyAnnounced`.
  *
  * @param call The {@link Call} which can potentially contain nested calls.
  * @param api The optional {@link ApiPromise}. If not provided, the one returned by the `ConfigService` is used.

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -217,9 +217,9 @@ export function isBatch(
 ): extrinsic is IMethod<[Vec<Call>]> {
   const apiPromise = api ?? ConfigService.get('api')
   return (
-    apiPromise.tx.utility.batch.is(extrinsic) ||
-    apiPromise.tx.utility.batchAll.is(extrinsic) ||
-    apiPromise.tx.utility.forceBatch.is(extrinsic)
+    apiPromise.tx.utility?.batch?.is(extrinsic) ||
+    apiPromise.tx.utility?.batchAll?.is(extrinsic) ||
+    apiPromise.tx.utility?.forceBatch?.is(extrinsic)
   )
 }
 
@@ -239,16 +239,16 @@ export function flattenCalls(call: IMethod, api?: ApiPromise): IMethod[] {
     // Inductive case
     return call.args[0].flatMap((c) => flattenCalls(c, apiObject))
   }
-  if (apiObject.tx.did.submitDidCall.is(call)) {
+  if (apiObject.tx.did?.submitDidCall?.is(call)) {
     return flattenCalls(call.args[0].call, apiObject)
   }
-  if (apiObject.tx.did.dispatchAs.is(call)) {
+  if (apiObject.tx.did?.dispatchAs?.is(call)) {
     return flattenCalls(call.args[1], apiObject)
   }
-  if (apiObject.tx.proxy.proxy.is(call)) {
+  if (apiObject.tx.proxy?.proxy?.is(call)) {
     return flattenCalls(call.args[2], apiObject)
   }
-  if (apiObject.tx.proxy.proxyAnnounced.is(call)) {
+  if (apiObject.tx.proxy?.proxyAnnounced?.is(call)) {
     return flattenCalls(call.args[3], apiObject)
   }
   // Base case

--- a/packages/credentials/src/V1/KiltAttestationProofV1.ts
+++ b/packages/credentials/src/V1/KiltAttestationProofV1.ts
@@ -244,7 +244,7 @@ async function verifyAttestedAt(
     .find(
       ({ phase, event }) =>
         phase.isApplyExtrinsic &&
-        api.events.attestation.AttestationCreated.is(event) &&
+        api.events.attestation?.AttestationCreated?.is(event) &&
         u8aEq(event.data[1], claimHash)
     )
   if (!attestationEvent)

--- a/packages/credentials/src/ctype/CType.chain.ts
+++ b/packages/credentials/src/ctype/CType.chain.ts
@@ -165,21 +165,29 @@ export async function fetchFromChain(
 
   // Re-create the ctype for each call identified to find the right ctype.
   // If more than one matching call is present, it always considers the last one as the valid one.
-  const lastRightCTypeCreationCall = ctypeCreationCalls
-    .reverse()
-    .find(
-      (ctypeCreationCall) =>
-        cTypeInputFromChain(ctypeCreationCall.args[0]).$id === cTypeId
-    )
+  const cTypeDefinition = ctypeCreationCalls.reduceRight<ICType | undefined>(
+    (selectedCType, cTypeCreationCall) => {
+      if (selectedCType) {
+        return selectedCType
+      }
+      const cType = cTypeInputFromChain(cTypeCreationCall.args[0])
 
-  if (typeof lastRightCTypeCreationCall === 'undefined') {
+      if (cType.$id === cTypeId) {
+        return cType
+      }
+      return undefined
+    },
+    undefined
+  )
+
+  if (typeof cTypeDefinition === 'undefined') {
     throw new SDKErrors.CTypeError(
       'Block should always contain the full CType, eventually.'
     )
   }
 
   return {
-    cType: cTypeInputFromChain(lastRightCTypeCreationCall.args[0]),
+    cType: cTypeDefinition,
     creator,
     createdAt,
   }

--- a/packages/credentials/src/ctype/CType.chain.ts
+++ b/packages/credentials/src/ctype/CType.chain.ts
@@ -142,7 +142,7 @@ export async function fetchFromChain(
     ({ events }) =>
       events.some(
         (event) =>
-          api.events.ctype.CTypeCreated.is(event) &&
+          api.events.ctype?.CTypeCreated?.is(event) &&
           event.data[1].toHex() === cTypeHash
       ),
     api
@@ -160,7 +160,7 @@ export async function fetchFromChain(
   // only consider ctype::add calls
   const ctypeCreationCalls = extrinsicCalls.filter(
     (c): c is GenericCall<typeof api.tx.ctype.add.args> =>
-      api.tx.ctype.add.is(c)
+      api.tx.ctype?.add?.is(c)
   )
 
   // Re-create the ctype for each call identified to find the right ctype.

--- a/packages/credentials/src/ctype/CType.chain.ts
+++ b/packages/credentials/src/ctype/CType.chain.ts
@@ -5,9 +5,8 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { ApiPromise } from '@polkadot/api'
 import type { Bytes, GenericCall, Option } from '@polkadot/types'
-import type { AccountId, Call } from '@polkadot/types/interfaces'
+import type { AccountId } from '@polkadot/types/interfaces'
 import type { BN } from '@polkadot/util'
 
 import type { CtypeCtypeEntry } from '@kiltprotocol/augment-api'
@@ -118,30 +117,6 @@ export function fromChain(
   }
 }
 
-// Given a (nested) call, flattens them and filter by calls that are of type `api.tx.ctype.add`.
-function extractCTypeCreationCallsFromDidCall(
-  api: ApiPromise,
-  call: Call
-): Array<GenericCall<typeof api.tx.ctype.add.args>> {
-  const extrinsicCalls = Blockchain.flattenCalls(call, api)
-  return extrinsicCalls.filter(
-    (c): c is GenericCall<typeof api.tx.ctype.add.args> =>
-      api.tx.ctype.add.is(c)
-  )
-}
-
-// Given a (nested) call, flattens them and filter by calls that are of type `api.tx.did.submitDidCall`.
-function extractDidCallsFromBatchCall(
-  api: ApiPromise,
-  call: Call
-): Array<GenericCall<typeof api.tx.did.submitDidCall.args>> {
-  const extrinsicCalls = Blockchain.flattenCalls(call, api)
-  return extrinsicCalls.filter(
-    (c): c is GenericCall<typeof api.tx.did.submitDidCall.args> =>
-      api.tx.did.submitDidCall.is(c)
-  )
-}
-
 /**
  * Resolves a CType identifier to the CType definition by fetching data from the block containing the transaction that registered the CType on chain.
  *
@@ -156,83 +131,65 @@ export async function fetchFromChain(
   const cTypeHash = idToHash(cTypeId)
 
   const cTypeEntry = await api.query.ctype.ctypes(cTypeHash)
-  const { createdAt } = fromChain(cTypeEntry)
+  const { createdAt, creator } = fromChain(cTypeEntry)
   if (typeof createdAt === 'undefined')
     throw new SDKErrors.CTypeError(
       'Cannot fetch CType definitions on a chain that does not store the createdAt block'
     )
 
-  const extrinsic = await Blockchain.retrieveExtrinsicFromBlock(
-    createdAt,
-    ({ events }) =>
-      events.some(
-        (event) =>
-          api.events.ctype.CTypeCreated.is(event) &&
-          event.data[1].toString() === cTypeHash
-      ),
-    api
+  const { extrinsics, events } = await api.derive.chain.getBlockByNumber(
+    createdAt
   )
 
-  if (extrinsic === null) {
-    throw new SDKErrors.CTypeError(
-      `There is not CType with the provided ID "${cTypeId}" on chain.`
-    )
-  }
-
-  if (
-    !Blockchain.isBatch(extrinsic, api) &&
-    !api.tx.did.submitDidCall.is(extrinsic)
-  ) {
-    throw new SDKErrors.PublicCredentialError(
-      'Extrinsic should be either a `did.submitDidCall` extrinsic or a batch with at least a `did.submitDidCall` extrinsic'
-    )
-  }
-
-  // If we're dealing with a batch, flatten any nested `submit_did_call` calls,
-  // otherwise the extrinsic is itself a submit_did_call, so just take it.
-  const didCalls = Blockchain.isBatch(extrinsic, api)
-    ? extrinsic.args[0].flatMap((batchCall) =>
-        extractDidCallsFromBatchCall(api, batchCall)
-      )
-    : [extrinsic]
-
-  // From the list of DID calls, only consider ctype::add calls, bundling each of them with their DID submitter.
-  // It returns a list of [reconstructedCType, attesterDid].
-  const ctypeCallContent = didCalls.flatMap((didCall) => {
-    const ctypeCreationCalls = extractCTypeCreationCallsFromDidCall(
-      api,
-      didCall.args[0].call
-    )
-    // Re-create the issued public credential for each call identified.
-    return ctypeCreationCalls.map(
-      (ctypeCreationCall) =>
-        [
-          cTypeInputFromChain(ctypeCreationCall.args[0]),
-          Did.fromChain(didCall.args[0].did),
-        ] as const
-    )
-  })
-
-  // If more than a call is present, it always considers the last one as the valid one.
-  const lastRightCTypeCreationCall = ctypeCallContent
+  const createdEvent = events
     .reverse()
-    .find((cTypeInput) => {
-      return cTypeInput[0].$id === cTypeId
-    })
+    .find(
+      ({ event }) =>
+        api.events.ctype.CTypeCreated.is(event) &&
+        event.data[1].toHex() === cTypeHash
+    )
 
-  if (!lastRightCTypeCreationCall) {
+  if (typeof createdEvent === 'undefined') {
+    throw new Error(
+      `A ctype creation event was not found at the specified block`
+    )
+  }
+
+  const extrinsicIndex = createdEvent.phase.asApplyExtrinsic.toNumber()
+  const extrinsic = extrinsics[extrinsicIndex]
+
+  if (typeof extrinsic === 'undefined') {
+    throw new SDKErrors.CTypeError(
+      `There is no CType with the provided ID "${cTypeId}" on chain.`
+    )
+  }
+
+  // Unpack any nested calls, e.g., within a batch or `submit_did_call`
+  const extrinsicCalls = Blockchain.flattenCalls(extrinsic.extrinsic, api)
+
+  // only consider ctype::add calls
+  const ctypeCreationCalls = extrinsicCalls.filter(
+    (c): c is GenericCall<typeof api.tx.ctype.add.args> =>
+      api.tx.ctype.add.is(c)
+  )
+
+  // Re-create the ctype for each call identified to find the right ctype.
+  // If more than one matching call is present, it always considers the last one as the valid one.
+  const lastRightCTypeCreationCall = ctypeCreationCalls
+    .reverse()
+    .find(
+      (ctypeCreationCall) =>
+        cTypeInputFromChain(ctypeCreationCall.args[0]).$id === cTypeId
+    )
+
+  if (typeof lastRightCTypeCreationCall === 'undefined') {
     throw new SDKErrors.CTypeError(
       'Block should always contain the full CType, eventually.'
     )
   }
 
-  const [ctypeInput, creator] = lastRightCTypeCreationCall
-
   return {
-    cType: {
-      ...ctypeInput,
-      $id: cTypeId,
-    },
+    cType: cTypeInputFromChain(lastRightCTypeCreationCall.args[0]),
     creator,
     createdAt,
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,7 +2092,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kiltprotocol/augment-api@workspace:*, @kiltprotocol/augment-api@workspace:packages/augment-api":
+"@kiltprotocol/augment-api@workspace:*, @kiltprotocol/augment-api@workspace:^, @kiltprotocol/augment-api@workspace:packages/augment-api":
   version: 0.0.0-use.local
   resolution: "@kiltprotocol/augment-api@workspace:packages/augment-api"
   dependencies:
@@ -2116,6 +2116,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kiltprotocol/chain-helpers@workspace:packages/chain-helpers"
   dependencies:
+    "@kiltprotocol/augment-api": "workspace:^"
     "@kiltprotocol/config": "workspace:*"
     "@kiltprotocol/type-definitions": "workspace:*"
     "@kiltprotocol/types": "workspace:*"


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3119

While I hot fixed the current behaviour in https://github.com/KILTprotocol/sdk-js/pull/836 to allow extrinsics submitted via dispatchAs, I think it's a better strategy for the future to build on top of on an unwrapper function that returns nested calls contained within other extrinsics that can easily be amended. E.g., we could easily add unwrapping of proxy calls to the logic here and everything still works.

## How to test:

Ideally, fetch a CType with it.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
