### PR TITLE
refactor!: integrate feedback on alpha release

### DIFF
--- a/packages/credentials/src/holder.ts
+++ b/packages/credentials/src/holder.ts
@@ -126,7 +126,7 @@ export async function deriveProof({
  * @param params.presentationOptions Object holding optional arguments for scoping the presentation.
  * @param params.presentationOptions.validFrom A Date or date-time string indicating the earliest point in time where the presentation becomes valid.
  * Represented as `issuanceDate` on the presentation.
- * Defaults to `proofOptions.now`.
+ * Defaults to `params.now`.
  * @param params.presentationOptions.validUntil A Date or date-time string indicating when the presentation is no longer valid.
  * Represented as `expirationDate` on the presentation.
  * @param params.presentationOptions.verifier Identifier (DID) of the verifier to prevent unauthorized re-use of the presentation.
@@ -139,7 +139,7 @@ export async function deriveProof({
  * @param params.proofOptions.domain A domain string to be included in the proof.
  * This plays a role similar to the `verifier` option, but is not restricted to DIDs.
  * This could, for example, be the domain of a web-application requesting credential presentation.
- * @param params.proofOptions.now Allows manipulating the current date and time for the purpose of presentation & proof generation.
+ * @param params.now Allows manipulating the current date and time for the purpose of presentation & proof generation.
  * Defaults to the current date and time.
  * @returns A holder-signed presentation.
  */
@@ -148,6 +148,7 @@ export async function createPresentation({
   holder,
   presentationOptions = {},
   proofOptions = {},
+  now,
 }: {
   credentials: VerifiableCredential[]
   holder: HolderOptions
@@ -161,12 +162,12 @@ export async function createPresentation({
     proofType?: string
     challenge?: string
     domain?: string
-    now?: Date
   }
+  now?: Date
 }): Promise<VerifiablePresentation> {
   const { didDocument, signers } = holder
   const { validFrom, validUntil, verifier } = presentationOptions
-  const { proofPurpose, proofType, challenge, domain, now } = proofOptions
+  const { proofPurpose, proofType, challenge, domain } = proofOptions
 
   let presentation = await Presentation.create({
     credentials,

--- a/packages/credentials/src/interfaces.ts
+++ b/packages/credentials/src/interfaces.ts
@@ -11,7 +11,6 @@ import type {
   DidDocument,
   DidHelpersAcceptedSigners,
   HexString,
-  KiltAddress,
   SharedArguments,
   TransactionResult,
 } from '@kiltprotocol/types'
@@ -36,7 +35,7 @@ export type SubmitOverride = (
 ) => Promise<SimplifiedTransactionResult | TransactionResult>
 
 interface SubmitterAddressOrOverride {
-  submitter: KiltAddress | SubmitOverride
+  submitter: SharedArguments['submitter'] | SubmitOverride
 }
 
 export type IssuerOptions = HolderOptions & SubmitterAddressOrOverride

--- a/packages/credentials/src/issuer.ts
+++ b/packages/credentials/src/issuer.ts
@@ -90,34 +90,33 @@ export async function createCredential({
 /**
  * Issues a Verifiable Credential from on the input document by attaching a proof. Edits to the document may be made depending on the proof type.
  *
- * @param credential A credential document as returned by {@link createCredential}.
- * @param issuer Interfaces for interacting with the issuer identity for the purpose of generating a proof.
- * @param issuer.didDocument The DID Document of the issuer.
- * @param issuer.signers An array of signer interfaces, each allowing to request signatures made with a key associated with the issuer DID Document.
+ * @param params Holds all named parameters.
+ * @param params.credential A credential document as returned by {@link createCredential}.
+ * @param params.issuer Interfaces for interacting with the issuer identity for the purpose of generating a proof.
+ * @param params.issuer.didDocument The DID Document of the issuer.
+ * @param params.issuer.signers An array of signer interfaces, each allowing to request signatures made with a key associated with the issuer DID Document.
  * The function will select the first signer that matches requirements around signature algorithm and relationship of the key to the DID as given by the DID Document.
- * @param issuer.submitter Some proof types require making transactions to effect state changes on the KILT blockchain.
+ * @param params.issuer.submitter Some proof types require making transactions to effect state changes on the KILT blockchain.
  * The blockchain account whose address is specified here will be used to cover all transaction fees and deposits due for this operation.
  * As transactions to the blockchain need to be signed, `signers` is expected to contain a signer interface where the `id` matches this address.
  *
  * Alternatively, you can pass a {@link SubmitOverride} callback that takes care of Did-authorizing and submitting the transaction.
  * If you are using a service that helps you submit and pay for transactions, this is your point of integration to it.
- * @param proofOptions Options that control proof generation.
- * @param proofOptions.proofType The type of proof to be created.
+ * @param params.proofOptions Options that control proof generation.
+ * @param params.proofOptions.proofType The type of proof to be created.
  * Defaults to {@link KiltAttestationProofV1.PROOF_TYPE KiltAttestationProofV1} which, as of now, is the only type suppported.
- * @param proofOptions.proofPurpose Controls which relationship to the DID is expected of the key selected for creating the proof.
- * Defaults to `assertionMethod`, which is also the only value supported for {@link KiltAttestationProofV1.PROOF_TYPE KiltAttestationProofV1} proofs.
- * @param proofOptions.now Allows manipulating the current date and time for the purpose of proof generation.
- * As of now, this has no effect though.
  */
-export async function issue(
-  credential: UnsignedVc,
-  issuer: IssuerOptions,
-  proofOptions: {
+export async function issue({
+  credential,
+  issuer,
+  proofOptions = {},
+}: {
+  credential: UnsignedVc
+  issuer: IssuerOptions
+  proofOptions?: {
     proofType?: string
-    proofPurpose?: string
-    now?: Date // given that this has no effect, should I remove it for now?
-  } = {}
-): Promise<VerifiableCredential> {
+  }
+}): Promise<VerifiableCredential> {
   const { proofType } = proofOptions
   switch (proofType) {
     case undefined:

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -234,7 +234,7 @@ async function runAll() {
   // The presentation includes a proof of ownership and is scoped to a verified and time frame to prevent unauthorized re-use.
   //
   const derived = await Kilt.Holder.deriveProof(credential, {
-    disclose: { only: ['/credentialSubject/age'] },
+    includeClaims: ['/credentialSubject/age'],
   })
 
   const presentation = await Kilt.Holder.createPresentation(

--- a/tests/bundle/bundle-test.ts
+++ b/tests/bundle/bundle-test.ts
@@ -218,10 +218,13 @@ async function runAll() {
     cType: DriversLicense,
   })
 
-  const credential = await Kilt.Issuer.issue(unsigned, {
-    didDocument,
-    signers: [...signers, submitter],
-    submitter: submitter.id,
+  const credential = await Kilt.Issuer.issue({
+    credential: unsigned,
+    issuer: {
+      didDocument,
+      signers: [...signers, submitter],
+      submitter: submitter.id,
+    },
   })
 
   console.log('credential issued')
@@ -233,18 +236,22 @@ async function runAll() {
   // Create a derived credential that only contains selected properties (selective disclosure), then create a credential presentation for it.
   // The presentation includes a proof of ownership and is scoped to a verified and time frame to prevent unauthorized re-use.
   //
-  const derived = await Kilt.Holder.deriveProof(credential, {
-    includeClaims: ['/credentialSubject/age'],
+  const derived = await Kilt.Holder.deriveProof({
+    credential,
+    proofOptions: { includeClaims: ['/credentialSubject/age'] },
   })
 
-  const presentation = await Kilt.Holder.createPresentation(
-    [derived],
-    {
+  const presentation = await Kilt.Holder.createPresentation({
+    credentials: [derived],
+    holder: {
       didDocument,
       signers,
     },
-    { verifier: didDocument.id, validUntil: new Date(Date.now() + 100_000) }
-  )
+    presentationOptions: {
+      verifier: didDocument.id,
+      validUntil: new Date(Date.now() + 100_000),
+    },
+  })
 
   console.log('presentation created')
 

--- a/tests/integration/didHelpers.spec.ts
+++ b/tests/integration/didHelpers.spec.ts
@@ -390,17 +390,20 @@ describe('transact', () => {
       cType,
     })
 
-    const issued = await Issuer.issue(unsigned, {
-      didDocument,
-      signers: [keypair],
-      submitter: async (args) =>
-        DidHelpers.transact({
-          ...args,
-          submitter: paymentAccount,
-          expectedEvents: [
-            { section: 'attestation', method: 'AttestationCreated' },
-          ],
-        }).submit(),
+    const issued = await Issuer.issue({
+      credential: unsigned,
+      issuer: {
+        didDocument,
+        signers: [keypair],
+        submitter: async (args) =>
+          DidHelpers.transact({
+            ...args,
+            submitter: paymentAccount,
+            expectedEvents: [
+              { section: 'attestation', method: 'AttestationCreated' },
+            ],
+          }).submit(),
+      },
     })
 
     expect(issued).toHaveProperty('proof', expect.any(Object))


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3540

- breaking: unnest selective disclosure parameters dc8d45865ca7d070f3d38a2451c16aff960a9b46
- breaking: fully switch to using named parameters on credentials functions 3c17ace73089be9b74458d6709881d576b33115b
- non-breaking: allow passing key pairs & signers as submitter parameter on `issue()` bcd882f8e5c10c0dc0d74946851072da1fd842aa

## How to test:

- Actually trying the new interfaces could be done on the beta that is to be released
- Tests for new features are yet to be written

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
