### PR TITLE
feat: adding a new test for w3n 

### DIFF
--- a/tests/integration/Web3Names.spec.ts
+++ b/tests/integration/Web3Names.spec.ts
@@ -172,6 +172,18 @@ describe('When there is an Web3NameCreator and a payer', () => {
     )
     await submitTx(authorizedTx, paymentAccount)
   }, 40_000)
+
+  it('should be possible to reclaim a name after a w3n has been reclaimed by a payment account', async () => {
+    const tx = api.tx.web3Names.claim(nick)
+    const authorizedTx = await Did.authorizeTx(
+      otherWeb3NameCreator.id,
+      tx,
+      await otherW3NCreatorKey.getSigners(otherWeb3NameCreator),
+      paymentAccount.address
+    )
+
+    await submitTx(authorizedTx, paymentAccount)
+  }, 40_000)
 })
 
 describe('Runtime constraints', () => {


### PR DESCRIPTION
## fixes no ticket

Currently no tests to check if you can reclaim a w3n after the payment account has removed it.

## How to test:
Please provide a brief step-by-step instruction.
If necessary provide information about dependencies (specific configuration, branches, database dumps, etc.)

- Step 1
- Step 2
- etc.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
