### PR TITLE
chore: pull image via ecr pull cache

### DIFF
--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -76,7 +76,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -145,7 +145,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -113,7 +113,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -240,7 +240,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3600
`standalone-node` is pushed only to docker-hub & to avoid rate limit I introduced `ecr-pull-cache`
## How to test:
 `docker pull $AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/dh/kiltprotocol/standalone-node`
## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
