### PR TITLE
fix: rename Docker image

### DIFF
--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -145,7 +145,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/standalone-node
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       docker-image-tag-name:
         type: string
-        description: The tag of the kiltprotocol/prototype-chain Docker image to test against
+        description: The tag of the kiltprotocol/standalone-node Docker image to test against
         required: true
 
 env:

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -76,7 +76,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -145,7 +145,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: kilt/standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -113,7 +113,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -240,7 +240,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
The Docker image specified there never existed, and it's only used internally for cache.