### PR TITLE
fix: CType ID is checked in presentation

### DIFF
--- a/packages/core/src/credential/Credential.ts
+++ b/packages/core/src/credential/Credential.ts
@@ -301,10 +301,15 @@ export function verifyWellFormed(
   verifyDataIntegrity(credential)
 
   if (ctype) {
+    if (`kilt:ctype:${credential.claim.cTypeHash}` !== ctype.$id) {
+      throw new SDKErrors.CTypeIdMismatchError(
+        ctype.$id,
+        credential.claim.cTypeHash
+      )
+    }
     verifyClaimAgainstSchema(credential.claim.contents, ctype)
   }
 }
-
 /**
  * Queries the attestation record for a credential and matches their data. Fails if no attestation exists, if it is revoked, or if the attestation data does not match the credential.
  *


### PR DESCRIPTION
## fixes [#3391](https://github.com/KILTprotocol/ticket/issues/3391)
Checking the ctype ID in the credential to verify if matching ctype and credential ctype hash

## How to test:

yarn test

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
