### PR TITLE
feat: implement deactivateDid

### DIFF
--- a/packages/sdk-js/src/DidHelpers/deactivateDid.spec.ts
+++ b/packages/sdk-js/src/DidHelpers/deactivateDid.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2018-2024, BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import type { DidDocument, KiltKeyringPair } from '@kiltprotocol/types'
+import { Crypto } from '@kiltprotocol/utils'
+import {
+  ApiMocks,
+  createLocalDemoFullDidFromKeypair,
+} from '../../../../tests/testUtils/index.js'
+import { ConfigService } from '../index.js'
+import { deactivateDid } from './deactivateDid.js'
+import { transact } from './transact.js'
+
+jest.mock('./transact.js')
+
+const mockedTransact = jest.mocked(transact)
+const mockedApi = ApiMocks.createAugmentedApi()
+
+describe('deactivate', () => {
+  let didDocument: DidDocument
+  let keypair: KiltKeyringPair
+  beforeAll(async () => {
+    ConfigService.set({ api: mockedApi })
+
+    keypair = Crypto.makeKeypairFromUri('//Alice')
+    const { id, verificationMethod, authentication } =
+      await createLocalDemoFullDidFromKeypair(keypair, {
+        verificationRelationships: new Set(['assertionMethod']),
+      })
+    didDocument = {
+      id,
+      authentication,
+      assertionMethod: authentication,
+      verificationMethod: verificationMethod?.filter(
+        (vm) => vm.id === authentication![0]
+      ),
+    }
+  })
+
+  it('creates a deactivate did tx', async () => {
+    deactivateDid({
+      didDocument,
+      api: mockedApi,
+      submitter: keypair,
+      signers: [keypair],
+    })
+
+    expect(mockedTransact).toHaveBeenLastCalledWith(
+      expect.objectContaining<Partial<Parameters<typeof transact>[0]>>({
+        call: expect.any(Object),
+        expectedEvents: expect.arrayContaining([
+          {
+            section: 'did',
+            method: 'DidDeleted',
+          },
+        ]),
+        didDocument,
+        api: mockedApi,
+        submitter: keypair,
+        signers: [keypair],
+      })
+    )
+    expect(mockedTransact.mock.lastCall?.[0].call.toHuman()).toMatchObject({
+      method: { method: 'delete', section: 'did' },
+    })
+  })
+})

--- a/packages/sdk-js/src/DidHelpers/deactivateDid.ts
+++ b/packages/sdk-js/src/DidHelpers/deactivateDid.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2018-2024, BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import type { SharedArguments, TransactionHandlers } from './interfaces.js'
+import { transact } from './transact.js'
+
+/**
+ * _Permanently_ deactivates the DID, removing all verification methods and services from its document.
+ * This action cannot be undone – once a DID has been deactivated, all operations on it (including attempts at re-creation) are permanently disabled.
+ *
+ * @param options Any {@link SharedArguments} and additional parameters.
+ * @param options.didDocument The {@link DidDocument} of the DID to be deactivated.
+ * @returns A set of {@link TransactionHandlers}.
+ */
+export function deactivateDid(options: SharedArguments): TransactionHandlers {
+  const { api, didDocument } = options
+  return transact({
+    ...options,
+    call: api.tx.did.delete(didDocument.service?.length ?? 0),
+    expectedEvents: [{ section: 'did', method: 'DidDeleted' }],
+  })
+}

--- a/packages/sdk-js/src/DidHelpers/index.ts
+++ b/packages/sdk-js/src/DidHelpers/index.ts
@@ -12,6 +12,7 @@ import { Signers } from '@kiltprotocol/utils'
 import type { SharedArguments } from './interfaces.js'
 
 export { createDid } from './createDid.js'
+export { deactivateDid } from './deactivateDid.js'
 export { addService, removeService } from './service.js'
 export { transact } from './transact.js'
 export {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3367

Implements the [`deactivateDid`](https://github.com/KILTprotocol/sdk-js/commit/2edcb7da763fa754d6be715ff9f90b141b11131a) function and adds unit & integration tests.
We didn't have an interface specced out for it, but I think it's pretty straightforward. It just deactivates the DID whose DID document is passed.

## How to test:

Basic unit & integration tests are included.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
