### PR TITLE
test: fix tests & ci

### DIFF
--- a/.github/actions/cached-image-pull/action.yml
+++ b/.github/actions/cached-image-pull/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: check image cache
       id: image-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.image-file.outputs.path }}
         key: image-cache-${{ inputs.image }}

--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     if: "! startsWith(github.event.head_commit.message, '[CI Skip]') && github.repository == 'kiltprotocol/sdk-js'"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch-depth 0 and token needed to push changes on the package.json files back.
           fetch-depth: 0
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install and Build
         run: |

--- a/.github/workflows/npmpublish-rc.yml
+++ b/.github/workflows/npmpublish-rc.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -19,8 +19,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -32,7 +32,7 @@ jobs:
         run: yarn run bundle
       - name: Get current package version
         id: package_version
-        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT    
+        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Publish to NPM
         run: yarn run publish --tag rc
         env:
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: KILTProtocol/docs
           event-type: sdk-update
-          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'             
+          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -19,8 +19,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -32,7 +32,7 @@ jobs:
         run: yarn run bundle
       - name: Get current package version
         id: package_version
-        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT                  
+        run: echo "package_version=$(node -pe "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Publish to NPM
         run: yarn run publish --tag latest
         env:
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: KILTProtocol/docs
           event-type: sdk-update
-          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'          
+          client-payload: '{"latestTag": "${{ steps.package_version.outputs.package_version }}"}'

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -12,14 +12,13 @@ env:
   TESTCONTAINERS_WATCHER_IMG: testcontainers/ryuk:0.3.2
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -30,7 +29,7 @@ jobs:
       - name: zip build
         run: zip -r build.zip .
       - name: upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build.zip
@@ -39,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: make sure testcontainers image is in cache
         uses: ./.github/actions/cached-image-pull
         with:
@@ -51,20 +50,20 @@ jobs:
     needs: cache_imgs
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: Log out node version
         run: node --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -72,7 +71,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: pull image
         env:
@@ -97,19 +96,19 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: yarn bundle
         run: yarn bundle
       - name: upload bundle artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist/sdk-js.umd.js
@@ -120,21 +119,21 @@ jobs:
     needs: [cache_imgs, bundle_cache]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - run: basename /packages/sdk-js/dist/
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -142,7 +141,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       docker-image-tag-name:
         type: string
-        description: The tag of the kiltprotocol/prototype-chain Docker image to test against
+        description: The tag of the kiltprotocol/standalone-node Docker image to test against
         required: true
 
 env:
@@ -76,7 +76,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -145,7 +145,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/test-node-candidate.yml
+++ b/.github/workflows/test-node-candidate.yml
@@ -76,7 +76,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -145,7 +145,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ github.event.inputs.docker-image-tag-name }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -113,7 +113,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -13,14 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -35,7 +35,7 @@ jobs:
       - name: list dependencies
         run: echo "$(yarn info -A --name-only --json)" > locked_dependencies.txt
       - name: upload dependencies list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deps-${{ matrix.node-version }}
           path: |
@@ -47,7 +47,7 @@ jobs:
       - name: zip build
         run: zip -r build.zip .
       - name: upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.node-version }}
           path: build.zip
@@ -63,11 +63,13 @@ jobs:
         include:
           - node-version: 20.x
             required: 'optional'
+          - node-version: 22.x
+            required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.node-version }}
       - name: unzip
@@ -91,7 +93,7 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-16.x
       - name: unzip
@@ -106,9 +108,9 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: pull image
+      - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: kilt/prototype-chain
@@ -135,7 +137,7 @@ jobs:
     needs: [test, integration_test]
     if: failure()
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: deps-16.x
       - name: set dependencies env

--- a/.github/workflows/tests-polkadot-deps.yml
+++ b/.github/workflows/tests-polkadot-deps.yml
@@ -113,7 +113,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,7 +156,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -239,7 +239,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: standalone-node
+          ECR_REPOSITORY: dh/kiltprotocol/standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - develop
       - master
