### PR TITLE
fix: CType does not check credential ctype in presentation

### DIFF
--- a/packages/legacy-credentials/src/Credential.ts
+++ b/packages/legacy-credentials/src/Credential.ts
@@ -298,13 +298,10 @@ export function verifyWellFormed(
 ): void {
   verifyDataStructure(credential)
   verifyDataIntegrity(credential)
-  const credentialCTypeId = CType.hashToId(credential.claim.cTypeHash)
   if (ctype) {
+    const credentialCTypeId = CType.hashToId(credential.claim.cTypeHash)
     if (credentialCTypeId !== ctype.$id) {
-      throw new SDKErrors.CTypeIdMismatchError(
-        ctype.$id,
-        credential.claim.cTypeHash
-      )
+      throw new SDKErrors.CTypeIdMismatchError(ctype.$id, credentialCTypeId)
     }
     CType.verifyClaimAgainstSchema(credential.claim.contents, ctype)
   }

--- a/packages/legacy-credentials/src/Credential.ts
+++ b/packages/legacy-credentials/src/Credential.ts
@@ -298,9 +298,9 @@ export function verifyWellFormed(
 ): void {
   verifyDataStructure(credential)
   verifyDataIntegrity(credential)
-
+  const credentialCTypeId = CType.hashToId(credential.claim.cTypeHash)
   if (ctype) {
-    if (`kilt:ctype:${credential.claim.cTypeHash}` !== ctype.$id) {
+    if (credentialCTypeId !== ctype.$id) {
       throw new SDKErrors.CTypeIdMismatchError(
         ctype.$id,
         credential.claim.cTypeHash

--- a/packages/legacy-credentials/src/Credential.ts
+++ b/packages/legacy-credentials/src/Credential.ts
@@ -300,6 +300,12 @@ export function verifyWellFormed(
   verifyDataIntegrity(credential)
 
   if (ctype) {
+    if (`kilt:ctype:${credential.claim.cTypeHash}` !== ctype.$id) {
+      throw new SDKErrors.CTypeIdMismatchError(
+        ctype.$id,
+        credential.claim.cTypeHash
+      )
+    }
     CType.verifyClaimAgainstSchema(credential.claim.contents, ctype)
   }
 }


### PR DESCRIPTION
## fixes [#3391](https://github.com/KILTprotocol/ticket/issues/3391)

Updating the verify credential to check against the credentials ctypes id against the given ctype

## How to test:
Please provide a brief step-by-step instruction.
If necessary provide information about dependencies (specific configuration, branches, database dumps, etc.)

- Step 1
- Step 2
- etc.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
