### PR TITLE
refactor!: make DidDocument ids absolute

### DIFF
--- a/packages/asset-credentials/src/credentials/PublicCredential.chain.ts
+++ b/packages/asset-credentials/src/credentials/PublicCredential.chain.ts
@@ -107,10 +107,12 @@ export interface PublicCredentialEntry {
  * @returns The decoded data.
  */
 export function fromChain(
-  encoded: Option<PublicCredentialsCredentialsCredentialEntry>
+  encoded:
+    | Option<PublicCredentialsCredentialsCredentialEntry>
+    | PublicCredentialsCredentialsCredentialEntry
 ): PublicCredentialEntry {
   const { attester, authorizationId, blockNumber, ctypeHash, revoked } =
-    encoded.unwrap()
+    'unwrap' in encoded ? encoded.unwrap() : encoded
   return {
     ctypeHash: ctypeHash.toHex(),
     attester: didFromChain(attester),

--- a/packages/credentials/src/attestation/Attestation.chain.ts
+++ b/packages/credentials/src/attestation/Attestation.chain.ts
@@ -21,10 +21,12 @@ const log = ConfigService.LoggingFactory.getLogger('Attestation')
  * @returns The attestation.
  */
 export function fromChain(
-  encoded: Option<AttestationAttestationsAttestationDetails>,
+  encoded:
+    | Option<AttestationAttestationsAttestationDetails>
+    | AttestationAttestationsAttestationDetails,
   claimHash: ICredential['rootHash'] // all the other decoders do not use extra data; they just return partial types
 ): IAttestation {
-  const chainAttestation = encoded.unwrap()
+  const chainAttestation = 'unwrap' in encoded ? encoded.unwrap() : encoded
   const delegationId = chainAttestation.authorizationId
     .unwrapOr(undefined)
     ?.value.toHex()

--- a/packages/credentials/src/ctype/CType.chain.ts
+++ b/packages/credentials/src/ctype/CType.chain.ts
@@ -91,7 +91,7 @@ export type ICTypeDetails = { cType: ICType } & CTypeChainDetails
  * @returns An object indicating the CType creator.
  */
 export function fromChain(
-  encoded: Option<AccountId>
+  encoded: Option<AccountId> | AccountId
 ): Pick<CTypeChainDetails, 'creator'>
 /**
  * Decodes the CType details returned by `api.query.ctype.ctypes()`.
@@ -99,12 +99,18 @@ export function fromChain(
  * @param encoded The data from the blockchain.
  * @returns An object indicating the CType creator and createdAt block.
  */
-export function fromChain(encoded: Option<CtypeCtypeEntry>): CTypeChainDetails
+export function fromChain(
+  encoded: Option<CtypeCtypeEntry> | CtypeCtypeEntry
+): CTypeChainDetails
 // eslint-disable-next-line jsdoc/require-jsdoc
 export function fromChain(
-  encoded: Option<CtypeCtypeEntry> | Option<AccountId>
+  encoded:
+    | Option<CtypeCtypeEntry>
+    | Option<AccountId>
+    | CtypeCtypeEntry
+    | AccountId
 ): CTypeChainDetails | Pick<CTypeChainDetails, 'creator'> {
-  const unwrapped = encoded.unwrap()
+  const unwrapped = 'unwrap' in encoded ? encoded.unwrap() : encoded
   if ('creator' in unwrapped && 'createdAt' in unwrapped) {
     const { creator, createdAt } = unwrapped
     return {

--- a/packages/credentials/src/delegation/DelegationDecoder.ts
+++ b/packages/credentials/src/delegation/DelegationDecoder.ts
@@ -39,10 +39,13 @@ export type DelegationHierarchyDetailsRecord = Pick<
 >
 
 export function delegationHierarchyDetailsFromChain(
-  encoded: Option<DelegationDelegationHierarchyDelegationHierarchyDetails>
+  encoded:
+    | Option<DelegationDelegationHierarchyDelegationHierarchyDetails>
+    | DelegationDelegationHierarchyDelegationHierarchyDetails
 ): DelegationHierarchyDetailsRecord {
+  const { ctypeHash } = 'unwrap' in encoded ? encoded.unwrap() : encoded
   return {
-    cTypeHash: encoded.unwrap().ctypeHash.toHex(),
+    cTypeHash: ctypeHash.toHex(),
   }
 }
 
@@ -74,9 +77,11 @@ export type DelegationNodeRecord = Omit<IDelegationNode, 'id'>
 export type DelegationNodeId = Hash
 
 export function delegationNodeFromChain(
-  encoded: Option<DelegationDelegationHierarchyDelegationNode>
+  encoded:
+    | Option<DelegationDelegationHierarchyDelegationNode>
+    | DelegationDelegationHierarchyDelegationNode
 ): DelegationNodeRecord {
-  const delegationNode = encoded.unwrap()
+  const delegationNode = 'unwrap' in encoded ? encoded.unwrap() : encoded
 
   return {
     hierarchyId: delegationNode.hierarchyRootId.toHex(),

--- a/packages/credentials/src/presentation/Presentation.spec.ts
+++ b/packages/credentials/src/presentation/Presentation.spec.ts
@@ -94,7 +94,7 @@ jest.mock('@kiltprotocol/did', () => {
 
 describe('verification', () => {
   const signerDid = credential.credentialSubject.id as Did
-  const keyId = `${signerDid}#key-1` as const
+  const vmUrl = `${signerDid}#key-1` as const
 
   beforeAll(async () => {
     const { publicKey } = sr25519PairFromSeed(seed)
@@ -107,13 +107,13 @@ describe('verification', () => {
           didDocument: {
             id: signerDid,
             verificationMethod: [
-              didKeyToVerificationMethod(signerDid, keyId, {
+              didKeyToVerificationMethod(signerDid, vmUrl, {
                 publicKey,
                 keyType: 'sr25519',
               }),
             ],
-            assertionMethod: [keyId],
-            authentication: [keyId],
+            assertionMethod: [vmUrl],
+            authentication: [vmUrl],
           },
         }
       }
@@ -131,7 +131,7 @@ describe('verification', () => {
 
     const signer = await createSigner({
       seed,
-      id: keyId,
+      id: vmUrl,
     })
     const signed = await createProof(presentation, cryptosuite, signer, {
       proofPurpose: 'assertionMethod',
@@ -147,7 +147,7 @@ describe('verification', () => {
   it('verifies a presentation proof', async () => {
     const signer = await createSigner({
       seed,
-      id: keyId,
+      id: vmUrl,
     })
     const challenge = randomAsHex()
     let presentation = await createPresentation({

--- a/packages/credentials/src/presentation/Presentation.spec.ts
+++ b/packages/credentials/src/presentation/Presentation.spec.ts
@@ -94,7 +94,7 @@ jest.mock('@kiltprotocol/did', () => {
 
 describe('verification', () => {
   const signerDid = credential.credentialSubject.id as Did
-  const keyId = `#key-1`
+  const keyId = `${signerDid}#key-1` as const
 
   beforeAll(async () => {
     const { publicKey } = sr25519PairFromSeed(seed)
@@ -131,7 +131,7 @@ describe('verification', () => {
 
     const signer = await createSigner({
       seed,
-      id: signerDid + keyId,
+      id: keyId,
     })
     const signed = await createProof(presentation, cryptosuite, signer, {
       proofPurpose: 'assertionMethod',
@@ -147,7 +147,7 @@ describe('verification', () => {
   it('verifies a presentation proof', async () => {
     const signer = await createSigner({
       seed,
-      id: signerDid + keyId,
+      id: keyId,
     })
     const challenge = randomAsHex()
     let presentation = await createPresentation({

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -285,9 +285,12 @@ export function serviceToChain(service: NewService | Service): ChainDidService {
  * @returns The DID service.
  */
 export function serviceFromChain(
-  encoded: DidServiceEndpointsDidEndpoint
+  encoded:
+    | Option<DidServiceEndpointsDidEndpoint>
+    | DidServiceEndpointsDidEndpoint
 ): Service<UriFragment> {
-  const { id, serviceTypes, urls } = encoded
+  const { id, serviceTypes, urls } =
+    'unwrap' in encoded ? encoded.unwrap() : encoded
   return {
     id: `#${id.toUtf8()}`,
     type: serviceTypes.map((type) => type.toUtf8()),

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -159,7 +159,7 @@ export function publicKeyFromChain(
  * @returns The DID Document.
  */
 export function documentFromChain(
-  encoded: Option<DidDidDetails>
+  encoded: Option<DidDidDetails> | DidDidDetails
 ): ChainDidDetails {
   const {
     publicKeys,
@@ -169,7 +169,7 @@ export function documentFromChain(
     keyAgreementKeys,
     lastTxCounter,
     deposit,
-  } = encoded.unwrap()
+  } = 'unwrap' in encoded ? encoded.unwrap() : encoded
 
   const keys: Record<string, ChainDidKey> = [...publicKeys.entries()]
     .map(([keyId, keyDetails]) => publicKeyFromChain(keyId, keyDetails))

--- a/packages/did/src/Did.rpc.ts
+++ b/packages/did/src/Did.rpc.ts
@@ -5,104 +5,41 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+import { encodeAddress } from '@polkadot/keyring'
 import type { Option, Vec } from '@polkadot/types'
 import type { Codec } from '@polkadot/types/types'
-import type {
-  RawDidLinkedInfo,
-  DidDidDetails,
-  DidServiceEndpointsDidEndpoint,
-  PalletDidLookupLinkableAccountLinkableAccountId,
-} from '@kiltprotocol/augment-api'
-import type { DidDocument, KiltAddress, Service } from '@kiltprotocol/types'
-
-import { ss58Format } from '@kiltprotocol/utils'
-import { encodeAddress } from '@polkadot/keyring'
 import { ethereumEncode } from '@polkadot/util-crypto'
 
+import type {
+  DidServiceEndpointsDidEndpoint,
+  PalletDidLookupLinkableAccountLinkableAccountId,
+  RawDidLinkedInfo,
+} from '@kiltprotocol/augment-api'
+import type {
+  Did,
+  DidDocument,
+  DidUrl,
+  KiltAddress,
+  Service,
+  VerificationMethod,
+} from '@kiltprotocol/types'
+import { ss58Format } from '@kiltprotocol/utils'
+
+import { fromChain, publicKeyFromChain, serviceFromChain } from './Did.chain.js'
+import { didKeyToVerificationMethod } from './Did.utils.js'
 import type {
   Address,
   SubstrateAddress,
 } from './DidLinks/AccountLinks.chain.js'
-import type {
-  ChainDidDetails,
-  ChainDidEncryptionKey,
-  ChainDidKey,
-  ChainDidVerificationKey,
-} from './Did.chain.js'
-
-import {
-  depositFromChain,
-  fragmentIdToChain,
-  fromChain,
-  publicKeyFromChain,
-} from './Did.chain.js'
-
-import { didKeyToVerificationMethod } from './Did.utils.js'
-import { addKeypairAsVerificationMethod } from './DidDetails/DidDetails.js'
-
-function documentFromChain(
-  encoded: DidDidDetails
-): Omit<ChainDidDetails, 'service'> {
-  const {
-    publicKeys,
-    authenticationKey,
-    attestationKey,
-    delegationKey,
-    keyAgreementKeys,
-    lastTxCounter,
-    deposit,
-  } = encoded
-
-  const keys: Record<string, ChainDidKey> = [...publicKeys.entries()]
-    .map(([keyId, keyDetails]) => publicKeyFromChain(keyId, keyDetails))
-    .reduce((res, key) => {
-      res[fragmentIdToChain(key.id)] = key
-      return res
-    }, {})
-
-  const authentication = keys[
-    authenticationKey.toHex()
-  ] as ChainDidVerificationKey
-
-  const didRecord: ChainDidDetails = {
-    authentication: [authentication],
-    lastTxCounter: lastTxCounter.toBn(),
-    deposit: depositFromChain(deposit),
-  }
-  if (attestationKey.isSome) {
-    const key = keys[attestationKey.unwrap().toHex()] as ChainDidVerificationKey
-    didRecord.assertionMethod = [key]
-  }
-  if (delegationKey.isSome) {
-    const key = keys[delegationKey.unwrap().toHex()] as ChainDidVerificationKey
-    didRecord.capabilityDelegation = [key]
-  }
-
-  const keyAgreementKeyIds = [...keyAgreementKeys.values()].map((keyId) =>
-    keyId.toHex()
-  )
-  if (keyAgreementKeyIds.length > 0) {
-    didRecord.keyAgreement = keyAgreementKeyIds.map(
-      (id) => keys[id] as ChainDidEncryptionKey
-    )
-  }
-
-  return didRecord
-}
-
-function serviceFromChain(encoded: DidServiceEndpointsDidEndpoint): Service {
-  const { id, serviceTypes, urls } = encoded
-  return {
-    id: `#${id.toUtf8()}`,
-    type: serviceTypes.map((type) => type.toUtf8()),
-    serviceEndpoint: urls.map((url) => url.toUtf8()),
-  }
-}
 
 function servicesFromChain(
-  encoded: DidServiceEndpointsDidEndpoint[]
+  encoded: DidServiceEndpointsDidEndpoint[],
+  did: Did
 ): Service[] {
-  return encoded.map((encodedValue) => serviceFromChain(encodedValue))
+  return encoded.map((encodedValue) => {
+    const service = serviceFromChain(encodedValue)
+    return { ...service, id: `${did}${service.id}` }
+  })
 }
 
 function isLinkableAccountId(
@@ -155,62 +92,56 @@ export function linkedInfoFromChain(
     encoded.unwrap()
 
   const {
-    authentication,
-    keyAgreement,
-    capabilityDelegation,
-    assertionMethod,
-  } = documentFromChain(details)
-  const did: DidDocument = {
-    id: fromChain(identifier),
-    authentication: [authentication[0].id],
-    verificationMethod: [
-      didKeyToVerificationMethod(fromChain(identifier), authentication[0].id, {
-        keyType: authentication[0].type,
-        publicKey: authentication[0].publicKey,
-      }),
-    ],
+    publicKeys,
+    authenticationKey,
+    attestationKey,
+    delegationKey,
+    keyAgreementKeys,
+  } = details
+
+  const did = fromChain(identifier)
+  const idPrefix = `${did}#` as const
+  function formatKeyId(keyId: Codec): DidUrl {
+    return `${idPrefix}${keyId.toHex()}`
   }
 
-  if (keyAgreement !== undefined && keyAgreement.length > 0) {
-    keyAgreement.forEach(({ id, publicKey, type }) => {
-      addKeypairAsVerificationMethod(
-        did,
-        { id, publicKey, type },
-        'keyAgreement'
-      )
+  const verificationMethod: VerificationMethod[] = [
+    ...publicKeys.entries(),
+  ].map(([keyId, keyDetails]) => {
+    const { publicKey, type, id } = publicKeyFromChain(keyId, keyDetails)
+    return didKeyToVerificationMethod(did, `${did}${id}` as const, {
+      keyType: type,
+      publicKey,
     })
+  })
+
+  const document: DidDocument = {
+    id: fromChain(identifier),
+    verificationMethod,
+    authentication: [formatKeyId(authenticationKey)],
+  }
+  if (attestationKey.isSome) {
+    document.assertionMethod = [formatKeyId(attestationKey)]
+  }
+  if (delegationKey.isSome) {
+    document.capabilityDelegation = [formatKeyId(delegationKey)]
+  }
+  if (!keyAgreementKeys.isEmpty) {
+    document.keyAgreement = [...keyAgreementKeys.values()].map(formatKeyId)
   }
 
-  if (assertionMethod !== undefined) {
-    const { id, type, publicKey } = assertionMethod[0]
-    addKeypairAsVerificationMethod(
-      did,
-      { id, publicKey, type },
-      'assertionMethod'
-    )
-  }
-
-  if (capabilityDelegation !== undefined) {
-    const { id, type, publicKey } = capabilityDelegation[0]
-    addKeypairAsVerificationMethod(
-      did,
-      { id, publicKey, type },
-      'capabilityDelegation'
-    )
-  }
-
-  const services = servicesFromChain(serviceEndpoints)
+  const services = servicesFromChain(serviceEndpoints, did)
   if (services.length > 0) {
-    did.service = services
+    document.service = services
   }
 
   if (w3n.isSome) {
-    did.alsoKnownAs = [`w3n:${w3n.unwrap().toHuman()}`]
+    document.alsoKnownAs = [`w3n:${w3n.unwrap().toHuman()}`]
   }
   const linkedAccounts = connectedAccountsFromChain(accounts, networkPrefix)
 
   return {
-    document: did,
+    document,
     accounts: linkedAccounts,
   }
 }

--- a/packages/did/src/Did.rpc.ts
+++ b/packages/did/src/Did.rpc.ts
@@ -85,11 +85,11 @@ export interface LinkedDidInfo {
  * @returns The accounts, DID, and web3name.
  */
 export function linkedInfoFromChain(
-  encoded: Option<RawDidLinkedInfo>,
+  encoded: Option<RawDidLinkedInfo> | RawDidLinkedInfo,
   networkPrefix = ss58Format
 ): LinkedDidInfo {
   const { identifier, accounts, w3n, serviceEndpoints, details } =
-    encoded.unwrap()
+    'unwrap' in encoded ? encoded.unwrap() : encoded
 
   const {
     publicKeys,

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -214,7 +214,7 @@ describe('light DID', () => {
 
   it('typeguard accepts legal signature objects', () => {
     const signature: DidSignature = {
-      keyUri: `${did.authentication![0]}`,
+      keyUri: did.authentication![0],
       signature: randomAsHex(32),
     }
     expect(isDidSignature(signature)).toBe(true)

--- a/packages/did/src/Did.signature.spec.ts
+++ b/packages/did/src/Did.signature.spec.ts
@@ -46,7 +46,7 @@ describe('light DID', () => {
       authentication: keyTool.authentication,
     })
     authenticationSigner = (await keyTool.getSigners(did)).find(
-      ({ id }) => id === did.id + did.authentication?.[0]
+      ({ id }) => id === did.authentication?.[0]
     )!
     expect(authenticationSigner).toBeDefined()
   })
@@ -214,7 +214,7 @@ describe('light DID', () => {
 
   it('typeguard accepts legal signature objects', () => {
     const signature: DidSignature = {
-      keyUri: `${did.id}${did.authentication![0]}`,
+      keyUri: `${did.authentication![0]}`,
       signature: randomAsHex(32),
     }
     expect(isDidSignature(signature)).toBe(true)
@@ -290,11 +290,11 @@ describe('full DID', () => {
     keypair = Crypto.makeKeypairFromSeed()
     did = {
       id: `did:kilt:${keypair.address}`,
-      authentication: ['#0x12345'],
+      authentication: [`did:kilt:${keypair.address}#0x12345`],
       verificationMethod: [
         {
           controller: `did:kilt:${keypair.address}`,
-          id: '#0x12345',
+          id: `did:kilt:${keypair.address}#0x12345`,
           publicKeyMultibase: keypairToMultibaseKey(keypair),
           type: 'Multikey',
         },
@@ -443,7 +443,7 @@ describe('full DID', () => {
 
   it('typeguard accepts legal signature objects', () => {
     const signature: DidSignature = {
-      keyUri: `${did.id}${did.authentication![0]}`,
+      keyUri: did.authentication![0],
       signature: randomAsHex(32),
     }
     expect(isDidSignature(signature)).toBe(true)

--- a/packages/did/src/Did.signature.ts
+++ b/packages/did/src/Did.signature.ts
@@ -120,8 +120,7 @@ export async function verifyDidSignature({
   }
   const didDocument = contentStream as DidDocument
   const verificationMethod = didDocument.verificationMethod?.find(
-    ({ controller, id }) =>
-      controller === didDocument.id && id === signer.fragment
+    ({ controller, id }) => controller === didDocument.id && id === signerUrl
   )
   if (verificationMethod === undefined) {
     throw new SDKErrors.DidNotFoundError('Verification method not found in DID')

--- a/packages/did/src/Did.utils.ts
+++ b/packages/did/src/Did.utils.ts
@@ -222,11 +222,11 @@ export function keypairToMultibaseKey({
  * @param key.publicKey The public component of the key.
  * @returns The provided key encoded as a {@link VerificationMethod}.
  */
-export function didKeyToVerificationMethod(
+export function didKeyToVerificationMethod<IdType extends DidUrl | UriFragment>(
   controller: VerificationMethod['controller'],
-  id: VerificationMethod['id'],
+  id: IdType,
   { keyType, publicKey }: DecodedVerificationMethod
-): VerificationMethod {
+): VerificationMethod<IdType> {
   const multiCodecPublicKeyPrefix = multicodecReversePrefixes[keyType]
   if (multiCodecPublicKeyPrefix === undefined) {
     throw new SDKErrors.DidError(

--- a/packages/did/src/DidDetails/DidDetails.ts
+++ b/packages/did/src/DidDetails/DidDetails.ts
@@ -74,7 +74,7 @@ export function isValidDidVerificationType(
 }
 
 export type NewVerificationMethod = Omit<VerificationMethod, 'controller'>
-export type NewService = Service
+export type NewService = Service<UriFragment>
 
 /**
  * Type guard checking whether the provided input represents one of the supported verification relationships.
@@ -160,9 +160,13 @@ export function addKeypairAsVerificationMethod(
   { id, publicKey, type: keyType }: BaseNewDidKey & { id: UriFragment },
   relationship: VerificationRelationship
 ): void {
-  const verificationMethod = didKeyToVerificationMethod(didDocument.id, id, {
-    keyType: keyType as DidSigningMethodType,
-    publicKey,
-  })
+  const verificationMethod = didKeyToVerificationMethod(
+    didDocument.id,
+    `${didDocument.id}${id}`,
+    {
+      keyType: keyType as DidSigningMethodType,
+      publicKey,
+    }
+  )
   addVerificationMethod(didDocument, verificationMethod, relationship)
 }

--- a/packages/did/src/DidDetails/LightDidDetails.spec.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.spec.ts
@@ -53,14 +53,15 @@ describe('When creating an instance from the details', () => {
       service,
     })
 
+    const did = `did:kilt:light:00${authKey.address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`
     expect(lightDid).toEqual(<DidDocument>{
-      id: `did:kilt:light:00${authKey.address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`,
-      authentication: ['#authentication'],
-      keyAgreement: ['#encryption'],
+      id: did,
+      authentication: [`${did}#authentication`],
+      keyAgreement: [`${did}#encryption`],
       verificationMethod: [
         {
-          controller: `did:kilt:light:00${authKey.address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`,
-          id: '#authentication',
+          controller: did,
+          id: `${did}#authentication`,
           publicKeyMultibase: keypairToMultibaseKey({
             publicKey: authKey.publicKey,
             type: 'sr25519',
@@ -68,8 +69,8 @@ describe('When creating an instance from the details', () => {
           type: 'Multikey',
         },
         {
-          controller: `did:kilt:light:00${authKey.address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`,
-          id: '#encryption',
+          controller: did,
+          id: `${did}#encryption`,
           publicKeyMultibase: keypairToMultibaseKey({
             publicKey: encKey.publicKey,
             type: 'x25519',
@@ -79,12 +80,12 @@ describe('When creating an instance from the details', () => {
       ],
       service: [
         {
-          id: '#service-1',
+          id: `${did}#service-1`,
           type: ['type-1'],
           serviceEndpoint: ['x:url-1'],
         },
         {
-          id: '#service-2',
+          id: `${did}#service-2`,
           type: ['type-21', 'type-22'],
           serviceEndpoint: ['x:url-21', 'x:url-22'],
         },
@@ -105,14 +106,15 @@ describe('When creating an instance from the details', () => {
 
     expect(parse(lightDid.id).address).toStrictEqual(authKey.address)
 
+    const did = `did:kilt:light:01${authKey.address}:z15dZSRuzEPTFnBErPxqJie4CmmQH1gYKSQYxmwW5Qhgz5Sr7EYJA3J65KoC5YbgF3NGoBsTY2v6zwj1uDnZzgXzLy8R72Fhjmp8ujY81y2AJc8uQ6s2pVbAMZ6bnvaZ3GVe8bMjY5MiKFySS27qRi`
     expect(lightDid).toEqual(<DidDocument>{
-      id: `did:kilt:light:01${authKey.address}:z15dZSRuzEPTFnBErPxqJie4CmmQH1gYKSQYxmwW5Qhgz5Sr7EYJA3J65KoC5YbgF3NGoBsTY2v6zwj1uDnZzgXzLy8R72Fhjmp8ujY81y2AJc8uQ6s2pVbAMZ6bnvaZ3GVe8bMjY5MiKFySS27qRi`,
-      authentication: ['#authentication'],
-      keyAgreement: ['#encryption'],
+      id: did,
+      authentication: [`${did}#authentication`],
+      keyAgreement: [`${did}#encryption`],
       verificationMethod: [
         {
-          controller: `did:kilt:light:01${authKey.address}:z15dZSRuzEPTFnBErPxqJie4CmmQH1gYKSQYxmwW5Qhgz5Sr7EYJA3J65KoC5YbgF3NGoBsTY2v6zwj1uDnZzgXzLy8R72Fhjmp8ujY81y2AJc8uQ6s2pVbAMZ6bnvaZ3GVe8bMjY5MiKFySS27qRi`,
-          id: '#authentication',
+          controller: did,
+          id: `${did}#authentication`,
           publicKeyMultibase: keypairToMultibaseKey({
             publicKey: authKey.publicKey,
             type: 'ed25519',
@@ -120,8 +122,8 @@ describe('When creating an instance from the details', () => {
           type: 'Multikey',
         },
         {
-          controller: `did:kilt:light:01${authKey.address}:z15dZSRuzEPTFnBErPxqJie4CmmQH1gYKSQYxmwW5Qhgz5Sr7EYJA3J65KoC5YbgF3NGoBsTY2v6zwj1uDnZzgXzLy8R72Fhjmp8ujY81y2AJc8uQ6s2pVbAMZ6bnvaZ3GVe8bMjY5MiKFySS27qRi`,
-          id: '#encryption',
+          controller: did,
+          id: `${did}#encryption`,
           publicKeyMultibase: keypairToMultibaseKey({
             publicKey: encKey.publicKey,
             type: 'x25519',
@@ -182,18 +184,19 @@ describe('When creating an instance from a light DID', () => {
       service: endpoints,
     })
 
-    const { address } = parse(expectedLightDid.id)
     const builtLightDid = parseDocumentFromLightDid(expectedLightDid.id)
 
     expect(builtLightDid).toStrictEqual(expectedLightDid)
+    const { address } = parse(expectedLightDid.id)
+    const did = `did:kilt:light:00${address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`
     expect(builtLightDid).toStrictEqual(<DidDocument>{
-      id: `did:kilt:light:00${address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`,
-      authentication: ['#authentication'],
-      keyAgreement: ['#encryption'],
+      id: did,
+      authentication: [`${did}#authentication`],
+      keyAgreement: [`${did}#encryption`],
       verificationMethod: [
         {
-          controller: `did:kilt:light:00${authKey.address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`,
-          id: '#authentication',
+          controller: did,
+          id: `${did}#authentication`,
           publicKeyMultibase: keypairToMultibaseKey({
             publicKey: authKey.publicKey,
             type: 'sr25519',
@@ -201,8 +204,8 @@ describe('When creating an instance from a light DID', () => {
           type: 'Multikey',
         },
         {
-          controller: `did:kilt:light:00${authKey.address}:z17GNCdxLqMYTMC5pnnDrPZGxLEFcXvDamtGNXeNkfSaFf8cktX6erFJiQy8S3ugL981NNys7Rz8DJiaNPZi98v1oeFVL7PjUGNTz1g3jgZo4VgQri2SYHBifZFX9foHZH4DreZXFN66k5dPrvAtBpFXaiG2WZkkxsnxNWxYpqWPPcxvbTE6pJbXxWKjRUd7rog1h9vjA93QA9jMDxm6BSGJHACFgSPUU3UTLk2kjNwT2bjZVvihVFu1zibxwHjowb7N6UQfieJ7ny9HnaQy64qJvGqh4NNtpwkhwm5DTYUoAeAhjt3a6TWyxmBgbFdZF7`,
-          id: '#encryption',
+          controller: did,
+          id: `${did}#encryption`,
           publicKeyMultibase: keypairToMultibaseKey({
             publicKey: encKey.publicKey,
             type: 'x25519',
@@ -212,12 +215,12 @@ describe('When creating an instance from a light DID', () => {
       ],
       service: [
         {
-          id: '#service-1',
+          id: `${did}#service-1`,
           type: ['type-1'],
           serviceEndpoint: ['x:url-1'],
         },
         {
-          id: '#service-2',
+          id: `${did}#service-2`,
           type: ['type-21', 'type-22'],
           serviceEndpoint: ['x:url-21', 'x:url-22'],
         },

--- a/packages/did/src/DidDetails/LightDidDetails.ts
+++ b/packages/did/src/DidDetails/LightDidDetails.ts
@@ -27,7 +27,7 @@ import {
   getAddressFromVerificationMethod,
   parse,
 } from '../Did.utils.js'
-import { fragmentIdToChain, validateNewService } from '../Did.chain.js'
+import { urlFragmentToChain, validateNewService } from '../Did.chain.js'
 import {
   addKeypairAsVerificationMethod,
   encryptionMethodTypes,
@@ -115,7 +115,7 @@ function validateCreateDocumentInput({
   // when upgrading to a full DID.
   service?.forEach((s) => {
     // A service ID cannot have a reserved ID that is used for key IDs.
-    if (s.id === '#authentication' || s.id === '#encryption') {
+    if (s.id.endsWith('#authentication') || s.id.endsWith('#encryption')) {
       throw new SDKErrors.DidError(
         `Cannot specify a service ID with the name "${s.id}" as it is a reserved keyword`
       )
@@ -156,7 +156,7 @@ function serializeAdditionalLightDidDetails({
   }
   if (service && service.length > 0) {
     objectToSerialize[SERVICES_MAP_KEY] = service.map(({ id, ...rest }) => ({
-      id: fragmentIdToChain(id),
+      id: urlFragmentToChain(id),
       ...rest,
     }))
   }
@@ -239,16 +239,20 @@ export function createLightDidDocument({
   const did =
     `did:kilt:light:${authenticationKeyTypeEncoding}${address}${encodedDetailsString}` as Did
 
+  const authKey = `${did}${authenticationKeyId}` as const
   const didDocument: DidDocument = {
     id: did,
-    authentication: [authenticationKeyId],
+    authentication: [authKey],
     verificationMethod: [
-      didKeyToVerificationMethod(did, authenticationKeyId, {
+      didKeyToVerificationMethod(did, authKey, {
         keyType: authentication[0].type,
         publicKey: authentication[0].publicKey,
       }),
     ],
-    service,
+  }
+
+  if (typeof service !== 'undefined' && service?.length > 0) {
+    didDocument.service = service.map((i) => ({ ...i, id: `${did}${i.id}` }))
   }
 
   if (keyAgreement !== undefined) {

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -15,6 +15,7 @@ import {
   ResolutionResult,
   Service,
   VerificationMethod,
+  UriFragment,
 } from '@kiltprotocol/types'
 import { Crypto, cbor } from '@kiltprotocol/utils'
 import { stringToU8a } from '@polkadot/util'
@@ -135,7 +136,9 @@ function generateCapabilityDelegationVerificationMethod(
   }
 }
 
-function generateServiceEndpoint<T extends string>(serviceId: T): Service<T> {
+function generateServiceEndpoint<T extends DidUrl | UriFragment>(
+  serviceId: T
+): Service<T> {
   const [fragment] = serviceId.split('#').reverse()
   return {
     id: serviceId,

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -150,7 +150,8 @@ function generateServiceEndpoint<T extends DidUrl | UriFragment>(
 jest.mock('../Did.rpc.js')
 // By default its mock returns a DIDDocument with the test authentication key, test service, and the DID derived from the identifier provided in the resolution.
 jest.mocked(linkedInfoFromChain).mockImplementation((linkedInfo) => {
-  const { identifier } = linkedInfo.unwrap()
+  const { identifier } =
+    'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
   const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
   const authMethod = generateAuthenticationVerificationMethod(did)
 
@@ -245,7 +246,8 @@ describe('When resolving a service', () => {
   it('returns error if either the DID or the service do not exist', async () => {
     // Mock transform function changed to not return any services (twice).
     jest.mocked(linkedInfoFromChain).mockImplementationOnce((linkedInfo) => {
-      const { identifier } = linkedInfo.unwrap()
+      const { identifier } =
+        'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
       const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
       const authMethod = generateAuthenticationVerificationMethod(did)
 
@@ -259,7 +261,8 @@ describe('When resolving a service', () => {
       }
     })
     jest.mocked(linkedInfoFromChain).mockImplementationOnce((linkedInfo) => {
-      const { identifier } = linkedInfo.unwrap()
+      const { identifier } =
+        'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
       const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
       const authMethod = generateAuthenticationVerificationMethod(did)
 
@@ -323,7 +326,8 @@ describe('When resolving a full DID', () => {
   it('correctly resolves the document with all keys', async () => {
     // Mock transform function changed to return all keys for the DIDDocument.
     jest.mocked(linkedInfoFromChain).mockImplementationOnce((linkedInfo) => {
-      const { identifier } = linkedInfo.unwrap()
+      const { identifier } =
+        'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
       const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
       const authMethod = generateAuthenticationVerificationMethod(did)
       const encMethod = generateEncryptionVerificationMethod(did)
@@ -399,7 +403,8 @@ describe('When resolving a full DID', () => {
   it('correctly resolves the document with services', async () => {
     // Mock transform function changed to return two services.
     jest.mocked(linkedInfoFromChain).mockImplementationOnce((linkedInfo) => {
-      const { identifier } = linkedInfo.unwrap()
+      const { identifier } =
+        'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
       const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
       const authMethod = generateAuthenticationVerificationMethod(did)
 
@@ -455,7 +460,8 @@ describe('When resolving a full DID', () => {
   it('correctly resolves the document with web3Name', async () => {
     // Mock transform function changed to return two services.
     jest.mocked(linkedInfoFromChain).mockImplementationOnce((linkedInfo) => {
-      const { identifier } = linkedInfo.unwrap()
+      const { identifier } =
+        'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
       const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
       const authMethod = generateAuthenticationVerificationMethod(did)
 
@@ -701,7 +707,8 @@ describe('DID Resolution compliance', () => {
         })
       })
     jest.mocked(linkedInfoFromChain).mockImplementation((linkedInfo) => {
-      const { identifier } = linkedInfo.unwrap()
+      const { identifier } =
+        'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
       const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
       const authMethod = generateAuthenticationVerificationMethod(did)
 
@@ -990,7 +997,8 @@ describe('DID Resolution compliance', () => {
     })
     it('returns empty `didDocumentMetadata` and `didResolutionMetadata.contentType: application/did+json` (ignoring the provided `accept` option) representation when successfully returning a service for a DID that has not been deleted nor migrated', async () => {
       jest.mocked(linkedInfoFromChain).mockImplementationOnce((linkedInfo) => {
-        const { identifier } = linkedInfo.unwrap()
+        const { identifier } =
+          'unwrap' in linkedInfo ? linkedInfo.unwrap() : linkedInfo
         const did: KiltDid = `did:kilt:${identifier as unknown as KiltAddress}`
         const authMethod = generateAuthenticationVerificationMethod(did)
 

--- a/packages/did/src/DidResolver/DidResolver.spec.ts
+++ b/packages/did/src/DidResolver/DidResolver.spec.ts
@@ -14,7 +14,6 @@ import {
   RepresentationResolutionResult,
   ResolutionResult,
   Service,
-  UriFragment,
   VerificationMethod,
 } from '@kiltprotocol/types'
 import { Crypto, cbor } from '@kiltprotocol/utils'
@@ -84,7 +83,7 @@ function generateAuthenticationVerificationMethod(
   controller: KiltDid
 ): VerificationMethod {
   return {
-    id: '#auth',
+    id: `${controller}#auth`,
     controller,
     type: 'Multikey',
     publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -98,7 +97,7 @@ function generateEncryptionVerificationMethod(
   controller: KiltDid
 ): VerificationMethod {
   return {
-    id: '#enc',
+    id: `${controller}#enc`,
     controller,
     type: 'Multikey',
     publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -112,7 +111,7 @@ function generateAssertionVerificationMethod(
   controller: KiltDid
 ): VerificationMethod {
   return {
-    id: '#att',
+    id: `${controller}#att`,
     controller,
     type: 'Multikey',
     publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -126,7 +125,7 @@ function generateCapabilityDelegationVerificationMethod(
   controller: KiltDid
 ): VerificationMethod {
   return {
-    id: '#del',
+    id: `${controller}#del`,
     controller,
     type: 'Multikey',
     publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -136,8 +135,8 @@ function generateCapabilityDelegationVerificationMethod(
   }
 }
 
-function generateServiceEndpoint(serviceId: UriFragment): Service {
-  const fragment = serviceId.substring(1)
+function generateServiceEndpoint<T extends string>(serviceId: T): Service<T> {
+  const [fragment] = serviceId.split('#').reverse()
   return {
     id: serviceId,
     type: [`type-${fragment}`],
@@ -158,7 +157,7 @@ jest.mocked(linkedInfoFromChain).mockImplementation((linkedInfo) => {
       id: did,
       authentication: [authMethod.id],
       verificationMethod: [authMethod],
-      service: [generateServiceEndpoint('#service-1')],
+      service: [generateServiceEndpoint(`${did}#service-1`)],
     },
   }
 })
@@ -233,7 +232,7 @@ describe('When resolving a service', () => {
       contentMetadata: {},
       dereferencingMetadata: { contentType: 'application/did+json' },
       contentStream: {
-        id: '#service-1',
+        id: `${fullDid}#service-1`,
         type: [`type-service-1`],
         serviceEndpoint: [`x:url-service-1`],
       },
@@ -302,11 +301,11 @@ describe('When resolving a full DID', () => {
       didResolutionMetadata: {},
       didDocument: {
         id: fullDidWithAuthenticationKey,
-        authentication: ['#auth'],
+        authentication: [`${fullDidWithAuthenticationKey}#auth`],
         verificationMethod: [
           {
             controller: fullDidWithAuthenticationKey,
-            id: '#auth',
+            id: `${fullDidWithAuthenticationKey}#auth`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'ed25519',
@@ -348,14 +347,14 @@ describe('When resolving a full DID', () => {
       didResolutionMetadata: {},
       didDocument: {
         id: fullDidWithAllKeys,
-        authentication: ['#auth'],
-        keyAgreement: ['#enc'],
-        assertionMethod: ['#att'],
-        capabilityDelegation: ['#del'],
+        authentication: [`${fullDidWithAllKeys}#auth`],
+        keyAgreement: [`${fullDidWithAllKeys}#enc`],
+        assertionMethod: [`${fullDidWithAllKeys}#att`],
+        capabilityDelegation: [`${fullDidWithAllKeys}#del`],
         verificationMethod: [
           {
             controller: fullDidWithAllKeys,
-            id: '#auth',
+            id: `${fullDidWithAllKeys}#auth`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'ed25519',
@@ -364,7 +363,7 @@ describe('When resolving a full DID', () => {
           },
           {
             controller: fullDidWithAllKeys,
-            id: '#enc',
+            id: `${fullDidWithAllKeys}#enc`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'x25519',
@@ -373,7 +372,7 @@ describe('When resolving a full DID', () => {
           },
           {
             controller: fullDidWithAllKeys,
-            id: '#att',
+            id: `${fullDidWithAllKeys}#att`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'sr25519',
@@ -382,7 +381,7 @@ describe('When resolving a full DID', () => {
           },
           {
             controller: fullDidWithAllKeys,
-            id: '#del',
+            id: `${fullDidWithAllKeys}#del`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'ecdsa',
@@ -408,8 +407,8 @@ describe('When resolving a full DID', () => {
           authentication: [authMethod.id],
           verificationMethod: [authMethod],
           service: [
-            generateServiceEndpoint('#id-1'),
-            generateServiceEndpoint('#id-2'),
+            generateServiceEndpoint(`${did}#id-1`),
+            generateServiceEndpoint(`${did}#id-2`),
           ],
         },
       }
@@ -422,11 +421,11 @@ describe('When resolving a full DID', () => {
       didResolutionMetadata: {},
       didDocument: {
         id: fullDidWithServiceEndpoints,
-        authentication: ['#auth'],
+        authentication: [`${fullDidWithServiceEndpoints}#auth`],
         verificationMethod: [
           {
             controller: fullDidWithServiceEndpoints,
-            id: '#auth',
+            id: `${fullDidWithServiceEndpoints}#auth`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'ed25519',
@@ -436,12 +435,12 @@ describe('When resolving a full DID', () => {
         ],
         service: [
           {
-            id: '#id-1',
+            id: `${fullDidWithServiceEndpoints}#id-1`,
             type: ['type-id-1'],
             serviceEndpoint: ['x:url-id-1'],
           },
           {
-            id: '#id-2',
+            id: `${fullDidWithServiceEndpoints}#id-2`,
             type: ['type-id-2'],
             serviceEndpoint: ['x:url-id-2'],
           },
@@ -474,11 +473,11 @@ describe('When resolving a full DID', () => {
       didResolutionMetadata: {},
       didDocument: {
         id: didWithAuthenticationKey,
-        authentication: ['#auth'],
+        authentication: [`${didWithAuthenticationKey}#auth`],
         verificationMethod: [
           {
             controller: didWithAuthenticationKey,
-            id: '#auth',
+            id: `${didWithAuthenticationKey}#auth`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               type: 'ed25519',
@@ -549,11 +548,11 @@ describe('When resolving a light DID', () => {
       didResolutionMetadata: {},
       didDocument: {
         id: lightDidWithAuthenticationKey.id,
-        authentication: ['#authentication'],
+        authentication: [`${lightDidWithAuthenticationKey.id}#authentication`],
         verificationMethod: [
           {
             controller: lightDidWithAuthenticationKey.id,
-            id: '#authentication',
+            id: `${lightDidWithAuthenticationKey.id}#authentication`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               ...authKey,
@@ -561,7 +560,6 @@ describe('When resolving a light DID', () => {
             }),
           },
         ],
-        service: undefined,
       },
     })
   })
@@ -580,12 +578,12 @@ describe('When resolving a light DID', () => {
       didResolutionMetadata: {},
       didDocument: {
         id: lightDid.id,
-        authentication: ['#authentication'],
-        keyAgreement: ['#encryption'],
+        authentication: [`${lightDid.id}#authentication`],
+        keyAgreement: [`${lightDid.id}#encryption`],
         verificationMethod: [
           {
             controller: lightDid.id,
-            id: '#authentication',
+            id: `${lightDid.id}#authentication`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({
               ...authKey,
@@ -594,19 +592,19 @@ describe('When resolving a light DID', () => {
           },
           {
             controller: lightDid.id,
-            id: '#encryption',
+            id: `${lightDid.id}#encryption`,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey(encryptionKey),
           },
         ],
         service: [
           {
-            id: '#service-1',
+            id: `${lightDid.id}#service-1`,
             type: ['type-service-1'],
             serviceEndpoint: ['x:url-service-1'],
           },
           {
-            id: '#service-2',
+            id: `${lightDid.id}#service-2`,
             type: ['type-service-2'],
             serviceEndpoint: ['x:url-service-2'],
           },
@@ -723,10 +721,10 @@ describe('DID Resolution compliance', () => {
         didResolutionMetadata: {},
         didDocument: {
           id: did,
-          authentication: ['#auth'],
+          authentication: [`${did}#auth`],
           verificationMethod: [
             {
-              id: '#auth',
+              id: `${did}#auth`,
               controller: did,
               type: 'Multikey',
               publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -772,10 +770,10 @@ describe('DID Resolution compliance', () => {
         didDocumentStream: stringToU8a(
           JSON.stringify({
             id: did,
-            authentication: ['#auth'],
+            authentication: [`${did}#auth`],
             verificationMethod: [
               {
-                id: '#auth',
+                id: `${did}#auth`,
                 controller: did,
                 type: 'Multikey',
                 publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -803,10 +801,10 @@ describe('DID Resolution compliance', () => {
         didDocumentStream: stringToU8a(
           JSON.stringify({
             id: did,
-            authentication: ['#auth'],
+            authentication: [`${did}#auth`],
             verificationMethod: [
               {
-                id: '#auth',
+                id: `${did}#auth`,
                 controller: did,
                 type: 'Multikey',
                 publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -833,10 +831,10 @@ describe('DID Resolution compliance', () => {
         didDocumentStream: Uint8Array.from(
           cbor.encode({
             id: did,
-            authentication: ['#auth'],
+            authentication: [`${did}#auth`],
             verificationMethod: [
               {
-                id: '#auth',
+                id: `${did}#auth`,
                 controller: did,
                 type: 'Multikey',
                 publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -897,10 +895,10 @@ describe('DID Resolution compliance', () => {
         dereferencingMetadata: { contentType: Did.DID_JSON_CONTENT_TYPE },
         contentStream: {
           id: did,
-          authentication: ['#auth'],
+          authentication: [`${did}#auth`],
           verificationMethod: [
             {
-              id: '#auth',
+              id: `${did}#auth`,
               controller: did,
               type: 'Multikey',
               publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -924,10 +922,10 @@ describe('DID Resolution compliance', () => {
         },
         contentStream: {
           id: did,
-          authentication: ['#auth'],
+          authentication: [`${did}#auth`],
           verificationMethod: [
             {
-              id: '#auth',
+              id: `${did}#auth`,
               controller: did,
               type: 'Multikey',
               publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -951,10 +949,10 @@ describe('DID Resolution compliance', () => {
         contentStream: Uint8Array.from(
           cbor.encode({
             id: did,
-            authentication: ['#auth'],
+            authentication: [`${did}#auth`],
             verificationMethod: [
               {
-                id: '#auth',
+                id: `${did}#auth`,
                 controller: did,
                 type: 'Multikey',
                 publicKeyMultibase: Did.keypairToMultibaseKey({
@@ -976,7 +974,7 @@ describe('DID Resolution compliance', () => {
         contentMetadata: {},
         dereferencingMetadata: { contentType: Did.DID_JSON_CONTENT_TYPE },
         contentStream: {
-          id: '#auth',
+          id: 'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs#auth',
           controller:
             'did:kilt:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs',
           type: 'Multikey',
@@ -1001,7 +999,7 @@ describe('DID Resolution compliance', () => {
             verificationMethod: [authMethod],
             service: [
               {
-                id: '#id-1',
+                id: `${did}#id-1`,
                 type: ['type'],
                 serviceEndpoint: ['x:url'],
               },
@@ -1017,7 +1015,7 @@ describe('DID Resolution compliance', () => {
         contentMetadata: {},
         dereferencingMetadata: { contentType: Did.DID_JSON_CONTENT_TYPE },
         contentStream: {
-          id: '#id-1',
+          id: didUrl,
           type: ['type'],
           serviceEndpoint: ['x:url'],
         },
@@ -1057,10 +1055,10 @@ describe('DID Resolution compliance', () => {
       dereferencingMetadata: { contentType: Did.DID_JSON_CONTENT_TYPE },
       contentStream: {
         id: did,
-        authentication: ['#auth'],
+        authentication: [`${did}#auth`],
         verificationMethod: [
           {
-            id: '#auth',
+            id: `${did}#auth`,
             controller: did,
             type: 'Multikey',
             publicKeyMultibase: Did.keypairToMultibaseKey({

--- a/packages/did/src/DidResolver/DidResolver.ts
+++ b/packages/did/src/DidResolver/DidResolver.ts
@@ -270,7 +270,8 @@ async function dereferenceInternal(
 
   const [dereferencedResource, dereferencingError] = (() => {
     const verificationMethod = didDocument?.verificationMethod?.find(
-      ({ controller, id }) => controller === didDocument.id && id === fragment
+      ({ controller, id }) =>
+        controller === didDocument.id && id.endsWith(fragment)
     )
 
     if (verificationMethod !== undefined) {
@@ -308,7 +309,7 @@ async function dereferenceInternal(
     }
 
     // If no verification method is found, try to retrieve a service with the provided ID, ignoring any query parameters.
-    const service = didDocument?.service?.find((s) => s.id === fragment)
+    const service = didDocument?.service?.find((s) => s.id.endsWith(fragment))
     if (service === undefined) {
       return [
         null,

--- a/packages/jsonld-suites/src/suites/KiltAttestationProofV1.spec.ts
+++ b/packages/jsonld-suites/src/suites/KiltAttestationProofV1.spec.ts
@@ -392,7 +392,6 @@ describe('vc-js', () => {
         'error',
         expect.any(Array)
       )
-      console.log(JSON.stringify(result))
       expect(result).toMatchObject({
         verified: true,
         presentationResult: { verified: true },

--- a/packages/jsonld-suites/src/suites/KiltAttestationProofV1.spec.ts
+++ b/packages/jsonld-suites/src/suites/KiltAttestationProofV1.spec.ts
@@ -314,7 +314,7 @@ describe('vc-js', () => {
     it('creates and verifies a signed presentation (sr25519)', async () => {
       const signer = {
         sign: async ({ data }: { data: Uint8Array }) => keypair.sign(data),
-        id: didDocument.id + didDocument.authentication![0],
+        id: didDocument.authentication![0],
       }
       const signingSuite = new Sr25519Signature2020({ signer })
 
@@ -358,7 +358,7 @@ describe('vc-js', () => {
       })
       const edSigner = {
         sign: async ({ data }: { data: Uint8Array }) => edKeypair.sign(data),
-        id: lightDid.id + lightDid.authentication?.[0],
+        id: lightDid.authentication?.[0],
       }
       const signingSuite = new Ed25519Signature2020({ signer: edSigner })
 
@@ -392,6 +392,7 @@ describe('vc-js', () => {
         'error',
         expect.any(Array)
       )
+      console.log(JSON.stringify(result))
       expect(result).toMatchObject({
         verified: true,
         presentationResult: { verified: true },

--- a/packages/jsonld-suites/src/suites/Sr25519Signature2020.spec.ts
+++ b/packages/jsonld-suites/src/suites/Sr25519Signature2020.spec.ts
@@ -131,14 +131,14 @@ it('issues and verifies a signed credential', async () => {
     }
   })()
   const assertionMethod = (() => {
-    const vc = didDocument.verificationMethod?.find(({ id }) =>
+    const vm = didDocument.verificationMethod?.find(({ id }) =>
       id.includes('assertion')
     )
-    const { publicKey } = Did.multibaseKeyToDidKey(vc!.publicKeyMultibase)
+    const { publicKey } = Did.multibaseKeyToDidKey(vm!.publicKeyMultibase)
     const publicKeyBase58 = base58Encode(publicKey)
     return {
-      ...vc,
-      id: vc!.id,
+      ...vm,
+      id: vm!.id,
       publicKeyBase58,
     }
   })()

--- a/packages/legacy-credentials/src/Credential.spec.ts
+++ b/packages/legacy-credentials/src/Credential.spec.ts
@@ -644,9 +644,8 @@ describe('Presentations', () => {
       didDocument: identityAlice,
     })
     // but replace signer key reference with authentication verification method of light did
-    presentation.claimerSignature.keyUri = `${identityDave.id}${
-      identityDave.authentication![0]
-    }`
+    const [keyUri] = identityDave.authentication!
+    presentation.claimerSignature.keyUri = keyUri
 
     // signature would check out but mismatch should be detected
     await expect(
@@ -771,14 +770,15 @@ describe('create presentation', () => {
         lightDidVerificationMethod.publicKeyMultibase
       )
       // Override the verification method ID to the computed one
-      lightDidVerificationMethod.id = computeKeyId(publicKey)
+      lightDidVerificationMethod.id = `${id}${computeKeyId(publicKey)}`
       return lightDidVerificationMethod
     })()
 
+    const authId = `${id}${authMethod.id}` as const
     return {
       id,
-      authentication: [authMethod.id],
-      verificationMethod: [authMethod],
+      authentication: [authId],
+      verificationMethod: [{ ...authMethod, id: authId }],
     }
   }
 

--- a/packages/types/src/Did.ts
+++ b/packages/types/src/Did.ts
@@ -52,9 +52,9 @@ type Base58BtcMultibaseString = `z${string}`
 /**
  * The verification method of a DID.
  */
-export type VerificationMethod<IdType extends string = DidUrl> = {
+export type VerificationMethod<IdType extends DidUrl | UriFragment = DidUrl> = {
   /**
-   * The identifier (DID + fragment, `#<id>`) of the verification method.
+   * The identifier (DID + fragment, i.e., `#<id>`) of the verification method.
    */
   id: IdType
   /**
@@ -74,7 +74,7 @@ export type VerificationMethod<IdType extends string = DidUrl> = {
 /*
  * The service of a KILT DID.
  */
-export type Service<IdType extends string = DidUrl> = {
+export type Service<IdType extends DidUrl | UriFragment = DidUrl> = {
   /*
    * The identifier (DID + fragment, i.e., `#<id>`) of the verification method.
    */
@@ -89,7 +89,7 @@ export type Service<IdType extends string = DidUrl> = {
   serviceEndpoint: string[]
 }
 
-export type DidDocument<IdType extends string = DidUrl> = {
+export type DidDocument<IdType extends DidUrl | UriFragment = DidUrl> = {
   id: Did
   alsoKnownAs?: string[]
   verificationMethod?: Array<VerificationMethod<IdType>>

--- a/packages/types/src/Did.ts
+++ b/packages/types/src/Did.ts
@@ -54,7 +54,7 @@ type Base58BtcMultibaseString = `z${string}`
  */
 export type VerificationMethod<IdType extends string = DidUrl> = {
   /**
-   * The relative identifier (i.e., `#<id>`) of the verification method.
+   * The identifier (DID + fragment, `#<id>`) of the verification method.
    */
   id: IdType
   /**
@@ -76,7 +76,7 @@ export type VerificationMethod<IdType extends string = DidUrl> = {
  */
 export type Service<IdType extends string = DidUrl> = {
   /*
-   * The relative identifier (i.e., `#<id>`) of the verification method.
+   * The identifier (DID + fragment, i.e., `#<id>`) of the verification method.
    */
   id: IdType
   /*

--- a/packages/types/src/Did.ts
+++ b/packages/types/src/Did.ts
@@ -52,11 +52,11 @@ type Base58BtcMultibaseString = `z${string}`
 /**
  * The verification method of a DID.
  */
-export type VerificationMethod = {
+export type VerificationMethod<IdType extends string = DidUrl> = {
   /**
    * The relative identifier (i.e., `#<id>`) of the verification method.
    */
-  id: UriFragment
+  id: IdType
   /**
    * The type of the verification method. This is fixed for KILT DIDs.
    */
@@ -74,11 +74,11 @@ export type VerificationMethod = {
 /*
  * The service of a KILT DID.
  */
-export type Service = {
+export type Service<IdType extends string = DidUrl> = {
   /*
    * The relative identifier (i.e., `#<id>`) of the verification method.
    */
-  id: UriFragment
+  id: IdType
   /*
    * The set of service types.
    */
@@ -89,15 +89,15 @@ export type Service = {
   serviceEndpoint: string[]
 }
 
-export type DidDocument = {
+export type DidDocument<IdType extends string = DidUrl> = {
   id: Did
   alsoKnownAs?: string[]
-  verificationMethod?: VerificationMethod[]
-  authentication?: UriFragment[]
-  assertionMethod?: UriFragment[]
-  keyAgreement?: UriFragment[]
-  capabilityDelegation?: UriFragment[]
-  service?: Service[]
+  verificationMethod?: Array<VerificationMethod<IdType>>
+  authentication?: IdType[]
+  assertionMethod?: IdType[]
+  keyAgreement?: IdType[]
+  capabilityDelegation?: IdType[]
+  service?: Array<Service<IdType>>
 }
 
 export type JsonLd<T> = T & { '@context': string[] }

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -77,7 +77,7 @@ async function createFullDid(
       >(({ id }) => [
         {
           ...signer,
-          id: `${didDocument.id}${id}`,
+          id,
         },
       ]) ?? []
     ).flat()

--- a/tests/testUtils/TestUtils.ts
+++ b/tests/testUtils/TestUtils.ts
@@ -174,10 +174,14 @@ function addKeypairAsVerificationMethod(
   { id, publicKey, type: keyType }: BaseNewDidKey & { id: UriFragment },
   relationship: VerificationRelationship
 ): void {
-  const verificationMethod = didKeyToVerificationMethod(didDocument.id, id, {
-    keyType: keyType as DidVerificationMethodType,
-    publicKey,
-  })
+  const verificationMethod = didKeyToVerificationMethod(
+    didDocument.id,
+    `${didDocument.id}${id}`,
+    {
+      keyType: keyType as DidVerificationMethodType,
+      publicKey,
+    }
+  )
   addVerificationMethod(didDocument, verificationMethod, relationship)
 }
 
@@ -242,7 +246,7 @@ export async function createLocalDemoFullDidFromKeypair(
   const {
     type: keyType,
     publicKey,
-    id: authKeyId,
+    id: authKeyFragment,
   } = makeDidKeyFromKeypair(keypair)
   const id = getFullDidFromVerificationMethod({
     publicKeyMultibase: keypairToMultibaseKey({
@@ -251,6 +255,7 @@ export async function createLocalDemoFullDidFromKeypair(
     }),
   })
 
+  const authKeyId = `${id}${authKeyFragment}` as const
   const result: DidDocument = {
     id,
     authentication: [authKeyId],
@@ -260,7 +265,7 @@ export async function createLocalDemoFullDidFromKeypair(
         publicKey,
       }),
     ],
-    service: endpoints,
+    service: endpoints.map((i) => ({ ...i, id: `${id}${i.id}` })),
   }
 
   if (verificationRelationships.has('keyAgreement')) {

--- a/tests/testUtils/TestUtils.ts
+++ b/tests/testUtils/TestUtils.ts
@@ -126,7 +126,7 @@ export async function makeSigningKeyTool(
         didDocument.verificationMethod?.map(({ id }) =>
           Signers.getSignersForKeypair({
             keypair,
-            id: `${didDocument.id}${id}`,
+            id: `${id.startsWith('#') ? didDocument.id : ''}${id}`,
           })
         ) ?? []
       )


### PR DESCRIPTION
## re/ https://github.com/KILTprotocol/ticket/issues/3242

All Ids are made absolute in Did documents.

## How to test:

Unit & integration tests are adjusted.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
