### PR TITLE
fix: transaction result serialization

### DIFF
--- a/packages/sdk-js/src/DidHelpers/checkResult.ts
+++ b/packages/sdk-js/src/DidHelpers/checkResult.ts
@@ -231,6 +231,7 @@ export async function checkResultImpl(
             ...clone.block,
             number: clone.block.number.toString(),
           }
+          delete clone.toJSON
           return clone
         },
       }
@@ -267,8 +268,40 @@ export async function checkResultImpl(
             ...clone.block,
             number: clone.block.number.toString(),
           }
+          delete clone.toJSON
           return clone
         },
+      }
+    },
+    toJSON() {
+      switch (status) {
+        case 'confirmed': {
+          return {
+            status,
+            value: (this as TransactionResult).asConfirmed.toJSON(),
+          }
+        }
+        case 'failed': {
+          return {
+            status,
+            value: (this as TransactionResult).asFailed.toJSON(),
+          }
+        }
+        case 'rejected': {
+          return {
+            status,
+            value: (this as TransactionResult).asRejected,
+          }
+        }
+        case 'unknown': {
+          return {
+            status,
+            value: (this as TransactionResult).asUnknown,
+          }
+        }
+        default: {
+          throw new Error('invalid status')
+        }
       }
     },
   }

--- a/packages/sdk-js/src/DidHelpers/checkResult.ts
+++ b/packages/sdk-js/src/DidHelpers/checkResult.ts
@@ -228,8 +228,8 @@ export async function checkResultImpl(
         toJSON() {
           const clone = { ...this } as any
           clone.block = {
+            ...clone.block,
             number: clone.block.number.toString(),
-            hash: this.block.hash,
           }
           return clone
         },

--- a/packages/sdk-js/src/DidHelpers/checkResult.ts
+++ b/packages/sdk-js/src/DidHelpers/checkResult.ts
@@ -227,7 +227,10 @@ export async function checkResultImpl(
         events: txEvents.map(({ event }) => event),
         toJSON() {
           const clone = { ...this } as any
-          clone.block.number = clone.block.number.toString()
+          clone.block = {
+            number: clone.block.number.toString(),
+            hash: this.block.hash,
+          }
           return clone
         },
       }

--- a/packages/sdk-js/src/DidHelpers/checkResult.ts
+++ b/packages/sdk-js/src/DidHelpers/checkResult.ts
@@ -264,8 +264,8 @@ export async function checkResultImpl(
         toJSON() {
           const clone = { ...this } as any
           clone.block = {
+            ...clone.block,
             number: clone.block.number.toString(),
-            hash: this.block.hash,
           }
           return clone
         },

--- a/packages/sdk-js/src/DidHelpers/interfaces.ts
+++ b/packages/sdk-js/src/DidHelpers/interfaces.ts
@@ -47,6 +47,7 @@ export interface TransactionResult {
     error: Error
     txHash: HexString
   }
+    toJSON: () => any
 }
 
 export interface TransactionHandlers {

--- a/packages/sdk-js/src/DidHelpers/interfaces.ts
+++ b/packages/sdk-js/src/DidHelpers/interfaces.ts
@@ -47,7 +47,7 @@ export interface TransactionResult {
     error: Error
     txHash: HexString
   }
-    toJSON: () => any
+  toJSON: () => any
 }
 
 export interface TransactionHandlers {

--- a/packages/sdk-js/src/DidHelpers/interfaces.ts
+++ b/packages/sdk-js/src/DidHelpers/interfaces.ts
@@ -26,6 +26,7 @@ export interface TransactionResult {
     didDocument: DidDocument
     block: { hash: HexString; number: BigInt }
     events: GenericEvent[]
+    toJSON: () => any
   }
   asFailed: {
     error: Error
@@ -34,6 +35,7 @@ export interface TransactionResult {
     didDocument?: DidDocument
     block: { hash: HexString; number: BigInt }
     events: GenericEvent[]
+    toJSON: () => any
   }
   asRejected: {
     error: Error

--- a/packages/sdk-js/src/DidHelpers/transact.spec.ts
+++ b/packages/sdk-js/src/DidHelpers/transact.spec.ts
@@ -102,7 +102,7 @@ describe('transact', () => {
         },
       }),
     })
-    // TODO move serialzation test to `checkResult.spec.ts` once created and 
+    // TODO move serialzation test to `checkResult.spec.ts` once created and
     // test the `asFailed` case.
     const confirmed = result.asConfirmed
     expect(typeof confirmed.block.number).toBe('bigint')

--- a/packages/sdk-js/src/DidHelpers/transact.spec.ts
+++ b/packages/sdk-js/src/DidHelpers/transact.spec.ts
@@ -110,5 +110,9 @@ describe('transact', () => {
     const resultRebuiltObj = JSON.parse(resultStringified)
     expect(BigInt(resultRebuiltObj.block.number)).toBe(BigInt(1000))
     expect(typeof confirmed.block.number).toBe('bigint')
+    expect(result.toJSON()).toStrictEqual({
+      status: 'confirmed',
+      value: confirmed.toJSON(),
+    })
   })
 })

--- a/packages/sdk-js/src/DidHelpers/transact.spec.ts
+++ b/packages/sdk-js/src/DidHelpers/transact.spec.ts
@@ -80,18 +80,17 @@ describe('transact', () => {
     expect(parsed.method).toHaveProperty('section', 'did')
     expect(parsed.method).toHaveProperty('method', 'submitDidCall')
 
-    await expect(
-      checkResult(
-        new SubmittableResult({
-          blockNumber: mockedApi.createType('BlockNumber', 1000),
-          status: mockedApi.createType('ExtrinsicStatus', {
-            inBlock: new Uint8Array(32).fill(2),
-          }),
-          txHash: parsed.hash,
-          events: makeAttestationCreatedEvents([[]]),
-        })
-      )
-    ).resolves.toMatchObject<Partial<TransactionResult>>({
+    const result = await checkResult(
+      new SubmittableResult({
+        blockNumber: mockedApi.createType('BlockNumber', 1000),
+        status: mockedApi.createType('ExtrinsicStatus', {
+          inBlock: new Uint8Array(32).fill(2),
+        }),
+        txHash: parsed.hash,
+        events: makeAttestationCreatedEvents([[]]),
+      })
+    )
+    expect(result).toMatchObject<Partial<TransactionResult>>({
       status: 'confirmed',
       asConfirmed: expect.objectContaining({
         txHash: parsed.hash.toHex(),
@@ -103,5 +102,13 @@ describe('transact', () => {
         },
       }),
     })
+    // TODO move serialzation test to `checkResult.spec.ts` once created and 
+    // test the `asFailed` case.
+    const confirmed = result.asConfirmed
+    expect(typeof confirmed.block.number).toBe('bigint')
+    const resultStringified = JSON.stringify(confirmed)
+    const resultRebuiltObj = JSON.parse(resultStringified)
+    expect(BigInt(resultRebuiltObj.block.number)).toBe(BigInt(1000))
+    expect(typeof confirmed.block.number).toBe('bigint')
   })
 })


### PR DESCRIPTION
fixes https://github.com/KILTprotocol/ticket/issues/3529

Adds `toJSON` implementation to the `TransactionResult` objects that include a block number.
Another way to solve the serialization issue is to change the block number type to `string`.
