### PR TITLE
refactor: align signatureFromJson & verifyDidSignature

### DIFF
--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -105,7 +105,7 @@ describe('light DID', () => {
 
     const deserialized = signatureFromJson(oldSignature)
     expect(deserialized.signature).toBeInstanceOf(Uint8Array)
-    expect(deserialized.keyUri).toStrictEqual(keyUri)
+    expect(deserialized.signerUrl).toStrictEqual(keyUri)
     expect(deserialized).not.toHaveProperty('keyId')
   })
 

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -171,14 +171,14 @@ export function isDidSignature(
  */
 export function signatureFromJson(input: DidSignature | LegacyDidSignature): {
   signature: Uint8Array
-  keyUri: DidUrl
+  signerUrl: DidUrl
 } {
-  const keyUri = (() => {
+  const signerUrl = (() => {
     if ('keyId' in input) {
       return input.keyId
     }
     return input.keyUri
   })()
   const signature = Crypto.coToUInt8(input.signature)
-  return { signature, keyUri }
+  return { signature, signerUrl }
 }

--- a/packages/legacy-credentials/src/Credential.ts
+++ b/packages/legacy-credentials/src/Credential.ts
@@ -235,7 +235,6 @@ export async function verifySignature(
     // allow full did to sign presentation if owned by corresponding light did
     allowUpgraded: true,
     expectedVerificationRelationship: 'authentication',
-    signerUrl: claimerSignature.keyUri,
     dereferenceDidUrl,
   })
 }


### PR DESCRIPTION
## re/ https://github.com/KILTprotocol/ticket/issues/3242

The output of signatureFromJson and the input of verifyDidSignature were no longer aligned, making their combination quite cumbersome.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
