### PR TITLE
fix: CI pipeline

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ npmPublishAccess: public
 npmPublishRegistry: "https://registry.npmjs.org"
 
 yarnPath: .yarn/releases/yarn-4.1.1.cjs
+
+compressionLevel: 0

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-env": "^7.20.2",
     "@commitlint/cli": "^9.0.1",
     "@commitlint/config-conventional": "^9.0.1",
-    "@playwright/test": "^1.21.1",
+    "@playwright/test": "^1.49.1",
     "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",

--- a/packages/chain-helpers/src/blockchain/Blockchain.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.ts
@@ -220,14 +220,14 @@ export async function signTx(
 ): Promise<SubmittableExtrinsic> {
   const signOptions: Partial<SignerOptions> = checkMetadata
     ? {
-      tip,
-      // Required as described in https://github.com/polkadot-js/api/blob/109d3b2201ea51f27180e34dfd883ec71d402f6b/packages/api-base/src/types/submittable.ts#L79.
-      metadataHash: await getMetadataHash(ConfigService.get('api')),
-      // Used by external signers to to know there's additional data to be included in the payload (see link above).
-      withSignedTransaction: true,
-      // Forces the tx to fail if the metadata does not match (added for backward compatibility). See https://paritytech.github.io/polkadot-sdk/master/frame_metadata_hash_extension/struct.CheckMetadataHash.html.
-      mode: 1,
-    }
+        tip,
+        // Required as described in https://github.com/polkadot-js/api/blob/109d3b2201ea51f27180e34dfd883ec71d402f6b/packages/api-base/src/types/submittable.ts#L79.
+        metadataHash: await getMetadataHash(ConfigService.get('api')),
+        // Used by external signers to to know there's additional data to be included in the payload (see link above).
+        withSignedTransaction: true,
+        // Forces the tx to fail if the metadata does not match (added for backward compatibility). See https://paritytech.github.io/polkadot-sdk/master/frame_metadata_hash_extension/struct.CheckMetadataHash.html.
+        mode: 1,
+      }
     : { tip }
 
   if ('address' in signer) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,15 +2412,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.21.1":
-  version: 1.28.1
-  resolution: "@playwright/test@npm:1.28.1"
+"@playwright/test@npm:^1.49.1":
+  version: 1.49.1
+  resolution: "@playwright/test@npm:1.49.1"
   dependencies:
-    "@types/node": "npm:*"
-    playwright-core: "npm:1.28.1"
+    playwright: "npm:1.49.1"
   bin:
     playwright: cli.js
-  checksum: 10c0/700454f5089a6631a2f80f8ded2c56c7e30928f98aa4fa0b0c339355f5b1d755ca559396d92e44e20766713b3b342d4a1a50888c642c8109ba0d46eb9a2beb09
+  checksum: 10c0/2fca0bb7b334f7a23c7c5dfa5dbe37b47794c56f39b747c8d74a2f95c339e7902a296f2f1dd32c47bdd723cfa92cee05219f1a5876725dc89a1871b9137a286d
   languageName: node
   linkType: hard
 
@@ -5963,12 +5962,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -8326,12 +8344,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.28.1":
-  version: 1.28.1
-  resolution: "playwright-core@npm:1.28.1"
+"playwright-core@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright-core@npm:1.49.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/990b619c75715cd98b2c10c1180a126e3a454b247063b8352bc67792fe01183ec07f31d30c8714c3768cefed12886d1d64ac06da701f2baafc2cad9b439e3919
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright@npm:1.49.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.49.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/ad6dcdd57b1be811443a352eab3ce7b6adb06204a784a76dfa5b41c15e84d96c0bfff931573da2d04f15f4a4f3dd26995afbe84c2cb377576de84168f51c3723
+  checksum: 10c0/2368762c898920d4a0a5788b153dead45f9c36c3f5cf4d2af5228d0b8ea65823e3bbe998877950a2b9bb23a211e4633996f854c6188769dc81a25543ac818ab5
   languageName: node
   linkType: hard
 
@@ -8806,7 +8839,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.20.2"
     "@commitlint/cli": "npm:^9.0.1"
     "@commitlint/config-conventional": "npm:^9.0.1"
-    "@playwright/test": "npm:^1.21.1"
+    "@playwright/test": "npm:^1.49.1"
     "@types/jest": "npm:^29.5.3"
     "@typescript-eslint/eslint-plugin": "npm:^5.7.0"
     "@typescript-eslint/parser": "npm:^5.7.0"


### PR DESCRIPTION
Disable compression for dependencies for reproducible install steps, and fix the CI issue with bundle test preparation.

Integration tests with `develop` are still broken since we have not yet released the updated type definitions.