### PR TITLE
chore: make resolution options optional

### DIFF
--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -171,9 +171,9 @@ export async function resolve(
  */
 export async function resolveRepresentation(
   did: Did,
-  { accept }: DereferenceOptions<SupportedContentType> = {
-    accept: DID_JSON_CONTENT_TYPE,
-  }
+  {
+    accept = DID_JSON_CONTENT_TYPE,
+  }: DereferenceOptions<SupportedContentType> = {}
 ): Promise<RepresentationResolutionResult<SupportedContentType>> {
   const inputTransform = (() => {
     switch (accept) {
@@ -341,10 +341,9 @@ async function dereferenceInternal(
  */
 export async function dereference(
   didUrl: Did | DidUrl,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  { accept }: DereferenceOptions<SupportedContentType> = {
-    accept: DID_JSON_CONTENT_TYPE,
-  }
+  {
+    accept = DID_JSON_CONTENT_TYPE,
+  }: DereferenceOptions<SupportedContentType> = {}
 ): Promise<DereferenceResult<SupportedContentType>> {
   // The spec does not include an error for unsupported content types for dereferences
   const contentType = isValidContentType(accept)

--- a/packages/types/src/DidResolver.ts
+++ b/packages/types/src/DidResolver.ts
@@ -145,7 +145,7 @@ export interface ResolveDid<Accept extends string = string> {
      * A metadata structure containing properties defined in 7.1.1 DID Resolution Options.
      * This input is REQUIRED, but the structure MAY be empty.
      */
-    resolutionOptions: ResolutionOptions
+    resolutionOptions?: ResolutionOptions
   ) => Promise<ResolutionResult>
 
   resolveRepresentation: (
@@ -158,7 +158,7 @@ export interface ResolveDid<Accept extends string = string> {
      * A metadata structure containing properties defined in 7.1.1 DID Resolution Options.
      * This input is REQUIRED, but the structure MAY be empty.
      */
-    resolutionOptions: RepresentationResolutionOptions<Accept>
+    resolutionOptions?: RepresentationResolutionOptions<Accept>
   ) => Promise<RepresentationResolutionResult<Accept>>
 }
 
@@ -245,7 +245,7 @@ export interface DereferenceDidUrl<Accept extends string = string> {
      * Properties defined by this specification are in 7.2.1 DID URL Dereferencing Options.
      * This input is REQUIRED, but the structure MAY be empty.
      */
-    dereferenceOptions: DereferenceOptions<Accept>
+    dereferenceOptions?: DereferenceOptions<Accept>
   ) => Promise<DereferenceResult<Accept>>
 }
 


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3268

Don't require passing empty resolution options into did resolver functions.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
