### PR TITLE
chore(deps): polkadot-js as peer dependency

### DIFF
--- a/packages/asset-credentials/package.json
+++ b/packages/asset-credentials/package.json
@@ -35,7 +35,12 @@
   },
   "peerDependencies": {
     "@kiltprotocol/augment-api": "^1.0.0",
-    "@kiltprotocol/type-definitions": "^1.0.0"
+    "@kiltprotocol/type-definitions": "^1.0.0",
+    "@polkadot/api": "^12.0.0",
+    "@polkadot/keyring": "^13.0.0",
+    "@polkadot/types": "^12.0.0",
+    "@polkadot/util": "^13.0.0",
+    "@polkadot/util-crypto": "^13.0.0"
   },
   "dependencies": {
     "@kiltprotocol/chain-helpers": "workspace:*",
@@ -43,14 +48,16 @@
     "@kiltprotocol/credentials": "workspace:*",
     "@kiltprotocol/did": "workspace:*",
     "@kiltprotocol/types": "workspace:*",
-    "@kiltprotocol/utils": "workspace:*",
-    "@polkadot/api": "^12.0.0",
-    "@polkadot/types": "^12.0.0",
-    "@polkadot/util": "^13.0.0",
-    "@polkadot/util-crypto": "^13.0.0"
+    "@kiltprotocol/utils": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@kiltprotocol/augment-api": {
+      "optional": true
+    },
+    "@polkadot/types": {
+      "optional": true
+    },
+    "@polkadot/util": {
       "optional": true
     }
   }

--- a/packages/chain-helpers/package.json
+++ b/packages/chain-helpers/package.json
@@ -35,21 +35,28 @@
   },
   "peerDependencies": {
     "@kiltprotocol/augment-api": "^1.0.0",
-    "@kiltprotocol/type-definitions": "^1.0.0"
+    "@kiltprotocol/type-definitions": "^1.0.0",
+    "@polkadot/api": "^12.0.0",
+    "@polkadot/api-derive": "^12.0.0",
+    "@polkadot/keyring": "^13.0.0",
+    "@polkadot/types": "^12.0.0",
+    "@polkadot/util": "^13.0.0",
+    "@polkadot/util-crypto": "^13.0.0"
   },
   "peerDependenciesMeta": {
     "@kiltprotocol/augment-api": {
+      "optional": true
+    },
+    "@polkadot/api-derive": {
+      "optional": true
+    },
+    "@polkadot/types": {
       "optional": true
     }
   },
   "dependencies": {
     "@kiltprotocol/config": "workspace:*",
     "@kiltprotocol/types": "workspace:*",
-    "@kiltprotocol/utils": "workspace:*",
-    "@polkadot/api": "^12.0.0",
-    "@polkadot/api-derive": "^12.0.0",
-    "@polkadot/types": "^12.0.0",
-    "@polkadot/util": "^13.0.0",
-    "@polkadot/util-crypto": "^13.0.0"
+    "@kiltprotocol/utils": "workspace:*"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -35,9 +35,16 @@
     "rimraf": "^3.0.2",
     "typescript": "^4.8.3"
   },
+  "peerDependencies": {
+    "@polkadot/api": "^12.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@polkadot/api": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@kiltprotocol/types": "workspace:*",
-    "@polkadot/api": "^12.0.0",
     "typescript-logging": "^1.0.0"
   }
 }

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -34,10 +34,6 @@
     "rimraf": "^3.0.2",
     "typescript": "^4.8.3"
   },
