### PR TITLE
feat: nested ctype val

### DIFF
--- a/packages/credentials/src/V1/KiltCredentialV1.ts
+++ b/packages/credentials/src/V1/KiltCredentialV1.ts
@@ -357,7 +357,7 @@ function extractUniqueReferences(
     if (typeof value !== 'object' || value === null) {
       return
     }
-    const objValue = value as Record<string, unknown>    
+    const objValue = value as Record<string, unknown>
     if ('$ref' in objValue) {
       const ref = objValue.$ref as string
       if (ref.startsWith('kilt:ctype:')) {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3632

Added nested CType validation support to validateSubject
Implemented automatic reference detection and blockchain fetching
Added support to handle both simple and complex CType structures
Updated tests for new functionality

Note: Improves credential validation by handling nested CTypes automatically.

## How to test:
Please provide a brief step-by-step instruction.
If necessary provide information about dependencies (specific configuration, branches, database dumps, etc.)

- Step 1
- Step 2
- etc.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
