### PR TITLE
chore: replace all uses of tx.balances.transfer()

### DIFF
--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -34,7 +34,7 @@ describe('Blockchain', () => {
 
     it('allows waiting for finalization', async () => {
       api.__setDefaultResult({ isFinalized: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(
         await signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).toHaveProperty('isFinalized', true)
@@ -42,7 +42,7 @@ describe('Blockchain', () => {
 
     it('allows waiting for in block', async () => {
       api.__setDefaultResult({ isInBlock: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(
         await signAndSubmitTx(tx, pair, { resolveOn: IS_IN_BLOCK })
       ).toHaveProperty('isInBlock', true)
@@ -50,7 +50,7 @@ describe('Blockchain', () => {
 
     it('allows waiting for ready', async () => {
       api.__setDefaultResult({ isReady: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(
         await signAndSubmitTx(tx, pair, { resolveOn: IS_READY })
       ).toHaveProperty('status.isReady', true)
@@ -59,7 +59,7 @@ describe('Blockchain', () => {
     it('uses default resolution config', async () => {
       api.__setDefaultResult({ isReady: true })
       ConfigService.set({ submitTxResolveOn: IS_READY })
-      let tx = api.tx.balances.transfer('abcdef', 50)
+      let tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(await signAndSubmitTx(tx, pair)).toHaveProperty(
         'status.isReady',
         true
@@ -67,12 +67,12 @@ describe('Blockchain', () => {
 
       api.__setDefaultResult({ isInBlock: true })
       ConfigService.set({ submitTxResolveOn: IS_IN_BLOCK })
-      tx = api.tx.balances.transfer('abcdef', 50)
+      tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(await signAndSubmitTx(tx, pair)).toHaveProperty('isInBlock', true)
 
       api.__setDefaultResult({ isFinalized: true })
       ConfigService.set({ submitTxResolveOn: IS_FINALIZED })
-      tx = api.tx.balances.transfer('abcdef', 50)
+      tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(await signAndSubmitTx(tx, pair)).toHaveProperty(
         'isFinalized',
         true
@@ -81,7 +81,7 @@ describe('Blockchain', () => {
 
     it('rejects on error condition', async () => {
       api.__setDefaultResult({ isInvalid: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       await expect(
         signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).rejects.toHaveProperty('isError', true)
@@ -90,7 +90,7 @@ describe('Blockchain', () => {
     it('throws if subscriptions not supported', async () => {
       // @ts-ignore
       api.hasSubscriptions = false
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       await expect(
         signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).rejects.toThrow(SDKErrors.SubscriptionsNotSupportedError)
@@ -102,7 +102,7 @@ describe('Blockchain', () => {
         // mock disconnect 500 ms after submission
         if (ev === 'disconnected') setTimeout(callback, 500)
       })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       await expect(
         signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).rejects.toHaveProperty('internalError', expect.any(Error))

--- a/tests/integration/Balance.spec.ts
+++ b/tests/integration/Balance.spec.ts
@@ -68,7 +68,10 @@ describe('when there is a dev chain with a faucet', () => {
     const spy = jest.fn<any>()
     api.query.system.account(address, spy)
     const balanceBefore = (await api.query.system.account(faucet.address)).data
-    const transferTx = api.tx.balances.transfer(address, EXISTENTIAL_DEPOSIT)
+    const transferTx = api.tx.balances.transferAllowDeath(
+      address,
+      EXISTENTIAL_DEPOSIT
+    )
     await submitTx(transferTx, faucet)
     const balanceAfter = (await api.query.system.account(faucet.address)).data
     const balanceIdent = (await api.query.system.account(address)).data
@@ -95,7 +98,7 @@ describe('When there are haves and have-nots', () => {
   })
 
   it('can transfer tokens from the rich to the poor', async () => {
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
@@ -107,7 +110,7 @@ describe('When there are haves and have-nots', () => {
   it('should not accept transactions from KeyringPair with zero balance', async () => {
     const originalBalance = (await api.query.system.account(stormyD.address))
       .data
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
@@ -125,7 +128,7 @@ describe('When there are haves and have-nots', () => {
   it.skip('should not accept transactions when sender cannot pay gas, but will keep gas fee', async () => {
     const RichieBalance = (await api.query.system.account(richieRich.address))
       .data
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       bobbyBroke.address,
       RichieBalance.free
     )
@@ -142,12 +145,12 @@ describe('When there are haves and have-nots', () => {
     const spy = jest.fn<any>()
     api.query.system.account(faucet.address, spy)
 
-    const transferTx1 = api.tx.balances.transfer(
+    const transferTx1 = api.tx.balances.transferAllowDeath(
       richieRich.address,
       EXISTENTIAL_DEPOSIT
     )
     await submitTx(transferTx1, faucet)
-    const transferTx2 = api.tx.balances.transfer(
+    const transferTx2 = api.tx.balances.transferAllowDeath(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
@@ -161,8 +164,11 @@ describe('When there are haves and have-nots', () => {
     api.query.system.account(faucet.address, listener)
 
     const batch = api.tx.utility.batchAll([
-      api.tx.balances.transfer(richieRich.address, EXISTENTIAL_DEPOSIT),
-      api.tx.balances.transfer(stormyD.address, EXISTENTIAL_DEPOSIT),
+      api.tx.balances.transferAllowDeath(
+        richieRich.address,
+        EXISTENTIAL_DEPOSIT
+      ),
+      api.tx.balances.transferAllowDeath(stormyD.address, EXISTENTIAL_DEPOSIT),
     ])
     await submitTx(batch, faucet)
 

--- a/tests/integration/Blockchain.spec.ts
+++ b/tests/integration/Blockchain.spec.ts
@@ -32,7 +32,7 @@ describe('Chain returns specific errors, that we check for', () => {
     testIdentity = (await makeSigningKeyTool()).keypair
     charlie = devCharlie
 
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       testIdentity.address,
       BalanceUtils.toFemtoKilt(10000)
     )
@@ -40,11 +40,11 @@ describe('Chain returns specific errors, that we check for', () => {
   }, 40000)
 
   it(`throws TxOutdated error if the nonce was already used for Tx in block`, async () => {
-    const tx = api.tx.balances.transfer(
+    const tx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000001')
     )
-    const errorTx = api.tx.balances.transfer(
+    const errorTx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000000')
     )
@@ -93,11 +93,11 @@ describe('Chain returns specific errors, that we check for', () => {
   }, 40000)
 
   it(`throws 'ERROR_TRANSACTION_USURPED' error if separate Tx was imported with identical nonce but higher priority while Tx is in pool`, async () => {
-    const tx = api.tx.balances.transfer(
+    const tx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000000')
     )
-    const errorTx = api.tx.balances.transfer(
+    const errorTx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000000')
     )

--- a/tests/integration/Ctypes.spec.ts
+++ b/tests/integration/Ctypes.spec.ts
@@ -105,7 +105,10 @@ describe('When there is an CtypeCreator and a verifier', () => {
       ).data.free.toBigInt() < minBalance
     ) {
       console.log('sending funds to assertion method key account...')
-      const fundsTx = api.tx.balances.transfer(assertionMethodKey, minBalance)
+      const fundsTx = api.tx.balances.transferAllowDeath(
+        assertionMethodKey,
+        minBalance
+      )
       await submitTx(fundsTx, paymentAccount)
       console.log('sending funds completed')
     }

--- a/tests/integration/ErrorHandler.spec.ts
+++ b/tests/integration/ErrorHandler.spec.ts
@@ -44,7 +44,7 @@ beforeAll(async () => {
 }, 60_000)
 
 it('records an extrinsic error when transferring less than the existential amount to new identity', async () => {
-  const transferTx = api.tx.balances.transfer(addressFromRandom(), 1)
+  const transferTx = api.tx.balances.transferAllowDeath(addressFromRandom(), 1)
   const promise = submitTx(transferTx, paymentAccount)
   if (api.runtimeVersion.specVersion.toBigInt() >= 11_200n) {
     await expect(promise).rejects.toMatchInlineSnapshot(`

--- a/tests/integration/PublicCredentials.spec.ts
+++ b/tests/integration/PublicCredentials.spec.ts
@@ -284,7 +284,10 @@ describe('When there is an attester and ctype NFT name', () => {
       ).data.free.toBigInt() < minBalance
     ) {
       console.log('sending funds to assertion method key account...')
-      const fundsTx = api.tx.balances.transfer(assertionMethodKey, minBalance)
+      const fundsTx = api.tx.balances.transferAllowDeath(
+        assertionMethodKey,
+        minBalance
+      )
       await submitTx(fundsTx, tokenHolder)
       console.log('sending funds completed')
     }

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -171,7 +171,9 @@ export async function endowAccounts(
 ): Promise<void> {
   const api = ConfigService.get('api')
   const transactions = await Promise.all(
-    addresses.map((address) => api.tx.balances.transfer(address, ENDOWMENT))
+    addresses.map((address) =>
+      api.tx.balances.transferKeepAlive(address, ENDOWMENT)
+    )
   )
   const batch = api.tx.utility.batchAll(transactions)
   await Blockchain.signAndSubmitTx(batch, faucet, { resolveOn })
@@ -182,7 +184,7 @@ export async function fundAccount(
   amount: BN
 ): Promise<void> {
   const api = ConfigService.get('api')
-  const transferTx = api.tx.balances.transfer(address, amount)
+  const transferTx = api.tx.balances.transferKeepAlive(address, amount)
   await submitTx(transferTx, devFaucet)
 }
 

--- a/tests/testUtils/mocks/mockedApi.ts
+++ b/tests/testUtils/mocks/mockedApi.ts
@@ -239,7 +239,8 @@ export function getMockedApi(): MockApiPromise {
         reclaimDeposit: jest.fn((claimHash: string) => getMockSubmittableTx()),
       },
       balances: {
-        transfer: jest.fn(() => getMockSubmittableTx()),
+        transferAllowDeath: jest.fn(() => getMockSubmittableTx()),
+        transferKeepAlive: jest.fn(() => getMockSubmittableTx()),
       },
       ctype: {
         add: jest.fn((hash, signature) => getMockSubmittableTx()),


### PR DESCRIPTION
## re/ KILTProtocol/ticket#3582

Replaces all uses of the deprecated balances.transfer extrinsic. 

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