-  "peerDependencies": {
-    "@kiltprotocol/augment-api": "^1.0.0",
-    "@kiltprotocol/type-definitions": "^1.0.0"
-  },
   "dependencies": {
     "@kiltprotocol/chain-helpers": "workspace:*",
     "@kiltprotocol/config": "workspace:*",
@@ -48,16 +44,23 @@
     "@kiltprotocol/sr25519-jcs-2023": "0.1.0-rc.4",
     "@kiltprotocol/types": "workspace:*",
     "@kiltprotocol/utils": "workspace:*",
+    "@scure/base": "^1.1.0",
+    "json-pointer": "^0.6.2"
+  },
+  "peerDependencies": {
+    "@kiltprotocol/augment-api": "^1.0.0",
+    "@kiltprotocol/type-definitions": "^1.0.0",
     "@polkadot/api": "^12.0.0",
     "@polkadot/keyring": "^13.0.0",
     "@polkadot/types": "^12.0.0",
     "@polkadot/util": "^13.0.0",
-    "@polkadot/util-crypto": "^13.0.0",
-    "@scure/base": "^1.1.0",
-    "json-pointer": "^0.6.2"
+    "@polkadot/util-crypto": "^13.0.0"
   },
   "peerDependenciesMeta": {
     "@kiltprotocol/augment-api": {
+      "optional": true
+    },
+    "@polkadot/api": {
       "optional": true
     }
   }

--- a/packages/credentials/src/V1/KiltAttestationProofV1.ts
+++ b/packages/credentials/src/V1/KiltAttestationProofV1.ts
@@ -8,11 +8,7 @@
 import type { ApiPromise } from '@polkadot/api'
 import type { QueryableStorageEntry } from '@polkadot/api/types'
 import type { Option, u64, Vec } from '@polkadot/types'
-import type {
-  AccountId,
-  Extrinsic,
-  Hash,
-} from '@polkadot/types/interfaces/types.js'
+import type { AccountId, Extrinsic, Hash } from '@polkadot/types/interfaces'
 import type { IEventData } from '@polkadot/types/types'
 import {
   hexToU8a,

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -34,22 +34,28 @@
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
-    "@kiltprotocol/augment-api": "^1.0.0"
-  },
-  "dependencies": {
-    "@digitalbazaar/multikey-context": "^2.0.1",
-    "@digitalbazaar/security-context": "^1.0.1",
-    "@kiltprotocol/config": "workspace:*",
-    "@kiltprotocol/types": "workspace:*",
-    "@kiltprotocol/utils": "workspace:*",
+    "@kiltprotocol/augment-api": "^1.0.0",
     "@polkadot/api": "^12.0.0",
     "@polkadot/keyring": "^13.0.0",
     "@polkadot/types": "^12.0.0",
     "@polkadot/util": "^13.0.0",
     "@polkadot/util-crypto": "^13.0.0"
   },
+  "dependencies": {
+    "@digitalbazaar/multikey-context": "^2.0.1",
+    "@digitalbazaar/security-context": "^1.0.1",
+    "@kiltprotocol/config": "workspace:*",
+    "@kiltprotocol/types": "workspace:*",
+    "@kiltprotocol/utils": "workspace:*"
+  },
   "peerDependenciesMeta": {
     "@kiltprotocol/augment-api": {
+      "optional": true
+    },
+    "@polkadot/api": {
+      "optional": true
+    },
+    "@polkadot/types": {
       "optional": true
     }
   }

--- a/packages/did/src/Did.rpc.ts
+++ b/packages/did/src/Did.rpc.ts
@@ -5,10 +5,9 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import { encodeAddress } from '@polkadot/keyring'
+import { encodeAddress, ethereumEncode } from '@polkadot/util-crypto'
 import type { Option, Vec } from '@polkadot/types'
 import type { Codec } from '@polkadot/types/types'
-import { ethereumEncode } from '@polkadot/util-crypto'
 
 import type {
   DidServiceEndpointsDidEndpoint,

--- a/packages/jsonld-suites/package.json
+++ b/packages/jsonld-suites/package.json
@@ -42,6 +42,8 @@
     "@kiltprotocol/type-definitions": "^1.0.0",
     "@kiltprotocol/types": "workspace:*",
     "@kiltprotocol/utils": "workspace:*",
+    "@polkadot/keyring": "^13.0.0",
+    "@polkadot/types": "^12.0.0",
     "@polkadot/util": "^13.0.0",
     "@polkadot/util-crypto": "^13.0.0",
     "crypto-ld": "^6.0.0"

--- a/packages/legacy-credentials/package.json
+++ b/packages/legacy-credentials/package.json
@@ -33,15 +33,17 @@
     "rimraf": "^3.0.2",
     "typescript": "^4.8.3"
   },