+      - v0-lts
 
 env:
   TESTCONTAINERS_WATCHER_IMG: testcontainers/ryuk:0.3.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,7 +156,7 @@ jobs:
       - name: pull image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -239,7 +239,7 @@ jobs:
       - name: pull node image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: kilt/prototype-chain
+          ECR_REPOSITORY: standalone-node
           IMAGE_TAG: ${{ matrix.image }}
         run: |
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,9 @@ jobs:
     needs: check_skip
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -51,7 +51,7 @@ jobs:
       - name: zip build
         run: zip -r build.zip .
       - name: upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build.zip
@@ -61,13 +61,13 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: lint
@@ -86,15 +86,17 @@ jobs:
         include:
           - node-version: 20
             required: 'optional'
+          - node-version: 22
+            required: 'optional'
 
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
@@ -106,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: make sure testcontainers image is in cache
         uses: ./.github/actions/cached-image-pull
         with:
@@ -128,20 +130,20 @@ jobs:
     continue-on-error: ${{ matrix.required == 'optional' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: Log out node version
         run: node --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -149,7 +151,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: pull image
         env:
@@ -168,30 +170,29 @@ jobs:
       - name: run integration tests (cjs)
         timeout-minutes: 60
         run: yarn test:integration -b
-      
+
       - name: run integration tests (esm)
         timeout-minutes: 60
         run: yarn test:integration:esm -b
-
 
   bundle_cache:
     runs-on: ubuntu-latest
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: yarn bundle
         run: yarn bundle
       - name: upload bundle artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist/sdk-js.umd.js
@@ -210,22 +211,22 @@ jobs:
 
     continue-on-error: ${{ matrix.required == 'optional' }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
       - name: unzip
         run: unzip build.zip -d .
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: checked-nonmin-bundle
           path: packages/sdk-js/dist
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -233,7 +234,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
       - run: basename /packages/sdk-js/dist/
       - name: pull node image
         env:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-env": "^7.20.2",
     "@commitlint/cli": "^9.0.1",
     "@commitlint/config-conventional": "^9.0.1",
-    "@playwright/test": "^1.21.1",
+    "@playwright/test": "^1.49.1",
     "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",

--- a/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
+++ b/packages/chain-helpers/src/blockchain/Blockchain.spec.ts
@@ -34,7 +34,7 @@ describe('Blockchain', () => {
 
     it('allows waiting for finalization', async () => {
       api.__setDefaultResult({ isFinalized: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(
         await signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).toHaveProperty('isFinalized', true)
@@ -42,7 +42,7 @@ describe('Blockchain', () => {
 
     it('allows waiting for in block', async () => {
       api.__setDefaultResult({ isInBlock: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(
         await signAndSubmitTx(tx, pair, { resolveOn: IS_IN_BLOCK })
       ).toHaveProperty('isInBlock', true)
@@ -50,7 +50,7 @@ describe('Blockchain', () => {
 
     it('allows waiting for ready', async () => {
       api.__setDefaultResult({ isReady: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(
         await signAndSubmitTx(tx, pair, { resolveOn: IS_READY })
       ).toHaveProperty('status.isReady', true)
@@ -59,7 +59,7 @@ describe('Blockchain', () => {
     it('uses default resolution config', async () => {
       api.__setDefaultResult({ isReady: true })
       ConfigService.set({ submitTxResolveOn: IS_READY })
-      let tx = api.tx.balances.transfer('abcdef', 50)
+      let tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(await signAndSubmitTx(tx, pair)).toHaveProperty(
         'status.isReady',
         true
@@ -67,12 +67,12 @@ describe('Blockchain', () => {
 
       api.__setDefaultResult({ isInBlock: true })
       ConfigService.set({ submitTxResolveOn: IS_IN_BLOCK })
-      tx = api.tx.balances.transfer('abcdef', 50)
+      tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(await signAndSubmitTx(tx, pair)).toHaveProperty('isInBlock', true)
 
       api.__setDefaultResult({ isFinalized: true })
       ConfigService.set({ submitTxResolveOn: IS_FINALIZED })
-      tx = api.tx.balances.transfer('abcdef', 50)
+      tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       expect(await signAndSubmitTx(tx, pair)).toHaveProperty(
         'isFinalized',
         true
@@ -81,7 +81,7 @@ describe('Blockchain', () => {
 
     it('rejects on error condition', async () => {
       api.__setDefaultResult({ isInvalid: true })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       await expect(
         signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).rejects.toHaveProperty('isError', true)
@@ -90,7 +90,7 @@ describe('Blockchain', () => {
     it('throws if subscriptions not supported', async () => {
       // @ts-ignore
       api.hasSubscriptions = false
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       await expect(
         signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).rejects.toThrow(SDKErrors.SubscriptionsNotSupportedError)
@@ -102,7 +102,7 @@ describe('Blockchain', () => {
         // mock disconnect 500 ms after submission
         if (ev === 'disconnected') setTimeout(callback, 500)
       })
-      const tx = api.tx.balances.transfer('abcdef', 50)
+      const tx = api.tx.balances.transferAllowDeath('abcdef', 50)
       await expect(
         signAndSubmitTx(tx, pair, { resolveOn: IS_FINALIZED })
       ).rejects.toHaveProperty('internalError', expect.any(Error))

--- a/tests/integration/Balance.spec.ts
+++ b/tests/integration/Balance.spec.ts
@@ -68,7 +68,10 @@ describe('when there is a dev chain with a faucet', () => {
     const spy = jest.fn<any>()
     api.query.system.account(address, spy)
     const balanceBefore = (await api.query.system.account(faucet.address)).data
-    const transferTx = api.tx.balances.transfer(address, EXISTENTIAL_DEPOSIT)
+    const transferTx = api.tx.balances.transferAllowDeath(
+      address,
+      EXISTENTIAL_DEPOSIT
+    )
     await submitTx(transferTx, faucet)
     const balanceAfter = (await api.query.system.account(faucet.address)).data
     const balanceIdent = (await api.query.system.account(address)).data
@@ -95,7 +98,7 @@ describe('When there are haves and have-nots', () => {
   })
 
   it('can transfer tokens from the rich to the poor', async () => {
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
@@ -107,7 +110,7 @@ describe('When there are haves and have-nots', () => {
   it('should not accept transactions from KeyringPair with zero balance', async () => {
     const originalBalance = (await api.query.system.account(stormyD.address))
       .data
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
@@ -125,7 +128,7 @@ describe('When there are haves and have-nots', () => {
   it.skip('should not accept transactions when sender cannot pay gas, but will keep gas fee', async () => {
     const RichieBalance = (await api.query.system.account(richieRich.address))
       .data
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       bobbyBroke.address,
       RichieBalance.free
     )
@@ -142,12 +145,12 @@ describe('When there are haves and have-nots', () => {
     const spy = jest.fn<any>()
     api.query.system.account(faucet.address, spy)
 
-    const transferTx1 = api.tx.balances.transfer(
+    const transferTx1 = api.tx.balances.transferAllowDeath(
       richieRich.address,
       EXISTENTIAL_DEPOSIT
     )
     await submitTx(transferTx1, faucet)
-    const transferTx2 = api.tx.balances.transfer(
+    const transferTx2 = api.tx.balances.transferAllowDeath(
       stormyD.address,
       EXISTENTIAL_DEPOSIT
     )
@@ -161,8 +164,11 @@ describe('When there are haves and have-nots', () => {
     api.query.system.account(faucet.address, listener)
 
     const batch = api.tx.utility.batchAll([
-      api.tx.balances.transfer(richieRich.address, EXISTENTIAL_DEPOSIT),
-      api.tx.balances.transfer(stormyD.address, EXISTENTIAL_DEPOSIT),
+      api.tx.balances.transferAllowDeath(
+        richieRich.address,
+        EXISTENTIAL_DEPOSIT
+      ),
+      api.tx.balances.transferAllowDeath(stormyD.address, EXISTENTIAL_DEPOSIT),
     ])
     await submitTx(batch, faucet)
 

--- a/tests/integration/Blockchain.spec.ts
+++ b/tests/integration/Blockchain.spec.ts
@@ -29,7 +29,7 @@ describe('Chain returns specific errors, that we check for', () => {
     testIdentity = makeSigningKeyTool().keypair
     charlie = devCharlie
 
-    const transferTx = api.tx.balances.transfer(
+    const transferTx = api.tx.balances.transferAllowDeath(
       testIdentity.address,
       BalanceUtils.toFemtoKilt(10000)
     )
@@ -37,11 +37,11 @@ describe('Chain returns specific errors, that we check for', () => {
   }, 40000)
 
   it(`throws TxOutdated error if the nonce was already used for Tx in block`, async () => {
-    const tx = api.tx.balances.transfer(
+    const tx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000001')
     )
-    const errorTx = api.tx.balances.transfer(
+    const errorTx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000000')
     )
@@ -90,11 +90,11 @@ describe('Chain returns specific errors, that we check for', () => {
   }, 40000)
 
   it(`throws 'ERROR_TRANSACTION_USURPED' error if separate Tx was imported with identical nonce but higher priority while Tx is in pool`, async () => {
-    const tx = api.tx.balances.transfer(
+    const tx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000000')
     )
-    const errorTx = api.tx.balances.transfer(
+    const errorTx = api.tx.balances.transferAllowDeath(
       charlie.address,
       new BN('1000000000000000')
     )

--- a/tests/integration/Ctypes.spec.ts
+++ b/tests/integration/Ctypes.spec.ts
@@ -104,7 +104,10 @@ describe('When there is an CtypeCreator and a verifier', () => {
       ).data.free.toBigInt() < minBalance
     ) {
       console.log('sending funds to assertion method key account...')
-      const fundsTx = api.tx.balances.transfer(assertionMethodKey, minBalance)
+      const fundsTx = api.tx.balances.transferAllowDeath(
+        assertionMethodKey,
+        minBalance
+      )
       await submitTx(fundsTx, paymentAccount)
       console.log('sending funds completed')
     }

--- a/tests/integration/ErrorHandler.spec.ts
+++ b/tests/integration/ErrorHandler.spec.ts
@@ -44,7 +44,7 @@ beforeAll(async () => {
 }, 60_000)
 
 it('records an extrinsic error when transferring less than the existential amount to new identity', async () => {
-  const transferTx = api.tx.balances.transfer(addressFromRandom(), 1)
+  const transferTx = api.tx.balances.transferAllowDeath(addressFromRandom(), 1)
   const promise = submitTx(transferTx, paymentAccount)
   if (api.runtimeVersion.specVersion.toBigInt() >= 11_200n) {
     await expect(promise).rejects.toMatchInlineSnapshot(`

--- a/tests/integration/PublicCredentials.spec.ts
+++ b/tests/integration/PublicCredentials.spec.ts
@@ -281,7 +281,10 @@ describe('When there is an attester and ctype NFT name', () => {
       ).data.free.toBigInt() < minBalance
     ) {
       console.log('sending funds to assertion method key account...')
-      const fundsTx = api.tx.balances.transfer(assertionMethodKey, minBalance)
+      const fundsTx = api.tx.balances.transferAllowDeath(
+        assertionMethodKey,
+        minBalance
+      )
       await submitTx(fundsTx, tokenHolder)
       console.log('sending funds completed')
     }

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -169,7 +169,9 @@ export async function endowAccounts(
 ): Promise<void> {
   const api = ConfigService.get('api')
   const transactions = await Promise.all(
-    addresses.map((address) => api.tx.balances.transfer(address, ENDOWMENT))
+    addresses.map((address) =>
+      api.tx.balances.transferKeepAlive(address, ENDOWMENT)
+    )
   )
   const batch = api.tx.utility.batchAll(transactions)
   await Blockchain.signAndSubmitTx(batch, faucet, { resolveOn })
@@ -180,7 +182,7 @@ export async function fundAccount(
   amount: BN
 ): Promise<void> {
   const api = ConfigService.get('api')
-  const transferTx = api.tx.balances.transfer(address, amount)
+  const transferTx = api.tx.balances.transferKeepAlive(address, amount)
   await submitTx(transferTx, devFaucet)
 }
 

--- a/tests/testUtils/mocks/mockedApi.ts
+++ b/tests/testUtils/mocks/mockedApi.ts
@@ -239,7 +239,8 @@ export function getMockedApi(): MockApiPromise {
         reclaimDeposit: jest.fn((claimHash: string) => getMockSubmittableTx()),
       },
       balances: {
-        transfer: jest.fn(() => getMockSubmittableTx()),
+        transferAllowDeath: jest.fn(() => getMockSubmittableTx()),
+        transferKeepAlive: jest.fn(() => getMockSubmittableTx()),
       },
       ctype: {
         add: jest.fn((hash, signature) => getMockSubmittableTx()),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,15 +2122,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.21.1":
-  version: 1.28.1
-  resolution: "@playwright/test@npm:1.28.1"
+"@playwright/test@npm:^1.49.1":
+  version: 1.49.1
+  resolution: "@playwright/test@npm:1.49.1"
   dependencies:
-    "@types/node": "*"
-    playwright-core: 1.28.1
+    playwright: 1.49.1
   bin:
     playwright: cli.js
-  checksum: dc39dfdf848171a6c65fc32a9dbc95162684a4a1e3401dd157d7d6822a065d8dcb96b2484fc3b223baea4da774450fddaeaa6d4d21546d17d45f01884fa8d7c5
+  checksum: cdbd16df3d773dc8e522d79b4b961e25c2e1b1d4f3ec45eb711078ab5d11bca47caafe833e2be2f923328fbd012405a9ee31d9b449d184077598546a36847e69
   languageName: node
   linkType: hard
 
@@ -5420,7 +5419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-fsevents@^2.3.2:
+"fsevents@^2.3.2, fsevents@npm:2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -5430,7 +5429,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
@@ -7830,12 +7829,27 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.28.1":
-  version: 1.28.1
-  resolution: "playwright-core@npm:1.28.1"
+"playwright-core@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright-core@npm:1.49.1"
+  bin:
+    playwright-core: cli.js
+  checksum: a940f4b10ff1de033b4b8594b5104b02849a892d9adda0d42330a872cd3d8d287ffd2b01fc33f33ccd34f8904bb8ae8220b878b62e899f3d9bcd1b0945ab45c7
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright@npm:1.49.1"
+  dependencies:
+    fsevents: 2.3.2
+    playwright-core: 1.49.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 8899e0d65de43ee10fadc171e0d48cd514bb574f3505478700094afa8a6e0dcd888a5c87af22acf31ebad455ada1327028909c42e20b8e25908b6255dc143bf0
+  checksum: c136d42d625e32614f90e5228a165dc8be48c5bfb52aca9210c6ff04161a409dbe42fe5ae4f05a2653f6a1b836876a04d3b0f24bcbbc053d1509c1d605b7c8d5
   languageName: node
   linkType: hard
 
@@ -7958,14 +7972,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "punycode@npm:2.1.1"
-  checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
-  languageName: node
-  linkType: hard
-
-"punycode@npm:^2.1.1":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
   checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
@@ -8341,7 +8348,7 @@ fsevents@^2.3.2:
     "@babel/preset-env": ^7.20.2
     "@commitlint/cli": ^9.0.1
     "@commitlint/config-conventional": ^9.0.1
-    "@playwright/test": ^1.21.1
+    "@playwright/test": ^1.49.1
     "@types/jest": ^29.5.3
     "@typescript-eslint/eslint-plugin": ^5.7.0
     "@typescript-eslint/parser": ^5.7.0
@@ -8453,21 +8460,12 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.2.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
     semver: bin/semver.js
   checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
-  languageName: node
-  linkType: hard
-
-"semver@npm:^6.2.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
-  bin:
-    semver: ./bin/semver.js
-  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Enables and fixes CI/tests for PRs to `v0-lts`, the legacy sdk support branch.
Includes backports of #929, #921, #903 & https://github.com/KILTprotocol/sdk-js/pull/871.

It seems that the type definitions here are already out of date, leading to CI failure. This is fixed in https://github.com/KILTprotocol/sdk-js/pull/933.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
