### PR TITLE
fix: rename cTypeLoader to cTypes on the verifyCredential

### DIFF
--- a/packages/credentials/src/verifier.ts
+++ b/packages/credentials/src/verifier.ts
@@ -216,7 +216,7 @@ export async function verifyCredential(
  * @param config - Additional configuration (optional).
  * @param config.didResolver - An alterative DID resolver to resolve the holder- and issuer DIDs (defaults to {@link resolve}).
  * An array of static DID documents can be provided instead, in which case the function will not try to retrieve any DID documents from a remote source.
- * @param config.ctypeLoader - An alternative CType loader for credential verification, or alternatively an array of CTypes.
+ * @param config.cTypes - An alternative CType loader for credential verification, or alternatively an array of CTypes.
  * See {@link verifyCredential} for details.
  * @param config.credentialStatusLoader - An alternative credential status resolver.
  * See {@link verifyCredential} for details.
@@ -241,7 +241,7 @@ export async function verifyPresentation(
   } = {},
   config: {
     didResolver?: typeof resolve | DidDocument[]
-    ctypeLoader?: CTypeLoader | ICType[]
+    cTypes?: CTypeLoader | ICType[]
     credentialStatusLoader?: (
       credential: VerifiableCredential
     ) => Promise<CredentialStatusResult>
@@ -256,7 +256,7 @@ export async function verifyPresentation(
       tolerance = 0,
       presentation: { proofTypes: presentationProofTypes } = {},
     } = verificationCriteria
-    const { ctypeLoader, credentialStatusLoader } = config
+    const { cTypes, credentialStatusLoader } = config
     // prepare did resolver to be used for loading issuer & holder did documents
     let { didResolver = resolve } = config
     if (Array.isArray(didResolver)) {
@@ -322,7 +322,7 @@ export async function verifyPresentation(
         const credentialResult = await verifyCredential(
           credential,
           { ...verificationCriteria.credentials, now, tolerance },
-          { credentialStatusLoader, cTypes: ctypeLoader, didResolver }
+          { credentialStatusLoader, cTypes, didResolver }
         )
         return { ...credentialResult, credential }
       })

--- a/packages/credentials/src/verifier.ts
+++ b/packages/credentials/src/verifier.ts
@@ -77,7 +77,7 @@ export async function checkStatus(
  * @param config - Additional configuration (optional).
  * @param config.didResolver - An alterative DID resolver to resolve issuer DIDs (defaults to {@link resolve}).
  * An array of static DID documents can be provided instead, in which case the function will not try to retrieve any DID documents from a remote source.
- * @param config.cTypes - To ensure that the credential' structure follows specific CType's schemas (definitions), with this parameter it is possible to pass:
+ * @param config.cTypes -  To ensure that the credential structure agrees with a known CType (credential schema), with this parameter it is possible to pass:
  *  - either an array of CType definitions
  *  - or a CType-Loader that retrieves the definition of the CType linked to the credential.
  *

--- a/packages/credentials/src/verifier.ts
+++ b/packages/credentials/src/verifier.ts
@@ -77,9 +77,11 @@ export async function checkStatus(
  * @param config - Additional configuration (optional).
  * @param config.didResolver - An alterative DID resolver to resolve issuer DIDs (defaults to {@link resolve}).
  * An array of static DID documents can be provided instead, in which case the function will not try to retrieve any DID documents from a remote source.
- * @param config.cTypes - An alternative CType loader that retrieves CType definitions associated with the credential in order to assure they follow the CType's credential schema.
- * An array of CType definitions can be passed instead, which has the effect of restricting allowable credential types to these known CTypes.
- * By default, this retrieves CType defitions from the KILT blockchain, using a loader with an internal definitions cache.
+ * @param config.cTypes - To ensure that the credential' structure follows specific CType's schemas (definitions), with this parameter it is possible to pass:
+ *  - either an array of CType definitions
+ *  - or a CType-Loader that retrieves the definition of the CType linked to the credential.
+ *
+ * By default, this retrieves CType definitions from the KILT blockchain, using a loader with an internal definitions cache.
  * @param config.credentialStatusLoader - An alternative credential status resolver.
  * This function takes the credential as input and is expected to return a promise of an {@link CredentialStatusResult}.
  * Defaults to {@link checkStatus}.
@@ -216,7 +218,7 @@ export async function verifyCredential(
  * @param config - Additional configuration (optional).
  * @param config.didResolver - An alterative DID resolver to resolve the holder- and issuer DIDs (defaults to {@link resolve}).
  * An array of static DID documents can be provided instead, in which case the function will not try to retrieve any DID documents from a remote source.
- * @param config.cTypes - An alternative CType loader for credential verification, or alternatively an array of CTypes.
+ * @param config.cTypes - Alternative input for the credential structural verification. It can either be an array of CTypes or a CType loader.
  * See {@link verifyCredential} for details.
  * @param config.credentialStatusLoader - An alternative credential status resolver.
  * See {@link verifyCredential} for details.

--- a/packages/credentials/src/verifier.ts
+++ b/packages/credentials/src/verifier.ts
@@ -77,7 +77,7 @@ export async function checkStatus(
  * @param config - Additional configuration (optional).
  * @param config.didResolver - An alterative DID resolver to resolve issuer DIDs (defaults to {@link resolve}).
  * An array of static DID documents can be provided instead, in which case the function will not try to retrieve any DID documents from a remote source.
- * @param config.ctypeLoader - An alternative CType loader that retrieves CType definitions associated with the credential in order to assure they follow the CType's credential schema.
+ * @param config.cTypes - An alternative CType loader that retrieves CType definitions associated with the credential in order to assure they follow the CType's credential schema.
  * An array of CType definitions can be passed instead, which has the effect of restricting allowable credential types to these known CTypes.
  * By default, this retrieves CType defitions from the KILT blockchain, using a loader with an internal definitions cache.
  * @param config.credentialStatusLoader - An alternative credential status resolver.
@@ -95,7 +95,7 @@ export async function verifyCredential(
   } = {},
   config: {
     didResolver?: typeof resolve | DidDocument[]
-    ctypeLoader?: CTypeLoader | ICType[]
+    cTypes?: CTypeLoader | ICType[]
     credentialStatusLoader?: (
       credential: VerifiableCredential
     ) => Promise<CredentialStatusResult>
@@ -132,14 +132,14 @@ export async function verifyCredential(
               )
             }
 
-            const { ctypeLoader } = config
+            const { cTypes } = config
             const options: Parameters<typeof KiltAttestationProofV1.verify>[2] =
               {}
-            if (Array.isArray(ctypeLoader)) {
-              options.cTypes = ctypeLoader
+            if (Array.isArray(cTypes)) {
+              options.cTypes = cTypes
               options.loadCTypes = false
-            } else if (typeof ctypeLoader === 'function') {
-              options.loadCTypes = ctypeLoader
+            } else if (typeof cTypes === 'function') {
+              options.loadCTypes = cTypes
             }
             await KiltAttestationProofV1.verify(
               credential as KiltCredentialV1.Interface,
@@ -322,7 +322,7 @@ export async function verifyPresentation(
         const credentialResult = await verifyCredential(
           credential,
           { ...verificationCriteria.credentials, now, tolerance },
-          { credentialStatusLoader, ctypeLoader, didResolver }
+          { credentialStatusLoader, cTypes: ctypeLoader, didResolver }
         )
         return { ...credentialResult, credential }
       })

--- a/packages/credentials/src/verifier.ts
+++ b/packages/credentials/src/verifier.ts
@@ -111,7 +111,6 @@ export async function verifyCredential({
   verificationCriteria?: VerificationCriteria
   config?: VerificationConfig
 }): Promise<VerifyCredentialResult> {
-
   const result: VerifyCredentialResult = {
     verified: false,
   }

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -292,7 +292,7 @@ async function runAll() {
     issued,
     {},
     {
-      ctypeLoader: [DriversLicense],
+      cTypes: [DriversLicense],
     }
   )
   if (credentialResult.verified) {

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -287,14 +287,6 @@ async function runAll() {
   })
   console.info('Credential issued')
 
-  const credentialResult = await Verifier.verifyCredential(
-    issued,
-    {},
-    {
-      cTypes: [DriversLicense],
-    }
-  )
-
   const credentialResult = await Verifier.verifyCredential({
     credential: issued,
     config: {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3270

Renames parameter from verifyPresentation() from `config.cTypeLoader` to `config.cTypes`. 

```
cTypes?: CTypeLoader | ICType[]
```