-  "peerDependencies": {
-    "@kiltprotocol/type-definitions": "^1.0.0"
-  },
   "dependencies": {
     "@kiltprotocol/config": "workspace:*",
     "@kiltprotocol/credentials": "workspace:*",
     "@kiltprotocol/did": "workspace:*",
     "@kiltprotocol/types": "workspace:*",
-    "@kiltprotocol/utils": "workspace:*",
+    "@kiltprotocol/utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "@kiltprotocol/type-definitions": "^1.0.0",
+    "@polkadot/keyring": "^13.0.0",
+    "@polkadot/types": "^12.0.0",
     "@polkadot/util": "^13.0.0",
     "@polkadot/util-crypto": "^13.0.0"
   }

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -48,8 +48,10 @@
     "@kiltprotocol/type-definitions": "rc",
     "@kiltprotocol/utils": "workspace:*",
     "@polkadot/api": "^12.0.0",
+    "@polkadot/keyring": "^13.0.0",
     "@polkadot/types": "^12.0.0",
-    "@polkadot/util": "^13.0.0"
+    "@polkadot/util": "^13.0.0",
+    "@polkadot/util-crypto": "^13.0.0"
   },
   "peerDependencies": {
     "@kiltprotocol/augment-api": "^1.11210.0"

--- a/packages/types/src/Address.ts
+++ b/packages/types/src/Address.ts
@@ -23,7 +23,7 @@ export interface KiltKeyringPair extends KeyringPair {
 /// A KILT-chain specific address, encoded with the KILT 38 network prefix.
 export type KiltAddress = KiltKeyringPair['address']
 
-declare module '@polkadot/keyring' {
+declare module '@polkadot/util-crypto' {
   function encodeAddress(
     key: HexString | Uint8Array | string,
     ss58Format: 38

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,14 +40,15 @@
     "@kiltprotocol/jcs-data-integrity-proofs-common": "0.1.0-rc.4",
     "@kiltprotocol/sr25519-jcs-2023": "0.1.0-rc.4",
     "@kiltprotocol/types": "workspace:*",
-    "@polkadot/api": "^12.0.0",
-    "@polkadot/keyring": "^13.0.0",
-    "@polkadot/util": "^13.0.0",
-    "@polkadot/util-crypto": "^13.0.0",
     "@scure/base": "^1.1.0",
     "cbor-web": "^9.0.0",
     "tweetnacl": "^1.0.3",
     "uuid": "^10.0.0",
     "varint": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@polkadot/keyring": "^13.0.0",
+    "@polkadot/util": "^13.0.0",
+    "@polkadot/util-crypto": "^13.0.0"
   }
 }

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -13,7 +13,7 @@
  * @packageDocumentation
  */
 
-import { decodeAddress, encodeAddress } from '@polkadot/keyring'
+import Keyring, { decodeAddress, encodeAddress } from '@polkadot/keyring'
 import type {
   HexString,
   KeyringPair,
@@ -34,7 +34,6 @@ import {
   randomAsU8a,
   signatureVerify,
 } from '@polkadot/util-crypto'
-import { Keyring } from '@polkadot/api'
 import nacl from 'tweetnacl'
 import { v4 as uuid } from 'uuid'
 import jsonabc from './jsonabc.js'

--- a/packages/utils/src/Signers.ts
+++ b/packages/utils/src/Signers.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import type { Signer } from '@polkadot/api/types/index.js'
+import type { Signer } from '@polkadot/types/types'
 import { decodePair } from '@polkadot/keyring/pair/decode'
 import {
   hexToU8a,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,17 +1995,22 @@ __metadata:
     "@kiltprotocol/did": "workspace:*"
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
-    "@polkadot/api": "npm:^12.0.0"
-    "@polkadot/types": "npm:^12.0.0"
-    "@polkadot/util": "npm:^13.0.0"
-    "@polkadot/util-crypto": "npm:^13.0.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:^4.8.3"
   peerDependencies:
     "@kiltprotocol/augment-api": ^1.0.0
     "@kiltprotocol/type-definitions": ^1.0.0
+    "@polkadot/api": ^12.0.0
+    "@polkadot/keyring": ^13.0.0
+    "@polkadot/types": ^12.0.0
+    "@polkadot/util": ^13.0.0
+    "@polkadot/util-crypto": ^13.0.0
   peerDependenciesMeta:
     "@kiltprotocol/augment-api":
+      optional: true
+    "@polkadot/types":
+      optional: true
+    "@polkadot/util":
       optional: true
   languageName: unknown
   linkType: soft
@@ -2057,18 +2062,23 @@ __metadata:
     "@kiltprotocol/config": "workspace:*"
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
-    "@polkadot/api": "npm:^12.0.0"
-    "@polkadot/api-derive": "npm:^12.0.0"
-    "@polkadot/types": "npm:^12.0.0"
-    "@polkadot/util": "npm:^13.0.0"
-    "@polkadot/util-crypto": "npm:^13.0.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:^4.8.3"
   peerDependencies:
     "@kiltprotocol/augment-api": ^1.0.0
     "@kiltprotocol/type-definitions": ^1.0.0
+    "@polkadot/api": ^12.0.0
+    "@polkadot/api-derive": ^12.0.0
+    "@polkadot/keyring": ^13.0.0
+    "@polkadot/types": ^12.0.0
+    "@polkadot/util": ^13.0.0
+    "@polkadot/util-crypto": ^13.0.0
   peerDependenciesMeta:
     "@kiltprotocol/augment-api":
+      optional: true
+    "@polkadot/api-derive":
+      optional: true
+    "@polkadot/types":
       optional: true
   languageName: unknown
   linkType: soft
@@ -2078,10 +2088,14 @@ __metadata:
   resolution: "@kiltprotocol/config@workspace:packages/config"
   dependencies:
     "@kiltprotocol/types": "workspace:*"
-    "@polkadot/api": "npm:^12.0.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:^4.8.3"
     typescript-logging: "npm:^1.0.0"
+  peerDependencies:
+    "@polkadot/api": ^12.0.0
+  peerDependenciesMeta:
+    "@polkadot/api":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2098,11 +2112,6 @@ __metadata:
     "@kiltprotocol/sr25519-jcs-2023": "npm:0.1.0-rc.4"
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
-    "@polkadot/api": "npm:^12.0.0"
-    "@polkadot/keyring": "npm:^13.0.0"
-    "@polkadot/types": "npm:^12.0.0"
-    "@polkadot/util": "npm:^13.0.0"
-    "@polkadot/util-crypto": "npm:^13.0.0"
     "@scure/base": "npm:^1.1.0"
     "@types/json-pointer": "npm:^1.0.34"
     json-pointer: "npm:^0.6.2"
@@ -2111,8 +2120,15 @@ __metadata:
   peerDependencies:
     "@kiltprotocol/augment-api": ^1.0.0
     "@kiltprotocol/type-definitions": ^1.0.0
+    "@polkadot/api": ^12.0.0
+    "@polkadot/keyring": ^13.0.0
+    "@polkadot/types": ^12.0.0
+    "@polkadot/util": ^13.0.0
+    "@polkadot/util-crypto": ^13.0.0
   peerDependenciesMeta:
     "@kiltprotocol/augment-api":
+      optional: true
+    "@polkadot/api":
       optional: true
   languageName: unknown
   linkType: soft
@@ -2126,17 +2142,21 @@ __metadata:
     "@kiltprotocol/config": "workspace:*"
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
-    "@polkadot/api": "npm:^12.0.0"
-    "@polkadot/keyring": "npm:^13.0.0"
-    "@polkadot/types": "npm:^12.0.0"
-    "@polkadot/util": "npm:^13.0.0"
-    "@polkadot/util-crypto": "npm:^13.0.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:^4.8.3"
   peerDependencies:
     "@kiltprotocol/augment-api": ^1.0.0
+    "@polkadot/api": ^12.0.0
+    "@polkadot/keyring": ^13.0.0
+    "@polkadot/types": ^12.0.0
+    "@polkadot/util": ^13.0.0
+    "@polkadot/util-crypto": ^13.0.0
   peerDependenciesMeta:
     "@kiltprotocol/augment-api":
+      optional: true
+    "@polkadot/api":
+      optional: true
+    "@polkadot/types":
       optional: true
   languageName: unknown
   linkType: soft
@@ -2188,6 +2208,8 @@ __metadata:
     "@kiltprotocol/type-definitions": "npm:^1.0.0"
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
+    "@polkadot/keyring": "npm:^13.0.0"
+    "@polkadot/types": "npm:^12.0.0"
     "@polkadot/util": "npm:^13.0.0"
     "@polkadot/util-crypto": "npm:^13.0.0"
     crypto-ld: "npm:^6.0.0"
@@ -2208,12 +2230,14 @@ __metadata:
     "@kiltprotocol/did": "workspace:*"
     "@kiltprotocol/types": "workspace:*"
     "@kiltprotocol/utils": "workspace:*"
-    "@polkadot/util": "npm:^13.0.0"
-    "@polkadot/util-crypto": "npm:^13.0.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:^4.8.3"
   peerDependencies:
     "@kiltprotocol/type-definitions": ^1.0.0
+    "@polkadot/keyring": ^13.0.0
+    "@polkadot/types": ^12.0.0
+    "@polkadot/util": ^13.0.0
+    "@polkadot/util-crypto": ^13.0.0
   languageName: unknown
   linkType: soft
 
@@ -2229,9 +2253,11 @@ __metadata:
     "@kiltprotocol/type-definitions": "npm:rc"
     "@kiltprotocol/utils": "workspace:*"
     "@polkadot/api": "npm:^12.0.0"
+    "@polkadot/keyring": "npm:^13.0.0"
     "@polkadot/typegen": "npm:^12.0.0"
     "@polkadot/types": "npm:^12.0.0"
     "@polkadot/util": "npm:^13.0.0"
+    "@polkadot/util-crypto": "npm:^13.0.0"
     rimraf: "npm:^3.0.2"
     terser-webpack-plugin: "npm:^5.1.1"
     typescript: "npm:^4.8.3"
@@ -2292,10 +2318,6 @@ __metadata:
     "@kiltprotocol/jcs-data-integrity-proofs-common": "npm:0.1.0-rc.4"
     "@kiltprotocol/sr25519-jcs-2023": "npm:0.1.0-rc.4"
     "@kiltprotocol/types": "workspace:*"
-    "@polkadot/api": "npm:^12.0.0"
-    "@polkadot/keyring": "npm:^13.0.0"
-    "@polkadot/util": "npm:^13.0.0"
-    "@polkadot/util-crypto": "npm:^13.0.0"
     "@scure/base": "npm:^1.1.0"
     "@types/uuid": "npm:^8.0.0"
     cbor-web: "npm:^9.0.0"
@@ -2304,6 +2326,10 @@ __metadata:
     typescript: "npm:^4.8.3"
     uuid: "npm:^10.0.0"
     varint: "npm:^6.0.0"
+  peerDependencies:
+    "@polkadot/keyring": ^13.0.0
+    "@polkadot/util": ^13.0.0
+    "@polkadot/util-crypto": ^13.0.0
   languageName: unknown
   linkType: soft
 
@@ -2481,7 +2507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:12.2.1, @polkadot/api-derive@npm:^12.0.0":
+"@polkadot/api-derive@npm:12.2.1":
   version: 12.2.1
   resolution: "@polkadot/api-derive@npm:12.2.1"
   dependencies:


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3058

Set polkadot dependencies as peer dependencies on sub-packages, which should help avoid versioning chaos.
For convenience the sdk-js package still marks all polkadot-js packages as direct dependents.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
