### PR TITLE
fix: constrain incompatible transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
   "version": "1.0.0",
   "packageManager": "yarn@4.1.1",
   "resolutions": {
+    "@polkadot-api/merkleize-metadata": "1.1.12",
+    "@types/node": "18.19.130",
     "@kiltprotocol/type-definitions": "1.11501.0-peregrine",
     "@kiltprotocol/augment-api": "1.11501.0-peregrine"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,7 +2437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/merkleize-metadata@npm:^1.0.0":
+"@polkadot-api/merkleize-metadata@npm:1.1.12":
   version: 1.1.12
   resolution: "@polkadot-api/merkleize-metadata@npm:1.1.12"
   dependencies:
@@ -3225,10 +3225,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 16.18.40
-  resolution: "@types/node@npm:16.18.40"
-  checksum: 10c0/bcd7c48fea30f219dcf1be9ee86baecea26dd488ba389835bcf2cbbd0a7c26247ad325793e1af82e610141a7d496efa70fec5f0a7f76ba89d17a2f14fb73329d
+"@types/node@npm:18.19.130":
+  version: 18.19.130
+  resolution: "@types/node@npm:18.19.130"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/22ba2bc9f8863101a7e90a56aaeba1eb3ebdc51e847cef4a6d188967ab1acbce9b4f92251372fd0329ecb924bbf610509e122c3dfe346c04dbad04013d4ad7d0
   languageName: node
   linkType: hard
 
@@ -9914,6 +9916,13 @@ __metadata:
     has-symbols: "npm:^1.0.2"
     which-boxed-primitive: "npm:^1.0.2"
   checksum: 10c0/6f0b91b0744c6f9fd05afa70484914b70686596be628543a143fab018733f902ff39fad2c3cf8f00fd5d32ba8bce8edf9cf61cee940c1af892316e112b25812b
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1030.

## Summary
- constrain `@types/node` to `18.19.130` so the SDK remains buildable with TypeScript 4.9 when dependencies are resolved without the lockfile
- constrain `@polkadot-api/merkleize-metadata` to `1.1.12` to retain the CommonJS-compatible entrypoint used by the Jest suite
- refresh the committed Yarn lockfile for the explicit resolutions

## Validation
- lockfile-free `yarn install` on Node 20.20.2
- lockfile-free `yarn build`
- lockfile-free `yarn test:ci` (35 suites, 320 passed, 3 skipped, 4 todo)
- `yarn install --immutable`
- `yarn build`
- `yarn test:ci`
- `yarn lint`
- `yarn style`