### PR TITLE
fix: updating the testcontainer dep

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: '3.2'
 
 services:
   dev-node:
-    image: kiltprotocol/standalone-node:develop
+    image: kiltprotocol/standalone-node:latest-develop
     command: '--dev --ws-port 9944 --ws-external'
 
   sdk:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # `docker-compose run sdk` will run integration tests using the latest
 # standalone-node image on dockerhub. The src/ directory is mounted, so rebuilding
 # is not required to integrate changes in this directory.
-# `docker-compose run sdk yarn test:integration:run Attestation` would run specific tests.
+# `docker-compose run sdk yarn test:integration:latest-develop Attestation` would run specific tests.
 # In order to test against the current state of the develop branch, you can build a standalone-node
 # image locally by telling docker-compose to use the override file `dc.build.node.yml` like so:
 # `docker-compose -f docker-compose.yml -f dc.build.node.yml run sdk`. Alternatively you could

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -41,7 +41,7 @@ export async function getStartedTestContainer(
     process.env.TESTCONTAINERS_NODE_IMG || 'kiltprotocol/standalone-node'
   console.log(`using testcontainer with image ${image}`)
   const strategies = [
-    ['--dev', '--ws-external', `--ws-port=${WS_PORT}`],
+    // ['--dev', '--ws-external', `--ws-port=${WS_PORT}`],
     ['--dev', '--rpc-external', `--rpc-port=${WS_PORT}`],
   ]
   // eslint-disable-next-line no-restricted-syntax
@@ -61,7 +61,7 @@ export async function getStartedTestContainer(
       console.log('container started and ready')
       return started
     } catch (error) {
-      console.warn(
+      throw console.error(
         'Failed to start container due to the following error:\n',
         error
       )


### PR DESCRIPTION
##  [#3410](https://github.com/KILTprotocol/ticket/issues/3410)
Tag wasn't updated in develop
https://hub.docker.com/r/kiltprotocol/standalone-node/tags?page=&page_size=&ordering=&name=develop

Found out that the branch doesn't use the docker images anymore and direct to testcontainer.

## How to test:

Run the docker compose and check to see if working.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
