### PR TITLE
refactor: use credentialSubject on credential constructor

### DIFF
--- a/packages/credentials/src/issuer.ts
+++ b/packages/credentials/src/issuer.ts
@@ -23,10 +23,8 @@ import type { IssuerOptions } from './interfaces.js'
  * This is added to the `type` field on the credential and determines the `credentialSchema` as well.
  * Defaults to the type {@link KiltCredentialV1.CREDENTIAL_TYPE KiltCredentialV1} which, for the time being, is also the only type supported.
  * @param arguments.issuer The Decentralized Identifier (DID) of the identity acting as the authority issuing this credential.
- * @param arguments.subject The DID identifying the subject of the credential, about which `claims` are made.
- * Sets the `credentialSubject.id` property of the credential.
- * @param arguments.claims An object containing key-value pairs that represent claims made about the subject.
- * These key-value pairs are added to the `credentialSubject` property of the credential.
+ * @param arguments.credentialSubject An object containing key-value pairs that represent claims made about the subject of the credential.
+ * @param arguments.credentialSubject.id The DID identifying the subject of the credential, about which claims are made (the remaining key-value pairs).
  * @param arguments.cType CTypes are special credential subtypes that are defined by a schema describing claims that may be made about the subject and are registered on the Kilt blockchain.
  * Each Kilt credential is based on exactly one of these subtypes. This argument is therefore mandatory and expects the schema definition of a CType.
  * @param arguments.cTypeDefinitions Some CTypes are themselves composed of definitions taken from other CTypes; in that case, these definitions need to be supplied here.
@@ -36,21 +34,20 @@ import type { IssuerOptions } from './interfaces.js'
 export async function createCredential({
   type,
   issuer,
-  subject,
-  claims = {},
+  credentialSubject,
   cType,
   cTypeDefinitions,
 }: {
   type?: string
   issuer: Did
-  subject: Did
-  claims?: Record<string, unknown>
+  credentialSubject: Record<string, unknown> & { id: Did }
   cType: ICType
   cTypeDefinitions?: ICType[] | CTypeLoader
 }): Promise<UnsignedVc> {
   switch (type) {
     case undefined:
     case KiltCredentialV1.CREDENTIAL_TYPE: {
+      const { id: subject, ...claims } = credentialSubject
       const credential = KiltCredentialV1.fromInput({
         issuer,
         subject,

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -262,20 +262,19 @@ async function runAll() {
 
   // Attestation workflow
   console.log('Attestation workflow started')
-  const content = { name: 'Bob', age: 21 }
+  const credentialSubject = { id: bob.id, name: 'Bob', age: 21 }
 
   const credential = await Issuer.createCredential({
     cType: DriversLicense,
-    claims: content,
-    subject: bob.id,
+    credentialSubject,
     issuer: alice.id,
   })
 
   console.info('Credential subject conforms to CType')
 
   if (
-    credential.credentialSubject.name !== content.name ||
-    credential.credentialSubject.age !== content.age ||
+    credential.credentialSubject.name !== credentialSubject.name ||
+    credential.credentialSubject.age !== credentialSubject.age ||
     credential.credentialSubject.id !== bob.id
   ) {
     throw new Error('Claim content inside Credential mismatching')


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3269

Align with VC terminology to avoid confusion. Tom suggested that instead of its goal of easing credential creation the current solution just introduces confusion and is incoherent with our goal of aligning our stack more closely with the specs and their vocabulary.

## How to test:

Tests have been updated.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
