### PR TITLE
chore: update to node v20 

### DIFF
--- a/.github/actions/cached-image-pull/action.yml
+++ b/.github/actions/cached-image-pull/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: check image cache
       id: image-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.image-file.outputs.path }}
         key: image-cache-${{ inputs.image }}

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     if: "! startsWith(github.event.head_commit.message, '[CI Skip]') && github.repository == 'kiltprotocol/sdk-js'"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch-depth 0 and token needed to push changes on the package.json files back.
           fetch-depth: 0
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install and Build
         run: |

--- a/.github/workflows/npmpublish-rc.yml
+++ b/.github/workflows/npmpublish-rc.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -31,8 +31,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -44,9 +44,9 @@ jobs:
         run: yarn run bundle
       - name: Get current package version
         id: package_version
-        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT    
+        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Publish to NPM
-        run: yarn run publish --tag ${{ inputs.npm_tag }} 
+        run: yarn run publish --tag ${{ inputs.npm_tag }}
         env:
           YARN_NPM_AUTH_TOKEN: ${{secrets.npm_token}}
       - name: Repository Dispatch
@@ -55,4 +55,4 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: KILTProtocol/docs
           event-type: sdk-update
-          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'             
+          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -19,8 +19,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -32,7 +32,7 @@ jobs:
         run: yarn run bundle
       - name: Get current package version
         id: package_version
-        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT                  
+        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Publish to NPM
         run: yarn run publish --tag latest
         env:
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: KILTProtocol/docs
           event-type: sdk-update
-          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'          
+          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -63,7 +63,7 @@ jobs:
         run: node --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -133,7 +133,7 @@ jobs:
           node-version-file: '.nvmrc'
       - run: basename /packages/sdk-js/dist/
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -12,14 +12,13 @@ env:
   TESTCONTAINERS_WATCHER_IMG: testcontainers/ryuk:0.3.2
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -30,7 +29,7 @@ jobs:
       - name: zip build
         run: zip -r build.zip .
       - name: upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build.zip
@@ -39,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: make sure testcontainers image is in cache
         uses: ./.github/actions/cached-image-pull
         with:
@@ -51,13 +50,13 @@ jobs:
     needs: cache_imgs
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: Log out node version
@@ -97,19 +96,19 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: yarn bundle
         run: yarn bundle
       - name: upload bundle artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist/sdk-js.umd.js
@@ -120,16 +119,16 @@ jobs:
     needs: [cache_imgs, bundle_cache]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - run: basename /packages/sdk-js/dist/

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: pull image
         env:
@@ -141,7 +141,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -61,7 +61,9 @@ jobs:
         node-version: [18.x, 20.x]
         required: ['required']
         include:
-          - node-version: [16.x, 22.x]
+          - node-version: 16.x
+            required: 'optional'
+          - node-version: 22.x
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -58,10 +58,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
         required: ['required']
         include:
           - node-version: 16.x
+            required: 'optional'
+          - node-version: 22.x
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -108,9 +108,9 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: pull image
+      - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: kilt/prototype-chain

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -58,10 +58,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
         required: ['required']
         include:
-          - node-version: 16.x
+          - node-version: [16.x, 22.x]
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         required: ['required']
         include:
           - node-version: 16.x

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -58,12 +58,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         required: ['required']
         include:
           - node-version: 16.x
-            required: 'optional'
-          - node-version: 22.x
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -16,11 +16,11 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -35,7 +35,7 @@ jobs:
       - name: list dependencies
         run: echo "$(yarn info -A --name-only --json)" > locked_dependencies.txt
       - name: upload dependencies list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deps-${{ matrix.node-version }}
           path: |
@@ -47,7 +47,7 @@ jobs:
       - name: zip build
         run: zip -r build.zip .
       - name: upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.node-version }}
           path: build.zip
@@ -67,7 +67,7 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.node-version }}
       - name: unzip
@@ -91,7 +91,7 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-20.x
       - name: unzip
@@ -135,7 +135,7 @@ jobs:
     needs: [test, integration_test]
     if: failure()
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: deps-20.x
       - name: set dependencies env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,12 +80,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
         required: ['required']
         include:
           - node-version: 16
-            required: 'optional'
-          - node-version: 22
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20]
         required: ['required']
         include:
           - node-version: 16
+            required: 'optional'
+          - node-version: 22
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20]
         required: ['required']
         include:
-          - node-version: 16
+          - node-version: [16, 22]
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: pull image
         env:
@@ -235,7 +235,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
       - run: basename /packages/sdk-js/dist/
       - name: pull node image
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
         run: node --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -227,7 +227,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,9 @@ jobs:
     needs: check_skip
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -50,7 +50,7 @@ jobs:
       - name: zip build
         run: zip -r build.zip .
       - name: upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build.zip
@@ -60,13 +60,13 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: lint
@@ -90,10 +90,10 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: make sure testcontainers image is in cache
         uses: ./.github/actions/cached-image-pull
         with:
@@ -129,13 +129,13 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: Log out node version
@@ -169,30 +169,29 @@ jobs:
       - name: run integration tests (cjs)
         timeout-minutes: 60
         run: yarn test:integration -b
-      
+
       - name: run integration tests (esm)
         timeout-minutes: 60
         run: yarn test:integration:esm -b
-
 
   bundle_cache:
     runs-on: ubuntu-latest
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: yarn bundle
         run: yarn bundle
       - name: upload bundle artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist/sdk-js.umd.js
@@ -211,17 +210,17 @@ jobs:
 
     continue-on-error: ${{ matrix.required == 'optional' }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,9 @@ jobs:
         node-version: [18, 20]
         required: ['required']
         include:
-          - node-version: [16, 22]
+          - node-version: 16
+            required: 'optional'
+          - node-version: 22
             required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
         required: ['required']
         include:
           - node-version: 16

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## fixes part of KILTProtocol/ticket#3081

- Makes sure the `package.json` specifies `yarn` version. 
- Upgrades the used **node version**  on the `.nvmrc`  to `lts/Iron`. 
- Makes sure the **GitHub workflows** uses node version 20. 
  For this following must be set: 
  - `actions/checkout@v4`
  - `actions/setup-node@v4` **with:**  _either_
    - **node-version-file:** '`package.json`' or '`.nvmrc`' 
    -  **node-version:**  `'`<Node.js version using [SemVer](https://semver.org/) or [aliases](https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule) > `'`
    - `actions/download-artifact@v4`
    - _optional, but done:_ `actions/cache@v4`
  -  `aws-actions/configure-aws-credentials@v4`
  -  `aws-actions/amazon-ecr-login@v2`
 - Makes sure the **Dockerfiles** also use the node version 20. 
  This means that the following must be set: 
      - `FROM node:20-alpine as builder`
  -  ~~It also updates dependencies: mostly to latest minor, but major for ones with complains.~~ Dropped.

